### PR TITLE
Fix cross-module method calls and type variable handling

### DIFF
--- a/scripts/compile-std.sh
+++ b/scripts/compile-std.sh
@@ -27,6 +27,7 @@ if [ -d "$HB_LLVM" ]; then
     exec "$HB_LLVM/bin/clang++" \
         -std=c++23 \
         -O2 \
+        -fbracket-depth=1024 \
         -I . \
         -I "$THEORIES_CPP" \
         -nostdlib++ \
@@ -41,5 +42,5 @@ if [ -d "$HB_LLVM" ]; then
         -o "$OUTPUT"
 else
     # Fallback to system clang++
-    exec clang++ -std=c++23 -O2 -I . -I "$THEORIES_CPP" $SOURCES -o "$OUTPUT"
+    exec clang++ -std=c++23 -O2 -fbracket-depth=1024 -I . -I "$THEORIES_CPP" $SOURCES -o "$OUTPUT"
 fi

--- a/src/mlutil.ml
+++ b/src/mlutil.ml
@@ -79,6 +79,7 @@ and eq_ml_meta m1 m2 =
 let type_subst_list l t =
   let rec subst t = match t with
     | Tvar j -> List.nth l (j-1)
+    | Tvar' j -> List.nth l (j-1)  (* Tvar' is also a type variable that needs substitution *)
     | Tmeta {contents=None} -> t
     | Tmeta {contents=Some u} -> subst u
     | Tarr (a,b) -> Tarr (subst a, subst b)
@@ -95,6 +96,8 @@ let type_subst_vect v t =
   let rec subst t = match t with
     | Tvar j when j >= 1 && j <= n -> v.(j-1)
     | Tvar _ -> t  (* Per-constructor type var, leave unchanged *)
+    | Tvar' j when j >= 1 && j <= n -> v.(j-1)  (* Tvar' is also a type variable *)
+    | Tvar' _ -> t  (* Per-constructor type var, leave unchanged *)
     | Tmeta {contents=None} -> t
     | Tmeta {contents=Some u} -> subst u
     | Tarr (a,b) -> Tarr (subst a, subst b)

--- a/tests/basics/list/list.h
+++ b/tests/basics/list/list.h
@@ -44,23 +44,25 @@ struct List {
     template <typename T2, MapsTo<T2, A, std::shared_ptr<list<A>>, T2> F1>
     T2 list_rect(const T2 f, F1 &&f0) const {
       return std::visit(
-          Overloaded{[&](const typename list<A>::nil _args) -> T2 { return f; },
-                     [&](const typename list<A>::cons _args) -> T2 {
-                       A y = _args._a0;
-                       std::shared_ptr<list<A>> l0 = _args._a1;
-                       return f0(y, l0, l0->list_rect(f, f0));
-                     }},
+          Overloaded{
+              [&](const typename list<A>::nil _args) -> auto { return f; },
+              [&](const typename list<A>::cons _args) -> auto {
+                A y = _args._a0;
+                std::shared_ptr<list<A>> l0 = _args._a1;
+                return f0(y, l0, l0->list_rect(f, f0));
+              }},
           this->v());
     }
     template <typename T2, MapsTo<T2, A, std::shared_ptr<list<A>>, T2> F1>
     T2 list_rec(const T2 f, F1 &&f0) const {
       return std::visit(
-          Overloaded{[&](const typename list<A>::nil _args) -> T2 { return f; },
-                     [&](const typename list<A>::cons _args) -> T2 {
-                       A y = _args._a0;
-                       std::shared_ptr<list<A>> l0 = _args._a1;
-                       return f0(y, l0, l0->list_rec(f, f0));
-                     }},
+          Overloaded{
+              [&](const typename list<A>::nil _args) -> auto { return f; },
+              [&](const typename list<A>::cons _args) -> auto {
+                A y = _args._a0;
+                std::shared_ptr<list<A>> l0 = _args._a1;
+                return f0(y, l0, l0->list_rec(f, f0));
+              }},
           this->v());
     }
     std::shared_ptr<list<A>> tl() const {
@@ -77,21 +79,23 @@ struct List {
     }
     A hd(const A x) const {
       return std::visit(
-          Overloaded{[&](const typename list<A>::nil _args) -> A { return x; },
-                     [](const typename list<A>::cons _args) -> A {
-                       A y = _args._a0;
-                       return y;
-                     }},
+          Overloaded{
+              [&](const typename list<A>::nil _args) -> auto { return x; },
+              [](const typename list<A>::cons _args) -> auto {
+                A y = _args._a0;
+                return y;
+              }},
           this->v());
     }
     A last(const A x) const {
       return std::visit(
-          Overloaded{[&](const typename list<A>::nil _args) -> A { return x; },
-                     [](const typename list<A>::cons _args) -> A {
-                       A y = _args._a0;
-                       std::shared_ptr<list<A>> ls = _args._a1;
-                       return ls->last(y);
-                     }},
+          Overloaded{
+              [&](const typename list<A>::nil _args) -> auto { return x; },
+              [](const typename list<A>::cons _args) -> auto {
+                A y = _args._a0;
+                std::shared_ptr<list<A>> ls = _args._a1;
+                return ls->last(y);
+              }},
           this->v());
     }
     std::shared_ptr<list<A>> app(const std::shared_ptr<list<A>> &l2) const {

--- a/tests/basics/nat/nat.h
+++ b/tests/basics/nat/nat.h
@@ -41,8 +41,8 @@ struct Nat {
     template <typename T1, MapsTo<T1, std::shared_ptr<nat>, T1> F1>
     T1 nat_rect(const T1 f, F1 &&f0) const {
       return std::visit(
-          Overloaded{[&](const typename nat::O _args) -> T1 { return f; },
-                     [&](const typename nat::S _args) -> T1 {
+          Overloaded{[&](const typename nat::O _args) -> auto { return f; },
+                     [&](const typename nat::S _args) -> auto {
                        std::shared_ptr<nat> n0 = _args._a0;
                        return f0(n0, n0->nat_rect(f, f0));
                      }},
@@ -51,8 +51,8 @@ struct Nat {
     template <typename T1, MapsTo<T1, std::shared_ptr<nat>, T1> F1>
     T1 nat_rec(const T1 f, F1 &&f0) const {
       return std::visit(
-          Overloaded{[&](const typename nat::O _args) -> T1 { return f; },
-                     [&](const typename nat::S _args) -> T1 {
+          Overloaded{[&](const typename nat::O _args) -> auto { return f; },
+                     [&](const typename nat::S _args) -> auto {
                        std::shared_ptr<nat> n0 = _args._a0;
                        return f0(n0, n0->nat_rec(f, f0));
                      }},

--- a/tests/basics/nat_bde/nat_bde.h
+++ b/tests/basics/nat_bde/nat_bde.h
@@ -60,27 +60,27 @@ struct Nat {
         T1 nat_rect(const T1 f, F1&& f0) const
         {
             return bsl::visit(
-                      bdlf::Overloaded{[&](const typename nat::O _args) -> T1 {
-                                           return f;
-                                       },
-                                       [&](const typename nat::S _args) -> T1 {
-                                           bsl::shared_ptr<nat> n0 = _args._a0;
-                                           return f0(n0, n0->nat_rect(f, f0));
-                                       }},
-                      this->v());
+                    bdlf::Overloaded{[&](const typename nat::O _args) -> auto {
+                                         return f;
+                                     },
+                                     [&](const typename nat::S _args) -> auto {
+                                         bsl::shared_ptr<nat> n0 = _args._a0;
+                                         return f0(n0, n0->nat_rect(f, f0));
+                                     }},
+                    this->v());
         }
         template <typename T1, MapsTo<T1, bsl::shared_ptr<nat>, T1> F1>
         T1 nat_rec(const T1 f, F1&& f0) const
         {
             return bsl::visit(
-                      bdlf::Overloaded{[&](const typename nat::O _args) -> T1 {
-                                           return f;
-                                       },
-                                       [&](const typename nat::S _args) -> T1 {
-                                           bsl::shared_ptr<nat> n0 = _args._a0;
-                                           return f0(n0, n0->nat_rec(f, f0));
-                                       }},
-                      this->v());
+                    bdlf::Overloaded{[&](const typename nat::O _args) -> auto {
+                                         return f;
+                                     },
+                                     [&](const typename nat::S _args) -> auto {
+                                         bsl::shared_ptr<nat> n0 = _args._a0;
+                                         return f0(n0, n0->nat_rec(f, f0));
+                                     }},
+                    this->v());
         }
         bsl::shared_ptr<nat> add(const bsl::shared_ptr<nat>& n) const
         {

--- a/tests/basics/top/top.h
+++ b/tests/basics/top/top.h
@@ -96,15 +96,19 @@ std::shared_ptr<List::list<T1>>
 concat(const std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>> &l) {
   return std::visit(
       Overloaded{
-          [](const typename List::list<std::shared_ptr<List::list<T1>>>::nil
-                 _args) -> std::shared_ptr<List::list<T1>> {
+          [](const typename List::list<std::shared_ptr<
+                 List::list<std::shared_ptr<List::list<T1>>>>>::nil _args)
+              -> std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>> {
             return List::list<T1>::ctor::nil_();
           },
-          [](const typename List::list<std::shared_ptr<List::list<T1>>>::cons
-                 _args) -> std::shared_ptr<List::list<T1>> {
-            std::shared_ptr<List::list<T1>> x = _args._a0;
-            std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>> l0 =
-                _args._a1;
+          [](const typename List::list<std::shared_ptr<
+                 List::list<std::shared_ptr<List::list<T1>>>>>::cons _args)
+              -> std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>> {
+            std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>> x =
+                _args._a0;
+            std::shared_ptr<List::list<
+                std::shared_ptr<List::list<std::shared_ptr<List::list<T1>>>>>>
+                l0 = _args._a1;
             return x->app(concat<T1>(l0));
           }},
       l->v());
@@ -114,8 +118,8 @@ template <typename T1, typename T2, MapsTo<T1, T2, T1> F0>
 T1 fold_right(F0 &&f, const T1 a0, const std::shared_ptr<List::list<T2>> &l) {
   return std::visit(
       Overloaded{
-          [&](const typename List::list<T2>::nil _args) -> T1 { return a0; },
-          [&](const typename List::list<T2>::cons _args) -> T1 {
+          [&](const typename List::list<T2>::nil _args) -> T2 { return a0; },
+          [&](const typename List::list<T2>::cons _args) -> T2 {
             T2 b = _args._a0;
             std::shared_ptr<List::list<T2>> l0 = _args._a1;
             return f(b, fold_right<T1, T2>(f, a0, l0));
@@ -276,12 +280,18 @@ struct TopSort {
         -> std::shared_ptr<List::list<T1>> {
       return std::visit(
           Overloaded{
-              [&](const typename List::list<std::pair<T1, T1>>::nil _args)
-                  -> std::shared_ptr<List::list<T1>> { return h; },
-              [&](const typename List::list<std::pair<T1, T1>>::cons _args)
-                  -> std::shared_ptr<List::list<T1>> {
-                std::pair<T1, T1> p = _args._a0;
-                std::shared_ptr<List::list<std::pair<T1, T1>>> l_ = _args._a1;
+              [&](const typename List::list<
+                  std::pair<std::pair<T1, T1>, std::pair<T1, T1>>>::nil _args)
+                  -> std::shared_ptr<List::list<std::pair<T1, T1>>> {
+                return h;
+              },
+              [&](const typename List::list<
+                  std::pair<std::pair<T1, T1>, std::pair<T1, T1>>>::cons _args)
+                  -> std::shared_ptr<List::list<std::pair<T1, T1>>> {
+                std::pair<std::pair<T1, T1>, std::pair<T1, T1>> p = _args._a0;
+                std::shared_ptr<
+                    List::list<std::pair<std::pair<T1, T1>, std::pair<T1, T1>>>>
+                    l_ = _args._a1;
                 T1 e1 = p.first;
                 T1 e2 = p.second;
                 std::optional<T1> f1 =
@@ -428,13 +438,24 @@ struct TopSort {
           List::list<std::pair<T1, std::shared_ptr<List::list<T1>>>>> &graph0) {
     return std::visit(
         Overloaded{
-            [](const typename List::list<
-                std::pair<T1, std::shared_ptr<List::list<T1>>>>::nil _args)
-                -> std::optional<T1> { return std::nullopt; },
-            [&](const typename List::list<
-                std::pair<T1, std::shared_ptr<List::list<T1>>>>::cons _args)
-                -> std::optional<T1> {
-              std::pair<T1, std::shared_ptr<List::list<T1>>> e0 = _args._a0;
+            [](const typename List::list<std::pair<
+                   std::pair<T1, std::shared_ptr<List::list<T1>>>,
+                   std::shared_ptr<List::list<std::pair<
+                       T1, std::shared_ptr<List::list<T1>>>>>>>::nil _args)
+                -> std::optional<
+                    std::pair<T1, std::shared_ptr<List::list<T1>>>> {
+              return std::nullopt;
+            },
+            [&](const typename List::list<std::pair<
+                    std::pair<T1, std::shared_ptr<List::list<T1>>>,
+                    std::shared_ptr<List::list<std::pair<
+                        T1, std::shared_ptr<List::list<T1>>>>>>>::cons _args)
+                -> std::optional<
+                    std::pair<T1, std::shared_ptr<List::list<T1>>>> {
+              std::pair<std::pair<T1, std::shared_ptr<List::list<T1>>>,
+                        std::shared_ptr<List::list<
+                            std::pair<T1, std::shared_ptr<List::list<T1>>>>>>
+                  e0 = _args._a0;
               T1 e = e0.first;
               std::shared_ptr<List::list<T1>> _x0 = e0.second;
               return std::make_optional<T1>(cycle_entry_aux<T1>(

--- a/tests/basics/top_bde/top_bde.h
+++ b/tests/basics/top_bde/top_bde.h
@@ -126,15 +126,21 @@ bsl::shared_ptr<List::list<T1> > concat(
 {
     return bsl::visit(
         bdlf::Overloaded{
-            [](const typename List::list<bsl::shared_ptr<List::list<T1> > >::
-                   nil _args) -> bsl::shared_ptr<List::list<T1> > {
+            [](const typename List::list<bsl::shared_ptr<List::list<
+                   bsl::shared_ptr<List::list<T1> > > > >::nil _args)
+                -> bsl::shared_ptr<
+                    List::list<bsl::shared_ptr<List::list<T1> > > > {
                 return List::list<T1>::ctor::nil_();
             },
-            [](const typename List::list<bsl::shared_ptr<List::list<T1> > >::
-                   cons _args) -> bsl::shared_ptr<List::list<T1> > {
-                bsl::shared_ptr<List::list<T1> > x  = _args._a0;
+            [](const typename List::list<bsl::shared_ptr<List::list<
+                   bsl::shared_ptr<List::list<T1> > > > >::cons _args)
+                -> bsl::shared_ptr<
+                    List::list<bsl::shared_ptr<List::list<T1> > > > {
                 bsl::shared_ptr<List::list<bsl::shared_ptr<List::list<T1> > > >
-                                                 l0 = _args._a1;
+                    x  = _args._a0;
+                bsl::shared_ptr<List::list<bsl::shared_ptr<
+                    List::list<bsl::shared_ptr<List::list<T1> > > > > >
+                    l0 = _args._a1;
                 return x->app(concat<T1>(l0));
             }},
         l->v());
@@ -144,10 +150,10 @@ template <typename T1, typename T2, MapsTo<T1, T2, T1> F0>
 T1 fold_right(F0&& f, const T1 a0, const bsl::shared_ptr<List::list<T2> >& l)
 {
     return bsl::visit(
-        bdlf::Overloaded{[&](const typename List::list<T2>::nil _args) -> T1 {
+        bdlf::Overloaded{[&](const typename List::list<T2>::nil _args) -> T2 {
                              return a0;
                          },
-                         [&](const typename List::list<T2>::cons _args) -> T1 {
+                         [&](const typename List::list<T2>::cons _args) -> T2 {
                              T2                               b  = _args._a0;
                              bsl::shared_ptr<List::list<T2> > l0 = _args._a1;
                              return f(b, fold_right<T1, T2>(f, a0, l0));
@@ -336,65 +342,72 @@ struct TopSort {
                 bsl::shared_ptr<List::list<T1> >                 h)
             -> bsl::shared_ptr<List::list<T1> > {
             return bsl::visit(
-                  bdlf::Overloaded{
-                      [&](const typename List::list<bsl::pair<T1, T1> >::nil
-                              _args) -> bsl::shared_ptr<List::list<T1> > {
-                          return h;
-                      },
-                      [&](const typename List::list<bsl::pair<T1, T1> >::cons
-                              _args) -> bsl::shared_ptr<List::list<T1> > {
-                          bsl::pair<T1, T1> p = _args._a0;
-                          bsl::shared_ptr<List::list<bsl::pair<T1, T1> > > l_ =
-                              _args._a1;
-                          T1                e1 = p.first;
-                          T1                e2 = p.second;
-                          bsl::optional<T1> f1 = find<T1>(
-                              [&](T1 x) {
-                                  return eqb_node(e1, x);
-                              },
-                              h);
-                          bsl::optional<T1> f2 = find<T1>(
-                              [&](T1 x) {
-                                  return eqb_node(e2, x);
-                              },
-                              h);
-                          if (f1.has_value()) {
-                              T1 _x = *f1;
-                              if (f2.has_value()) {
-                                  T1 _x0 = *f2;
-                                  return get_elems_aux(l_, h);
-                              }
-                              else {
-                                  return get_elems_aux(
-                                      l_,
-                                      List::list<T1>::ctor::cons_(e2, h));
-                              }
-                          }
-                          else {
-                              if (f2.has_value()) {
-                                  T1 _x = *f2;
-                                  return get_elems_aux(
-                                      l_,
-                                      List::list<T1>::ctor::cons_(e1, h));
-                              }
-                              else {
-                                  if (eqb_node(e1, e2)) {
-                                      return get_elems_aux(
-                                          l_,
-                                          List::list<T1>::ctor::cons_(e1, h));
-                                  }
-                                  else {
-                                      return get_elems_aux(
-                                          l_,
-                                          List::list<T1>::ctor::cons_(
-                                              e1,
-                                              List::list<T1>::ctor::cons_(e2,
-                                                                          h)));
-                                  }
-                              }
-                          }
-                      }},
-                  l0->v());
+                bdlf::Overloaded{
+                    [&](const typename List::list<
+                        bsl::pair<bsl::pair<T1, T1>, bsl::pair<T1, T1> > >::nil
+                            _args)
+                        -> bsl::shared_ptr<List::list<bsl::pair<T1, T1> > > {
+                        return h;
+                    },
+                    [&](const typename List::list<
+                        bsl::pair<bsl::pair<T1, T1>,
+                                  bsl::pair<T1, T1> > >::cons _args)
+                        -> bsl::shared_ptr<List::list<bsl::pair<T1, T1> > > {
+                        bsl::pair<bsl::pair<T1, T1>, bsl::pair<T1, T1> > p =
+                            _args._a0;
+                        bsl::shared_ptr<
+                            List::list<bsl::pair<bsl::pair<T1, T1>,
+                                                 bsl::pair<T1, T1> > > >
+                                          l_ = _args._a1;
+                        T1                e1 = p.first;
+                        T1                e2 = p.second;
+                        bsl::optional<T1> f1 = find<T1>(
+                            [&](T1 x) {
+                                return eqb_node(e1, x);
+                            },
+                            h);
+                        bsl::optional<T1> f2 = find<T1>(
+                            [&](T1 x) {
+                                return eqb_node(e2, x);
+                            },
+                            h);
+                        if (f1.has_value()) {
+                            T1 _x = *f1;
+                            if (f2.has_value()) {
+                                T1 _x0 = *f2;
+                                return get_elems_aux(l_, h);
+                            }
+                            else {
+                                return get_elems_aux(
+                                    l_,
+                                    List::list<T1>::ctor::cons_(e2, h));
+                            }
+                        }
+                        else {
+                            if (f2.has_value()) {
+                                T1 _x = *f2;
+                                return get_elems_aux(
+                                    l_,
+                                    List::list<T1>::ctor::cons_(e1, h));
+                            }
+                            else {
+                                if (eqb_node(e1, e2)) {
+                                    return get_elems_aux(
+                                        l_,
+                                        List::list<T1>::ctor::cons_(e1, h));
+                                }
+                                else {
+                                    return get_elems_aux(
+                                        l_,
+                                        List::list<T1>::ctor::cons_(
+                                            e1,
+                                            List::list<T1>::ctor::cons_(e2,
+                                                                        h)));
+                                }
+                            }
+                        }
+                    }},
+                l0->v());
         };
         return get_elems_aux(l, List::list<T1>::ctor::nil_());
     }
@@ -541,27 +554,40 @@ struct TopSort {
                graph0)
     {
         return bsl::visit(
-               bdlf::Overloaded{
-                   [](const typename List::list<
-                       bsl::pair<T1, bsl::shared_ptr<List::list<T1> > > >::nil
-                          _args) -> bsl::optional<T1> {
-                       return bsl::nullopt;
-                   },
-                   [&](const typename List::list<
-                       bsl::pair<T1, bsl::shared_ptr<List::list<T1> > > >::cons
-                           _args) -> bsl::optional<T1> {
-                       bsl::pair<T1, bsl::shared_ptr<List::list<T1> > > e0 =
-                           _args._a0;
-                       T1                               e   = e0.first;
-                       bsl::shared_ptr<List::list<T1> > _x0 = e0.second;
-                       return bsl::make_optional<T1>(cycle_entry_aux<T1>(
-                           eqb_node,
-                           graph0,
-                           List::list<T1>::ctor::nil_(),
-                           e,
-                           graph0->length()));
-                   }},
-               graph0->v());
+            bdlf::Overloaded{
+                [](const typename List::list<bsl::pair<
+                       bsl::pair<T1, bsl::shared_ptr<List::list<T1> > >,
+                       bsl::shared_ptr<List::list<bsl::pair<
+                           T1,
+                           bsl::shared_ptr<List::list<T1> > > > > > >::nil
+                       _args)
+                    -> bsl::optional<
+                        bsl::pair<T1, bsl::shared_ptr<List::list<T1> > > > {
+                    return bsl::nullopt;
+                },
+                [&](const typename List::list<bsl::pair<
+                        bsl::pair<T1, bsl::shared_ptr<List::list<T1> > >,
+                        bsl::shared_ptr<List::list<bsl::pair<
+                            T1,
+                            bsl::shared_ptr<List::list<T1> > > > > > >::cons
+                        _args)
+                    -> bsl::optional<
+                        bsl::pair<T1, bsl::shared_ptr<List::list<T1> > > > {
+                    bsl::pair<bsl::pair<T1, bsl::shared_ptr<List::list<T1> > >,
+                              bsl::shared_ptr<List::list<bsl::pair<
+                                  T1,
+                                  bsl::shared_ptr<List::list<T1> > > > > >
+                                                     e0  = _args._a0;
+                    T1                               e   = e0.first;
+                    bsl::shared_ptr<List::list<T1> > _x0 = e0.second;
+                    return bsl::make_optional<T1>(cycle_entry_aux<T1>(
+                        eqb_node,
+                        graph0,
+                        List::list<T1>::ctor::nil_(),
+                        e,
+                        graph0->length()));
+                }},
+            graph0->v());
     }
 
     template <typename T1, MapsTo<bool, T1, T1> F0>

--- a/tests/basics/tree/tree.h
+++ b/tests/basics/tree/tree.h
@@ -151,8 +151,8 @@ struct Tree {
     T2 tree_rect(const T2 f, F1 &&f0) const {
       return std::visit(
           Overloaded{
-              [&](const typename tree<A>::leaf _args) -> T2 { return f; },
-              [&](const typename tree<A>::node _args) -> T2 {
+              [&](const typename tree<A>::leaf _args) -> auto { return f; },
+              [&](const typename tree<A>::node _args) -> auto {
                 std::shared_ptr<tree<A>> t0 = _args._a0;
                 A y = _args._a1;
                 std::shared_ptr<tree<A>> t1 = _args._a2;
@@ -167,8 +167,8 @@ struct Tree {
     T2 tree_rec(const T2 f, F1 &&f0) const {
       return std::visit(
           Overloaded{
-              [&](const typename tree<A>::leaf _args) -> T2 { return f; },
-              [&](const typename tree<A>::node _args) -> T2 {
+              [&](const typename tree<A>::leaf _args) -> auto { return f; },
+              [&](const typename tree<A>::node _args) -> auto {
                 std::shared_ptr<tree<A>> t0 = _args._a0;
                 A y = _args._a1;
                 std::shared_ptr<tree<A>> t1 = _args._a2;

--- a/tests/monadic/free_monad/free_monad.h
+++ b/tests/monadic/free_monad/free_monad.h
@@ -87,25 +87,24 @@ struct FreeMonad {
   static T1 IO_rect(F0 &&f, F1 &&f0, const T1 f1, F3 &&f2,
                     const std::shared_ptr<iO> &i) {
     return std::visit(
-        Overloaded{[&](const typename iO::pure _args) -> T1 {
-                     std::any a = _args._a0;
-                     return f("dummy", a);
-                   },
-                   [&](const typename iO::bind _args) -> T1 {
-                     std::shared_ptr<iO> i0 = _args._a0;
-                     std::function<std::shared_ptr<iO>(std::any)> i1 =
-                         _args._a1;
-                     return f0("dummy", "dummy", i0,
-                               IO_rect<T1>(f, f0, f1, f2, i0), i1,
-                               [&](std::any a) {
-                                 return IO_rect<T1>(f, f0, f1, f2, i1(a));
-                               });
-                   },
-                   [&](const typename iO::get_line _args) -> T1 { return f1; },
-                   [&](const typename iO::print _args) -> T1 {
-                     std::string s = _args._a0;
-                     return f2(s);
-                   }},
+        Overloaded{
+            [&](const typename iO::pure _args) -> auto {
+              std::any a = _args._a0;
+              return f("dummy", a);
+            },
+            [&](const typename iO::bind _args) -> auto {
+              std::shared_ptr<iO> i0 = _args._a0;
+              std::function<std::shared_ptr<iO>(std::any)> i1 = _args._a1;
+              return f0("dummy", "dummy", i0, IO_rect<T1>(f, f0, f1, f2, i0),
+                        i1, [&](std::any a) {
+                          return IO_rect<T1>(f, f0, f1, f2, i1(a));
+                        });
+            },
+            [&](const typename iO::get_line _args) -> auto { return f1; },
+            [&](const typename iO::print _args) -> auto {
+              std::string s = _args._a0;
+              return f2(s);
+            }},
         i->v());
   }
 
@@ -118,25 +117,23 @@ struct FreeMonad {
   static T1 IO_rec(F0 &&f, F1 &&f0, const T1 f1, F3 &&f2,
                    const std::shared_ptr<iO> &i) {
     return std::visit(
-        Overloaded{[&](const typename iO::pure _args) -> T1 {
-                     std::any a = _args._a0;
-                     return f("dummy", a);
-                   },
-                   [&](const typename iO::bind _args) -> T1 {
-                     std::shared_ptr<iO> i0 = _args._a0;
-                     std::function<std::shared_ptr<iO>(std::any)> i1 =
-                         _args._a1;
-                     return f0("dummy", "dummy", i0,
-                               IO_rec<T1>(f, f0, f1, f2, i0), i1,
-                               [&](std::any a) {
-                                 return IO_rec<T1>(f, f0, f1, f2, i1(a));
-                               });
-                   },
-                   [&](const typename iO::get_line _args) -> T1 { return f1; },
-                   [&](const typename iO::print _args) -> T1 {
-                     std::string s = _args._a0;
-                     return f2(s);
-                   }},
+        Overloaded{
+            [&](const typename iO::pure _args) -> auto {
+              std::any a = _args._a0;
+              return f("dummy", a);
+            },
+            [&](const typename iO::bind _args) -> auto {
+              std::shared_ptr<iO> i0 = _args._a0;
+              std::function<std::shared_ptr<iO>(std::any)> i1 = _args._a1;
+              return f0(
+                  "dummy", "dummy", i0, IO_rec<T1>(f, f0, f1, f2, i0), i1,
+                  [&](std::any a) { return IO_rec<T1>(f, f0, f1, f2, i1(a)); });
+            },
+            [&](const typename iO::get_line _args) -> auto { return f1; },
+            [&](const typename iO::print _args) -> auto {
+              std::string s = _args._a0;
+              return f2(s);
+            }},
         i->v());
   }
 

--- a/tests/monadic/stm/stm.cpp
+++ b/tests/monadic/stm/stm.cpp
@@ -50,9 +50,8 @@ void stmtest::stm_enqueue(
   std::shared_ptr<List::list<unsigned int>> xs =
       stm::readTVar<std::shared_ptr<List::list<unsigned int>>>(q);
   return stm::writeTVar<std::shared_ptr<List::list<unsigned int>>>(
-      q,
-      ::app<unsigned int>(xs, List::list<unsigned int>::ctor::cons_(
-                                  x, List::list<unsigned int>::ctor::nil_())));
+      q, xs->app(List::list<unsigned int>::ctor::cons_(
+             x, List::list<unsigned int>::ctor::nil_())));
 }
 
 unsigned int stmtest::stm_dequeue(

--- a/tests/monadic/stm/stm.t.cpp
+++ b/tests/monadic/stm/stm.t.cpp
@@ -35,10 +35,8 @@ void aSsErT(bool condition, const char *message, int line)
 #define ASSERT(X)                                              \
     aSsErT(!(X), #X, __LINE__);
 
-using namespace stmtest;
-
 int main() {
-  auto x = io_inc(4);
+  auto x = stmtest::io_inc(4);
   std::cout << std::to_string(x) << '\n';
   // auto p = io_transfer_test(23, 32, 8);
   // std::cout << p.first << ", " << p.second << '\n';

--- a/tests/wip/isort/isort.cpp
+++ b/tests/wip/isort/isort.cpp
@@ -32,34 +32,35 @@ sort_cons_prog(const unsigned int a,
                const std::shared_ptr<List::list<unsigned int>> &_x,
                const std::shared_ptr<List::list<unsigned int>> &l_) {
   return std::visit(
-      Overloaded{[&](const typename List::list<T1>::nil _args) -> T2 {
-                   return List::list<unsigned int>::ctor::cons_(
-                       a, List::list<unsigned int>::ctor::nil_());
-                 },
-                 [&](const typename List::list<T1>::cons _args) -> T2 {
-                   T1 y = _args._a0;
-                   std::shared_ptr<List::list<T1>> l = _args._a1;
-                   std::shared_ptr<
-                       Sig0::sig0<std::shared_ptr<List::list<unsigned int>>>>
-                       s = sort_cons_prog(a, l, l);
-                   bool s = le_lt_dec(a, y);
-                   if (s0) {
-                     return List::list<unsigned int>::ctor::cons_(
-                         a, List::list<unsigned int>::ctor::cons_(y, l));
-                   } else {
-                     return List::list<unsigned int>::ctor::cons_(y, s);
-                   }
-                 }},
+      Overloaded{
+          [&](const typename List::list<unsigned int>::nil _args) -> auto {
+            return List::list<unsigned int>::ctor::cons_(
+                a, List::list<unsigned int>::ctor::nil_());
+          },
+          [&](const typename List::list<unsigned int>::cons _args) -> auto {
+            unsigned int y = _args._a0;
+            std::shared_ptr<List::list<unsigned int>> l = _args._a1;
+            std::shared_ptr<
+                Sig0::sig0<std::shared_ptr<List::list<unsigned int>>>>
+                s = sort_cons_prog(a, l, l);
+            bool s = le_lt_dec(a, y);
+            if (s0) {
+              return List::list<unsigned int>::ctor::cons_(
+                  a, List::list<unsigned int>::ctor::cons_(y, l));
+            } else {
+              return List::list<unsigned int>::ctor::cons_(y, s);
+            }
+          }},
       l_->v());
 }
 
 std::shared_ptr<Sig0::sig0<std::shared_ptr<List::list<unsigned int>>>>
 isort(const std::shared_ptr<List::list<T1>> &l) {
   return std::visit(
-      Overloaded{[](const typename List::list<T1>::nil _args) -> T2 {
+      Overloaded{[](const typename List::list<T1>::nil _args) -> auto {
                    return List::list<unsigned int>::ctor::nil_();
                  },
-                 [](const typename List::list<T1>::cons _args) -> T2 {
+                 [](const typename List::list<T1>::cons _args) -> auto {
                    T1 y = _args._a0;
                    std::shared_ptr<List::list<T1>> l0 = _args._a1;
                    return sort_cons_prog(y, l0, isort(l0));

--- a/tests/wip/levenshtein/levenshtein.cpp
+++ b/tests/wip/levenshtein/levenshtein.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<Sumbool::sumbool>
 bool_dec(const std::shared_ptr<Bool0::bool0> &b1,
          const std::shared_ptr<Bool0::bool0> &b2) {
   return std::visit(
-      Overloaded{[&](const typename Bool0::bool0::true0 _args) -> T1 {
+      Overloaded{[&](const typename Bool0::bool0::true0 _args) -> auto {
                    return std::visit(
                        Overloaded{[](const typename Bool0::bool0::true0 _args)
                                       -> std::shared_ptr<Sumbool::sumbool> {
@@ -47,7 +47,7 @@ bool_dec(const std::shared_ptr<Bool0::bool0> &b1,
                                   }},
                        b2->v());
                  },
-                 [&](const typename Bool0::bool0::false0 _args) -> T1 {
+                 [&](const typename Bool0::bool0::false0 _args) -> auto {
                    return std::visit(
                        Overloaded{[](const typename Bool0::bool0::true0 _args)
                                       -> std::shared_ptr<Sumbool::sumbool> {
@@ -60,238 +60,6 @@ bool_dec(const std::shared_ptr<Bool0::bool0> &b1,
                        b2->v());
                  }},
       b1->v());
-}
-
-std::shared_ptr<Sumbool::sumbool>
-ascii_dec(const std::shared_ptr<Ascii::ascii> &a,
-          const std::shared_ptr<Ascii::ascii> &b) {
-  return std::
-      visit(Overloaded{[&](const typename Ascii::ascii::Ascii _args) -> T1 {
-              std::shared_ptr<Bool0::bool0> b0 = _args._a0;
-              std::shared_ptr<Bool0::bool0> b1 = _args._a1;
-              std::shared_ptr<Bool0::bool0> b2 = _args._a2;
-              std::shared_ptr<Bool0::bool0> b3 = _args._a3;
-              std::shared_ptr<Bool0::bool0> b4 = _args._a4;
-              std::shared_ptr<Bool0::bool0> b5 = _args._a5;
-              std::shared_ptr<Bool0::bool0> b6 = _args._a6;
-              std::shared_ptr<Bool0::bool0> b7 = _args._a7;
-              return std::visit(Overloaded{[&](const typename Ascii::ascii::Ascii _args) -> std::
-                                                                                             shared_ptr<
-                                                                                                 Sumbool::
-                                                                                                     sumbool> {
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b8 =
-                                                                                                       _args
-                                                                                                           ._a0;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b9 =
-                                                                                                       _args
-                                                                                                           ._a1;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b10 =
-                                                                                                       _args
-                                                                                                           ._a2;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b11 =
-                                                                                                       _args
-                                                                                                           ._a3;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b12 =
-                                                                                                       _args
-                                                                                                           ._a4;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b13 =
-                                                                                                       _args
-                                                                                                           ._a5;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b14 =
-                                                                                                       _args
-                                                                                                           ._a6;
-                                                                                               std::shared_ptr<
-                                                                                                   Bool0::
-                                                                                                       bool0>
-                                                                                                   b15 =
-                                                                                                       _args
-                                                                                                           ._a7;
-                                                                                               return std::visit(
-                                                                                                   Overloaded{
-                                                                                                       [&](const typename Sumbool::
-                                                                                                               sumbool::left
-                                                                                                                   _args)
-                                                                                                           -> T1 {
-                                                                                                         return std::visit(
-                                                                                                             Overloaded{
-                                                                                                                 [&](const typename Sumbool::
-                                                                                                                         sumbool::left
-                                                                                                                             _args)
-                                                                                                                     -> T1 {
-                                                                                                                   return std::
-                                                                                                                       visit(
-                                                                                                                           Overloaded{[&](const typename Sumbool::
-                                                                                                                                              sumbool::left
-                                                                                                                                                  _args)
-                                                                                                                                          -> T1 {
-                                                                                                                                        return std::
-                                                                                                                                            visit(Overloaded{[&](const typename Sumbool::
-                                                                                                                                                                     sumbool::left
-                                                                                                                                                                         _args)
-                                                                                                                                                                 -> T1 {
-                                                                                                                                                               return std::visit(
-                                                                                                                                                                   Overloaded{
-                                                                                                                                                                       [&](const typename Sumbool::
-                                                                                                                                                                               sumbool::left
-                                                                                                                                                                                   _args) -> T1 {
-                                                                                                                                                                         return std::visit(Overloaded{[&](const typename Sumbool::
-                                                                                                                                                                                                              sumbool::left
-                                                                                                                                                                                                                  _args)
-                                                                                                                                                                                                          -> T1 {
-                                                                                                                                                                                                        return std::visit(
-                                                                                                                                                                                                            Overloaded{
-                                                                                                                                                                                                                [&](const typename Sumbool::
-                                                                                                                                                                                                                        sumbool::left
-                                                                                                                                                                                                                            _args)
-                                                                                                                                                                                                                    -> T1 {
-                                                                                                                                                                                                                  return std::visit(
-                                                                                                                                                                                                                      Overloaded{
-                                                                                                                                                                                                                          [](const typename Sumbool::
-                                                                                                                                                                                                                                 sumbool::left
-                                                                                                                                                                                                                                     _args)
-                                                                                                                                                                                                                              -> T1 {
-                                                                                                                                                                                                                            return Sumbool::
-                                                                                                                                                                                                                                sumbool::ctor::
-                                                                                                                                                                                                                                    left_();
-                                                                                                                                                                                                                          },
-                                                                                                                                                                                                                          [](const typename Sumbool::
-                                                                                                                                                                                                                                 sumbool::right
-                                                                                                                                                                                                                                     _args)
-                                                                                                                                                                                                                              -> T1 {
-                                                                                                                                                                                                                            return Sumbool::
-                                                                                                                                                                                                                                sumbool::ctor::
-                                                                                                                                                                                                                                    right_();
-                                                                                                                                                                                                                          }},
-                                                                                                                                                                                                                      bool_dec(
-                                                                                                                                                                                                                          b7,
-                                                                                                                                                                                                                          b15)
-                                                                                                                                                                                                                          ->v());
-                                                                                                                                                                                                                },
-                                                                                                                                                                                                                [](const typename Sumbool::
-                                                                                                                                                                                                                       sumbool::right
-                                                                                                                                                                                                                           _args)
-                                                                                                                                                                                                                    -> T1 {
-                                                                                                                                                                                                                  return Sumbool::
-                                                                                                                                                                                                                      sumbool::ctor::
-                                                                                                                                                                                                                          right_();
-                                                                                                                                                                                                                }},
-                                                                                                                                                                                                            bool_dec(
-                                                                                                                                                                                                                b6,
-                                                                                                                                                                                                                b14)
-                                                                                                                                                                                                                ->v());
-                                                                                                                                                                                                      },
-                                                                                                                                                                                                      [](const typename Sumbool::
-                                                                                                                                                                                                             sumbool::right
-                                                                                                                                                                                                                 _args)
-                                                                                                                                                                                                          -> T1 {
-                                                                                                                                                                                                        return Sumbool::
-                                                                                                                                                                                                            sumbool::ctor::
-                                                                                                                                                                                                                right_();
-                                                                                                                                                                                                      }},
-                                                                                                                                                                                           bool_dec(
-                                                                                                                                                                                               b5,
-                                                                                                                                                                                               b13)
-                                                                                                                                                                                               ->v());
-                                                                                                                                                                       },
-                                                                                                                                                                       [](const typename Sumbool::
-                                                                                                                                                                              sumbool::right
-                                                                                                                                                                                  _args)
-                                                                                                                                                                           -> T1 {
-                                                                                                                                                                         return Sumbool::
-                                                                                                                                                                             sumbool::ctor::
-                                                                                                                                                                                 right_();
-                                                                                                                                                                       }},
-                                                                                                                                                                   bool_dec(
-                                                                                                                                                                       b4,
-                                                                                                                                                                       b12)
-                                                                                                                                                                       ->v());
-                                                                                                                                                             },
-                                                                                                                                                             [](const typename Sumbool::sumbool::right _args) -> T1 {
-                                                                                                                                                               return Sumbool::
-                                                                                                                                                                   sumbool::ctor::
-                                                                                                                                                                       right_();
-                                                                                                                                                             }},
-                                                                                                                                                  bool_dec(
-                                                                                                                                                      b3,
-                                                                                                                                                      b11)
-                                                                                                                                                      ->v());
-                                                                                                                                      },
-                                                                                                                                      [](const typename Sumbool::
-                                                                                                                                             sumbool::right
-                                                                                                                                                 _args)
-                                                                                                                                          -> T1 {
-                                                                                                                                        return Sumbool::
-                                                                                                                                            sumbool::ctor::
-                                                                                                                                                right_();
-                                                                                                                                      }},
-                                                                                                                           bool_dec(
-                                                                                                                               b2,
-                                                                                                                               b10)
-                                                                                                                               ->v());
-                                                                                                                 },
-                                                                                                                 [](const typename Sumbool::
-                                                                                                                        sumbool::right
-                                                                                                                            _args)
-                                                                                                                     -> T1 {
-                                                                                                                   return Sumbool::
-                                                                                                                       sumbool::ctor::
-                                                                                                                           right_();
-                                                                                                                 }},
-                                                                                                             bool_dec(
-                                                                                                                 b1,
-                                                                                                                 b9)
-                                                                                                                 ->v());
-                                                                                                       },
-                                                                                                       [](const typename Sumbool::
-                                                                                                              sumbool::right
-                                                                                                                  _args)
-                                                                                                           -> T1 {
-                                                                                                         return Sumbool::
-                                                                                                             sumbool::ctor::
-                                                                                                                 right_();
-                                                                                                       }},
-                                                                                                   bool_dec(
-                                                                                                       b0,
-                                                                                                       b8)
-                                                                                                       ->v());
-                                                                                             }},
-                                b->v());
-            }},
-            a->v());
-}
-
-std::shared_ptr<Nat::nat> length(const std::shared_ptr<String::string> &s) {
-  return std::visit(
-      Overloaded{
-          [](const typename String::string::EmptyString _args)
-              -> std::shared_ptr<Nat::nat> { return Nat::nat::ctor::O_(); },
-          [](const typename String::string::String _args)
-              -> std::shared_ptr<Nat::nat> {
-            std::shared_ptr<String::string> s_ = _args._a1;
-            return Nat::nat::ctor::S_(length(s_));
-          }},
-      s->v());
 }
 
 std::shared_ptr<Chain::chain>
@@ -310,14 +78,15 @@ insert_chain(const std::shared_ptr<Ascii::ascii> &c,
 std::shared_ptr<Chain::chain>
 inserts_chain_empty(const std::shared_ptr<String::string> &s) {
   return std::visit(
-      Overloaded{[](const typename String::string::EmptyString _args) -> T1 {
+      Overloaded{[](const typename String::string::EmptyString _args) -> auto {
                    return Chain::chain::ctor::empty_();
                  },
-                 [](const typename String::string::String _args) -> T1 {
+                 [](const typename String::string::String _args) -> auto {
                    std::shared_ptr<Ascii::ascii> a = _args._a0;
                    std::shared_ptr<String::string> s0 = _args._a1;
                    return insert_chain(a, String::string::ctor::EmptyString_(),
-                                       s0, length(s0), inserts_chain_empty(s0));
+                                       s0, s0->length(),
+                                       inserts_chain_empty(s0));
                  }},
       s->v());
 }
@@ -336,15 +105,15 @@ delete_chain(const std::shared_ptr<Ascii::ascii> &c,
 std::shared_ptr<Chain::chain>
 deletes_chain_empty(const std::shared_ptr<String::string> &s) {
   return std::visit(
-      Overloaded{[](const typename String::string::EmptyString _args) -> T1 {
+      Overloaded{[](const typename String::string::EmptyString _args) -> auto {
                    return Chain::chain::ctor::empty_();
                  },
-                 [](const typename String::string::String _args) -> T1 {
+                 [](const typename String::string::String _args) -> auto {
                    std::shared_ptr<Ascii::ascii> a = _args._a0;
                    std::shared_ptr<String::string> s0 = _args._a1;
                    return delete_chain(a, s0,
                                        String::string::ctor::EmptyString_(),
-                                       length(s0), deletes_chain_empty(s0));
+                                       s0->length(), deletes_chain_empty(s0));
                  }},
       s->v());
 }
@@ -476,7 +245,7 @@ levenshtein_chain(const std::shared_ptr<String::string> &s,
                                                    std::shared_ptr<
                                                        Chain::chain>>::ctor::
                                                    existT_(
-                                                       length(t),
+                                                       t->length(),
                                                        inserts_chain_empty(t));
                                              }},
                                          t->v());
@@ -522,8 +291,7 @@ levenshtein_chain(const std::shared_ptr<String::string> &s,
                                                                               Chain::
                                                                                   chain>>::
                                                                           ctor::existT_(
-                                                                              length(
-                                                                                  s),
+                                                                              s->length(),
                                                                               deletes_chain_empty(
                                                                                   String::string::
                                                                                       ctor::String_(
@@ -533,10 +301,10 @@ levenshtein_chain(const std::shared_ptr<String::string> &s,
                                                                     [&](const typename String::
                                                                             string::String
                                                                                 _args)
-                                                                        -> std::function<std::shared_ptr<
-                                                                            SigT::
-                                                                                sigT<std::shared_ptr<Nat::nat>, std::shared_ptr<Chain::
-                                                                                                                                    chain>>>(dummy_prop, dummy_prop)> {
+                                                                        -> std::function<
+                                                                            std::shared_ptr<
+                                                                                SigT::sigT<
+                                                                                    std::shared_ptr<Nat::nat>, std::shared_ptr<Chain::chain>>>(dummy_prop, dummy_prop)> {
                                                                       std::shared_ptr<
                                                                           Ascii::
                                                                               ascii>
@@ -775,9 +543,8 @@ levenshtein_chain(const std::shared_ptr<String::string> &s,
                                                                                             ys)
                                                                                             ->v());
                                                                                   }},
-                                                                              ascii_dec(
-                                                                                  x,
-                                                                                  y)
+                                                                              x->ascii_dec(
+                                                                                   y)
                                                                                   ->v());
                                                                     }},
                                                                 t->v());

--- a/tests/wip/levenshtein/levenshtein.h
+++ b/tests/wip/levenshtein/levenshtein.h
@@ -91,7 +91,7 @@ struct SigT {
     const variant_t &v() const { return v_; }
     A projT1() const {
       return std::visit(
-          Overloaded{[](const typename SigT::sigT<A, P>::existT _args) -> A {
+          Overloaded{[](const typename SigT::sigT<A, P>::existT _args) -> auto {
             A a = _args._a0;
             return a;
           }},
@@ -172,209 +172,218 @@ struct Ascii {
     std::shared_ptr<Sumbool::sumbool>
     ascii_dec(const std::shared_ptr<Ascii::ascii> &b) const {
       return std::visit(
-          Overloaded{[&](const typename Ascii::ascii::Ascii _args) -> T1 {
-            std::shared_ptr<Bool0::bool0> b0 = _args._a0;
-            std::shared_ptr<Bool0::bool0> b1 = _args._a1;
-            std::shared_ptr<Bool0::bool0> b2 = _args._a2;
-            std::shared_ptr<Bool0::bool0> b3 = _args._a3;
-            std::shared_ptr<Bool0::bool0> b4 = _args._a4;
-            std::shared_ptr<Bool0::bool0> b5 = _args._a5;
-            std::shared_ptr<Bool0::bool0> b6 = _args._a6;
-            std::shared_ptr<Bool0::bool0> b7 = _args._a7;
-            return std::
-                visit(Overloaded{[&](const typename Ascii::ascii::Ascii _args) -> std::
-                                                                                   shared_ptr<
-                                                                                       Sumbool::
-                                                                                           sumbool> {
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b8 =
-                                                                                             _args
-                                                                                                 ._a0;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b9 =
-                                                                                             _args
-                                                                                                 ._a1;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b10 =
-                                                                                             _args
-                                                                                                 ._a2;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b11 =
-                                                                                             _args
-                                                                                                 ._a3;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b12 =
-                                                                                             _args
-                                                                                                 ._a4;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b13 =
-                                                                                             _args
-                                                                                                 ._a5;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b14 =
-                                                                                             _args
-                                                                                                 ._a6;
-                                                                                     std::shared_ptr<
-                                                                                         Bool0::
-                                                                                             bool0>
-                                                                                         b15 =
-                                                                                             _args
-                                                                                                 ._a7;
-                                                                                     return std::visit(
-                                                                                         Overloaded{
-                                                                                             [&](const typename Sumbool::
-                                                                                                     sumbool::left
-                                                                                                         _args)
-                                                                                                 -> T1 {
-                                                                                               return std::visit(
-                                                                                                   Overloaded{
-                                                                                                       [&](const typename Sumbool::sumbool::
-                                                                                                               left _args) -> T1 {
-                                                                                                         return std::visit(
-                                                                                                             Overloaded{
-                                                                                                                 [&](const typename Sumbool::
-                                                                                                                         sumbool::left
-                                                                                                                             _args)
-                                                                                                                     -> T1 {
-                                                                                                                   return std::visit(
-                                                                                                                       Overloaded{[&](const typename Sumbool::
-                                                                                                                                          sumbool::left
-                                                                                                                                              _args)
-                                                                                                                                      -> T1 {
-                                                                                                                                    return std::visit(Overloaded{
-                                                                                                                                                          [&](const typename Sumbool::
-                                                                                                                                                                  sumbool::left
-                                                                                                                                                                      _args)
-                                                                                                                                                              -> T1 {
-                                                                                                                                                            return std::
-                                                                                                                                                                visit(Overloaded{
-                                                                                                                                                                          [&](const typename Sumbool::sumbool::left _args) -> T1 {
-                                                                                                                                                                            return std::visit(Overloaded{[&](const typename Sumbool::
-                                                                                                                                                                                                                 sumbool::left
-                                                                                                                                                                                                                     _args)
-                                                                                                                                                                                                             -> T1 {
-                                                                                                                                                                                                           return std::visit(
-                                                                                                                                                                                                               Overloaded{
-                                                                                                                                                                                                                   [](const typename Sumbool::
-                                                                                                                                                                                                                          sumbool::left
-                                                                                                                                                                                                                              _args)
-                                                                                                                                                                                                                       -> T1 {
-                                                                                                                                                                                                                     return Sumbool::
-                                                                                                                                                                                                                         sumbool::ctor::
-                                                                                                                                                                                                                             left_();
-                                                                                                                                                                                                                   },
-                                                                                                                                                                                                                   [](
-                                                                                                                                                                                                                       const typename Sumbool::sumbool::right
-                                                                                                                                                                                                                           _args) -> T1 {
-                                                                                                                                                                                                                     return Sumbool::
-                                                                                                                                                                                                                         sumbool::ctor::
-                                                                                                                                                                                                                             right_();
-                                                                                                                                                                                                                   }},
-                                                                                                                                                                                                               bool_dec(
-                                                                                                                                                                                                                   b7,
-                                                                                                                                                                                                                   b15)
-                                                                                                                                                                                                                   ->v());
-                                                                                                                                                                                                         },
-                                                                                                                                                                                                         [](const typename Sumbool::sumbool::right _args) -> T1 {
-                                                                                                                                                                                                           return Sumbool::
-                                                                                                                                                                                                               sumbool::ctor::
-                                                                                                                                                                                                                   right_();
-                                                                                                                                                                                                         }},
-                                                                                                                                                                                              bool_dec(
-                                                                                                                                                                                                  b6,
-                                                                                                                                                                                                  b14)
-                                                                                                                                                                                                  ->v());
-                                                                                                                                                                          },
-                                                                                                                                                                          [](const typename Sumbool::
-                                                                                                                                                                                 sumbool::right
-                                                                                                                                                                                     _args)
-                                                                                                                                                                              -> T1 {
-                                                                                                                                                                            return Sumbool::
-                                                                                                                                                                                sumbool::ctor::
-                                                                                                                                                                                    right_();
-                                                                                                                                                                          }},
-                                                                                                                                                                      bool_dec(
-                                                                                                                                                                          b5,
-                                                                                                                                                                          b13)
-                                                                                                                                                                          ->v());
-                                                                                                                                                          },
-                                                                                                                                                          [](const typename Sumbool::sumbool::right _args) -> T1 {
-                                                                                                                                                            return Sumbool::
-                                                                                                                                                                sumbool::ctor::
-                                                                                                                                                                    right_();
-                                                                                                                                                          }},
-                                                                                                                                                      bool_dec(
-                                                                                                                                                          b4,
-                                                                                                                                                          b12)
-                                                                                                                                                          ->v());
-                                                                                                                                  },
-                                                                                                                                  [](
-                                                                                                                                      const typename Sumbool::sumbool::right
-                                                                                                                                          _args) -> T1 {
-                                                                                                                                    return Sumbool::
-                                                                                                                                        sumbool::ctor::
-                                                                                                                                            right_();
-                                                                                                                                  }},
-                                                                                                                       bool_dec(
-                                                                                                                           b3,
-                                                                                                                           b11)
-                                                                                                                           ->v());
-                                                                                                                 },
-                                                                                                                 [](const typename Sumbool::
-                                                                                                                        sumbool::right
-                                                                                                                            _args)
-                                                                                                                     -> T1 {
-                                                                                                                   return Sumbool::
-                                                                                                                       sumbool::ctor::
-                                                                                                                           right_();
-                                                                                                                 }},
-                                                                                                             bool_dec(
-                                                                                                                 b2,
-                                                                                                                 b10)
-                                                                                                                 ->v());
-                                                                                                       },
-                                                                                                       [](const typename Sumbool::
-                                                                                                              sumbool::right
-                                                                                                                  _args)
-                                                                                                           -> T1 {
-                                                                                                         return Sumbool::
-                                                                                                             sumbool::ctor::
-                                                                                                                 right_();
-                                                                                                       }},
-                                                                                                   bool_dec(
-                                                                                                       b1,
-                                                                                                       b9)
-                                                                                                       ->v());
-                                                                                             },
-                                                                                             [](const typename Sumbool::
-                                                                                                    sumbool::right
+          Overloaded{
+              [&](const typename Ascii::ascii::Ascii _args) -> auto {
+                std::shared_ptr<Bool0::bool0> b0 = _args._a0;
+                std::shared_ptr<Bool0::bool0> b1 = _args._a1;
+                std::shared_ptr<Bool0::bool0> b2 = _args._a2;
+                std::shared_ptr<Bool0::bool0> b3 = _args._a3;
+                std::shared_ptr<Bool0::bool0> b4 = _args._a4;
+                std::shared_ptr<Bool0::bool0> b5 = _args._a5;
+                std::shared_ptr<Bool0::bool0> b6 = _args._a6;
+                std::shared_ptr<Bool0::bool0> b7 = _args._a7;
+                return std::
+                    visit(
+                        Overloaded{
+                            [&](const typename Ascii::ascii::Ascii _args) -> std::
+                                                                              shared_ptr<
+                                                                                  Sumbool::
+                                                                                      sumbool> {
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b8 =
+                                                                                        _args
+                                                                                            ._a0;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b9 =
+                                                                                        _args
+                                                                                            ._a1;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b10 =
+                                                                                        _args
+                                                                                            ._a2;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b11 =
+                                                                                        _args
+                                                                                            ._a3;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b12 =
+                                                                                        _args
+                                                                                            ._a4;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b13 =
+                                                                                        _args
+                                                                                            ._a5;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b14 =
+                                                                                        _args
+                                                                                            ._a6;
+                                                                                std::shared_ptr<
+                                                                                    Bool0::
+                                                                                        bool0>
+                                                                                    b15 =
+                                                                                        _args
+                                                                                            ._a7;
+                                                                                return std::
+                                                                                    visit(
+                                                                                        Overloaded{
+                                                                                            [&](const typename Sumbool::
+                                                                                                    sumbool::left
                                                                                                         _args)
-                                                                                                 -> T1 {
-                                                                                               return Sumbool::
-                                                                                                   sumbool::ctor::
-                                                                                                       right_();
-                                                                                             }},
-                                                                                         bool_dec(
-                                                                                             b0,
-                                                                                             b8)
-                                                                                             ->v());
-                                                                                   }},
-                      b->v());
-          }},
+                                                                                                -> auto {
+                                                                                              return std::
+                                                                                                  visit(
+                                                                                                      Overloaded{
+                                                                                                          [&](const typename Sumbool::
+                                                                                                                  sumbool::left
+                                                                                                                      _args)
+                                                                                                              -> auto {
+                                                                                                            return std::visit(Overloaded{[&](const typename Sumbool::
+                                                                                                                                                 sumbool::left
+                                                                                                                                                     _args)
+                                                                                                                                             -> auto {
+                                                                                                                                           return std::visit(Overloaded{
+                                                                                                                                                                 [&](const typename Sumbool::sumbool::left _args) -> auto {
+                                                                                                                                                                   return std::visit(Overloaded{[&](const typename Sumbool::
+                                                                                                                                                                                                        sumbool::left
+                                                                                                                                                                                                            _args)
+                                                                                                                                                                                                    -> auto {
+                                                                                                                                                                                                  return std::
+                                                                                                                                                                                                      visit(Overloaded{
+                                                                                                                                                                                                                [&](const typename Sumbool::
+                                                                                                                                                                                                                        sumbool::left
+                                                                                                                                                                                                                            _args)
+                                                                                                                                                                                                                    -> auto {
+                                                                                                                                                                                                                  return std::visit(Overloaded{[&](const typename Sumbool::sumbool::left _args) -> auto {
+                                                                                                                                                                                                                                                 return std::visit(
+                                                                                                                                                                                                                                                     Overloaded{
+                                                                                                                                                                                                                                                         [](const typename Sumbool::
+                                                                                                                                                                                                                                                                sumbool::left
+                                                                                                                                                                                                                                                                    _args)
+                                                                                                                                                                                                                                                             -> auto {
+                                                                                                                                                                                                                                                           return Sumbool::
+                                                                                                                                                                                                                                                               sumbool::ctor::
+                                                                                                                                                                                                                                                                   left_();
+                                                                                                                                                                                                                                                         },
+                                                                                                                                                                                                                                                         [](
+                                                                                                                                                                                                                                                             const typename Sumbool::
+                                                                                                                                                                                                                                                                 sumbool::
+                                                                                                                                                                                                                                                                     right _args) -> auto {
+                                                                                                                                                                                                                                                           return Sumbool::
+                                                                                                                                                                                                                                                               sumbool::ctor::
+                                                                                                                                                                                                                                                                   right_();
+                                                                                                                                                                                                                                                         }},
+                                                                                                                                                                                                                                                     bool_dec(
+                                                                                                                                                                                                                                                         b7,
+                                                                                                                                                                                                                                                         b15)
+                                                                                                                                                                                                                                                         ->v());
+                                                                                                                                                                                                                                               },
+                                                                                                                                                                                                                                               [](const typename Sumbool::
+                                                                                                                                                                                                                                                      sumbool::right
+                                                                                                                                                                                                                                                          _args)
+                                                                                                                                                                                                                                                   -> auto {
+                                                                                                                                                                                                                                                 return Sumbool::
+                                                                                                                                                                                                                                                     sumbool::ctor::
+                                                                                                                                                                                                                                                         right_();
+                                                                                                                                                                                                                                               }},
+                                                                                                                                                                                                                                    bool_dec(
+                                                                                                                                                                                                                                        b6,
+                                                                                                                                                                                                                                        b14)
+                                                                                                                                                                                                                                        ->v());
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                [](const typename Sumbool::
+                                                                                                                                                                                                                       sumbool::right
+                                                                                                                                                                                                                           _args)
+                                                                                                                                                                                                                    -> auto {
+                                                                                                                                                                                                                  return Sumbool::
+                                                                                                                                                                                                                      sumbool::ctor::
+                                                                                                                                                                                                                          right_();
+                                                                                                                                                                                                                }},
+                                                                                                                                                                                                            bool_dec(
+                                                                                                                                                                                                                b5,
+                                                                                                                                                                                                                b13)
+                                                                                                                                                                                                                ->v());
+                                                                                                                                                                                                },
+                                                                                                                                                                                                [](const typename Sumbool::
+                                                                                                                                                                                                       sumbool::right
+                                                                                                                                                                                                           _args)
+                                                                                                                                                                                                    -> auto {
+                                                                                                                                                                                                  return Sumbool::
+                                                                                                                                                                                                      sumbool::ctor::
+                                                                                                                                                                                                          right_();
+                                                                                                                                                                                                }},
+                                                                                                                                                                                     bool_dec(
+                                                                                                                                                                                         b4,
+                                                                                                                                                                                         b12)
+                                                                                                                                                                                         ->v());
+                                                                                                                                                                 },
+                                                                                                                                                                 [](const typename Sumbool::
+                                                                                                                                                                        sumbool::right
+                                                                                                                                                                            _args)
+                                                                                                                                                                     -> auto {
+                                                                                                                                                                   return Sumbool::
+                                                                                                                                                                       sumbool::ctor::
+                                                                                                                                                                           right_();
+                                                                                                                                                                 }},
+                                                                                                                                                             bool_dec(
+                                                                                                                                                                 b3,
+                                                                                                                                                                 b11)
+                                                                                                                                                                 ->v());
+                                                                                                                                         },
+                                                                                                                                         [](const typename Sumbool::
+                                                                                                                                                sumbool::right
+                                                                                                                                                    _args)
+                                                                                                                                             -> auto {
+                                                                                                                                           return Sumbool::
+                                                                                                                                               sumbool::ctor::
+                                                                                                                                                   right_();
+                                                                                                                                         }},
+                                                                                                                              bool_dec(
+                                                                                                                                  b2,
+                                                                                                                                  b10)
+                                                                                                                                  ->v());
+                                                                                                          },
+                                                                                                          [](const typename Sumbool::
+                                                                                                                 sumbool::right
+                                                                                                                     _args)
+                                                                                                              -> auto {
+                                                                                                            return Sumbool::
+                                                                                                                sumbool::ctor::
+                                                                                                                    right_();
+                                                                                                          }},
+                                                                                                      bool_dec(
+                                                                                                          b1,
+                                                                                                          b9)
+                                                                                                          ->v());
+                                                                                            },
+                                                                                            [](const typename Sumbool::
+                                                                                                   sumbool::right
+                                                                                                       _args)
+                                                                                                -> auto {
+                                                                                              return Sumbool::
+                                                                                                  sumbool::ctor::
+                                                                                                      right_();
+                                                                                            }},
+                                                                                        bool_dec(
+                                                                                            b0,
+                                                                                            b8)
+                                                                                            ->v());
+                                                                              }},
+                        b->v());
+              }},
           this->v());
     }
   };

--- a/tests/wip/msort/msort.h
+++ b/tests/wip/msort/msort.h
@@ -98,18 +98,17 @@ T2 div_conq(F0 &&splitF, const T2 x, F2 &&x0, F3 &&x1,
               div_conq<T1, T2>(splitF, x, x0, x1, splitF(ls).second));
   } else {
     return std::visit(
-        Overloaded{
-            [&](const typename List::list<T1>::nil _args)
-                -> std::function<T2(
-                    std::function<T2(std::shared_ptr<List::list<T1>>)>)> {
-              return x;
-            },
-            [&](const typename List::list<T1>::cons _args)
-                -> std::function<T2(
-                    std::function<T2(std::shared_ptr<List::list<T1>>)>)> {
-              T1 a = _args._a0;
-              return x0(a);
-            }},
+        Overloaded{[&](const typename List::list<T1>::nil _args)
+                       -> std::function<T2(
+                           std::function<T2(std::shared_ptr<List::list<T1>>)>,
+                           dummy_prop)> { return x; },
+                   [&](const typename List::list<T1>::cons _args)
+                       -> std::function<T2(
+                           std::function<T2(std::shared_ptr<List::list<T1>>)>,
+                           dummy_prop)> {
+                     T1 a = _args._a0;
+                     return x0(a);
+                   }},
         ls->v());
   }
 }

--- a/tests/wip/nested_tree/nested_tree.h
+++ b/tests/wip/nested_tree/nested_tree.h
@@ -121,10 +121,10 @@ struct NestedTree {
                 F1>
   static T1 tree_rect(const T1 f, F1 &&f0, const std::shared_ptr<tree<T2>> &t) {
     return std::visit(
-        Overloaded{[&](const typename tree<T2>::leaf _args) -> T1 {
+        Overloaded{[&](const typename tree<T2>::leaf _args) -> T2 {
                      return f("dummy");
                    },
-                   [&](const typename tree<T2>::node _args) -> T1 {
+                   [&](const typename tree<T2>::node _args) -> T2 {
                      T2 y = _args._a0;
                      std::shared_ptr<tree<std::pair<T2, T2>>> t0 = _args._a1;
                      return f0("dummy", y, t0, tree_rect<T1, T2>(f, f0, t0));
@@ -138,10 +138,10 @@ struct NestedTree {
                 F1>
   static T1 tree_rec(const T1 f, F1 &&f0, const std::shared_ptr<tree<T2>> &t) {
     return std::visit(
-        Overloaded{[&](const typename tree<T2>::leaf _args) -> T1 {
+        Overloaded{[&](const typename tree<T2>::leaf _args) -> T2 {
                      return f("dummy");
                    },
-                   [&](const typename tree<T2>::node _args) -> T1 {
+                   [&](const typename tree<T2>::node _args) -> T2 {
                      T2 y = _args._a0;
                      std::shared_ptr<tree<std::pair<T2, T2>>> t0 = _args._a1;
                      return f0("dummy", y, t0, tree_rec<T1, T2>(f, f0, t0));

--- a/tests/wip/regexp/regexp.cpp
+++ b/tests/wip/regexp/regexp.cpp
@@ -22,7 +22,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                         const std::shared_ptr<Matcher::regexp> &x) {
   return std::visit(
       Overloaded{
-          [&](const typename Matcher::regexp::Any _args) -> T1 {
+          [&](const typename Matcher::regexp::Any _args) -> auto {
             return std::visit(
                 Overloaded{
                     [](const typename Matcher::regexp::Any _args) -> bool {
@@ -48,7 +48,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Char _args) -> T1 {
+          [&](const typename Matcher::regexp::Char _args) -> auto {
             int c = _args._a0;
             return std::visit(
                 Overloaded{
@@ -80,7 +80,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Eps _args) -> T1 {
+          [&](const typename Matcher::regexp::Eps _args) -> auto {
             return std::visit(
                 Overloaded{
                     [](const typename Matcher::regexp::Any _args) -> bool {
@@ -106,7 +106,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Cat _args) -> T1 {
+          [&](const typename Matcher::regexp::Cat _args) -> auto {
             std::shared_ptr<Matcher::regexp> r1 = _args._a0;
             std::shared_ptr<Matcher::regexp> r2 = _args._a1;
             return std::visit(
@@ -144,7 +144,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Alt _args) -> T1 {
+          [&](const typename Matcher::regexp::Alt _args) -> auto {
             std::shared_ptr<Matcher::regexp> r1 = _args._a0;
             std::shared_ptr<Matcher::regexp> r2 = _args._a1;
             return std::visit(
@@ -182,7 +182,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Zero _args) -> T1 {
+          [&](const typename Matcher::regexp::Zero _args) -> auto {
             return std::visit(
                 Overloaded{
                     [](const typename Matcher::regexp::Any _args) -> bool {
@@ -208,7 +208,7 @@ bool Matcher::regexp_eq(const std::shared_ptr<Matcher::regexp> &r,
                     }},
                 x->v());
           },
-          [&](const typename Matcher::regexp::Star _args) -> T1 {
+          [&](const typename Matcher::regexp::Star _args) -> auto {
             std::shared_ptr<Matcher::regexp> r0 = _args._a0;
             return std::visit(
                 Overloaded{
@@ -876,52 +876,55 @@ bool Matcher::deriv_parse(const std::shared_ptr<Matcher::regexp> &r,
 
 bool Matcher::NullEpsOrZero(const std::shared_ptr<Matcher::regexp> &r) {
   return std::visit(
-      Overloaded{
-          [](const typename Matcher::regexp::Any _args) -> T1 { return false; },
-          [](const typename Matcher::regexp::Char _args) -> T1 {
-            return false;
-          },
-          [](const typename Matcher::regexp::Eps _args) -> T1 { return true; },
-          [](const typename Matcher::regexp::Cat _args) -> T1 {
-            std::shared_ptr<Matcher::regexp> r1 = _args._a0;
-            std::shared_ptr<Matcher::regexp> r2 = _args._a1;
-            if (NullEpsOrZero(r1)) {
-              if (NullEpsOrZero(r2)) {
-                return true;
-              } else {
-                return false;
-              }
-            } else {
-              if (NullEpsOrZero(r2)) {
-                return false;
-              } else {
-                return false;
-              }
-            }
-          },
-          [](const typename Matcher::regexp::Alt _args) -> T1 {
-            std::shared_ptr<Matcher::regexp> r1 = _args._a0;
-            std::shared_ptr<Matcher::regexp> r2 = _args._a1;
-            if (NullEpsOrZero(r1)) {
-              if (NullEpsOrZero(r2)) {
-                return true;
-              } else {
-                return true;
-              }
-            } else {
-              if (NullEpsOrZero(r2)) {
-                return true;
-              } else {
-                return false;
-              }
-            }
-          },
-          [](const typename Matcher::regexp::Zero _args) -> T1 {
-            return false;
-          },
-          [](const typename Matcher::regexp::Star _args) -> T1 {
-            return true;
-          }},
+      Overloaded{[](const typename Matcher::regexp::Any _args) -> auto {
+                   return false;
+                 },
+                 [](const typename Matcher::regexp::Char _args) -> auto {
+                   return false;
+                 },
+                 [](const typename Matcher::regexp::Eps _args) -> auto {
+                   return true;
+                 },
+                 [](const typename Matcher::regexp::Cat _args) -> auto {
+                   std::shared_ptr<Matcher::regexp> r1 = _args._a0;
+                   std::shared_ptr<Matcher::regexp> r2 = _args._a1;
+                   if (NullEpsOrZero(r1)) {
+                     if (NullEpsOrZero(r2)) {
+                       return true;
+                     } else {
+                       return false;
+                     }
+                   } else {
+                     if (NullEpsOrZero(r2)) {
+                       return false;
+                     } else {
+                       return false;
+                     }
+                   }
+                 },
+                 [](const typename Matcher::regexp::Alt _args) -> auto {
+                   std::shared_ptr<Matcher::regexp> r1 = _args._a0;
+                   std::shared_ptr<Matcher::regexp> r2 = _args._a1;
+                   if (NullEpsOrZero(r1)) {
+                     if (NullEpsOrZero(r2)) {
+                       return true;
+                     } else {
+                       return true;
+                     }
+                   } else {
+                     if (NullEpsOrZero(r2)) {
+                       return true;
+                     } else {
+                       return false;
+                     }
+                   }
+                 },
+                 [](const typename Matcher::regexp::Zero _args) -> auto {
+                   return false;
+                 },
+                 [](const typename Matcher::regexp::Star _args) -> auto {
+                   return true;
+                 }},
       r->v());
 }
 


### PR DESCRIPTION
 1. Cross-module method call transformation (cpp.ml)
     - Add pre_register_methods_from_structure to scan the entire structure
       and register methods BEFORE code generation begins
     - This fixes calls like List.app from stmtest being generated as
       ::app(xs, ...) instead of xs->app(...)
     - Only register methods where the eponymous type is the first argument
     - Only scan top-level inductives at the actual extraction top level,
       not inside nested modules (prevents over-registration)

  2. Type variable substitution (mlutil.ml)
     - Handle Tvar' in type_subst_list and type_subst_vect
     - Tvar' is used for per-constructor type variables and needs the same
       substitution treatment as regular Tvar

  3. Pattern matching type handling (translation.ml)
     - Track current function's type variables (template parameters) and
       pass them through to pattern match lambda generation
     - Track parameter types to refine pattern match scrutinee types
     - Use 'auto' return type for lambdas with unresolved type variables
     
 Test results:
 
 ```
 basics/
  ack                       ✓ pass
  add_one                   ✓ pass
  args                      ✓ pass
  binom                     ✓ pass
  eqordshow                 ✓ pass
  list                      ✓ pass
  map                       ✓ pass
  module                    ✓ pass
  multi_ind_functor         ✓ pass
  mutual_functor            ✓ pass
  mutual_mod                ✓ pass
  nat                       ✓ pass
  nat_bde                   ✓ pass
  rapply                    ✓ pass
  rev                       ✓ pass
  rmatch                    ✓ pass
  tokenizer                 ✓ pass
  top                       ✓ pass
  top_bde                   ✓ pass
  tree                      ✓ pass
  zip                       ✓ pass

monadic/
  bind_return               ✓ pass
  free_monad                ✓ pass
  hash                      ✓ pass
  hash_bde                  ✓ pass
  io                        ✓ pass
  par                       ✓ pass
  skiplist                  ✓ pass
  stm                       ✓ pass
  thread                    ✓ pass
  vector                    ✓ pass

wip/
  colist                    ✗ fail
  graph                     ✗ fail
  ind_param                 ✗ fail
  isort                     ✗ fail
  levenshtein               ✗ fail
  msort                     ✗ fail
  nested_mod                ✗ fail
  nested_tree               ✗ fail
  psort                     ✗ fail
  pstring                   ✗ fail
  qsort                     ✗ fail
  regexp                    ✗ fail
  vec                       ✗ fail

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Results: 31 passed, 13 failed, 44 total
```