### PR TITLE
[wip/levenshtein] Prove computed minimality and bridge theorem

### DIFF
--- a/tests/wip/levenshtein/Levenshtein.v
+++ b/tests/wip/levenshtein/Levenshtein.v
@@ -5,7 +5,6 @@
 From Stdlib Require Import String Ascii Nat Lia.
 From Stdlib Require Import Program.Equality.
 From Stdlib Require Import Arith.Wf_nat.
-From Stdlib Require Import Logic.ClassicalDescription Logic.Classical_Prop.
 
 Open Scope string_scope.
 Infix "::" := String (at level 60, right associativity) : string_scope.
@@ -24,6 +23,26 @@ Inductive chain : string -> string -> nat -> Type :=
     chain s t n -> chain (a :: s) (a :: t) n
 | change {s t u : string} {n : nat} :
     edit s t -> chain t u n -> chain s u (S n).
+
+Lemma chain_length_bounds :
+  forall s t n (c : chain s t n),
+    length t <= length s + n /\ length s <= length t + n.
+Proof.
+  intros s t n c.
+  induction c as [|a s t n c IH|s t u n e c IH].
+  - simpl. split; lia.
+  - destruct IH as [IH1 IH2].
+    simpl in *.
+    split; lia.
+  - destruct IH as [IH1 IH2].
+    destruct e.
+    + simpl in *.
+      split; lia.
+    + simpl in *.
+      split; lia.
+    + simpl in *.
+      split; lia.
+Qed.
 
 Lemma same_chain : forall s, chain s s 0.
 Proof.
@@ -170,6 +189,50 @@ Proof.
       lia.
 Qed.
 
+Lemma min3_app_cases {t : Type} (x y z : t) (f : t -> nat) (P : t -> Prop) :
+  P x -> P y -> P z -> P (min3_app x y z f).
+Proof.
+  intros Hx Hy Hz.
+  unfold min3_app.
+  destruct (Nat.leb (f x) (f y)); destruct (Nat.leb _ _); auto.
+Qed.
+
+Lemma min3_app_value {t : Type} (x y z : t) (f : t -> nat) :
+  f (min3_app x y z f) = Nat.min (f x) (Nat.min (f y) (f z)).
+Proof.
+  unfold min3_app.
+  destruct (Nat.leb (f x) (f y)) eqn:Hxy.
+  - destruct (Nat.leb (f x) (f z)) eqn:Hxz.
+    + apply Nat.leb_le in Hxy.
+      apply Nat.leb_le in Hxz.
+      rewrite Nat.min_l by lia.
+      rewrite Nat.min_l by lia.
+      reflexivity.
+    + apply Nat.leb_le in Hxy.
+      apply Nat.leb_gt in Hxz.
+      rewrite Nat.min_l by lia.
+      rewrite Nat.min_r by lia.
+      reflexivity.
+  - destruct (Nat.leb (f y) (f z)) eqn:Hyz.
+    + apply Nat.leb_gt in Hxy.
+      apply Nat.leb_le in Hyz.
+      rewrite Nat.min_r by lia.
+      rewrite Nat.min_l by lia.
+      reflexivity.
+    + apply Nat.leb_gt in Hxy.
+      apply Nat.leb_gt in Hyz.
+      rewrite Nat.min_r by lia.
+      rewrite Nat.min_r by lia.
+      reflexivity.
+Qed.
+
+Lemma min3_comm12 : forall a b c : nat,
+  Nat.min a (Nat.min b c) = Nat.min b (Nat.min a c).
+Proof.
+  intros a b c.
+  lia.
+Qed.
+
 Fixpoint levenshtein_chain (s : string)  :=
   fix levenshtein_chain1 (t : string) : {n : nat & chain s t n} :=
     (match s as s', t as t' return s = s' -> t = t' -> {n : nat & chain s t n} with
@@ -206,57 +269,29 @@ Fixpoint levenshtein_chain (s : string)  :=
         end
     end) (eq_refl s) (eq_refl t).
 
-Definition chain_inhabited (s t : string) (n : nat) : Prop :=
-  exists c : chain s t n, True.
-
-Lemma chain_inhabited_dec : forall s t n, chain_inhabited s t n \/ ~ chain_inhabited s t n.
-Proof.
-  intros s t n.
-  destruct (classic (chain_inhabited s t n)); auto.
-Qed.
-
-Lemma chain_inhabited_ex : forall s t, exists n, chain_inhabited s t n.
-Proof.
-  intros s t.
-  destruct (levenshtein_chain s t) as [n c].
-  exists n.
-  exists c.
-  exact I.
-Qed.
-
-Definition levenshtein_witness (s t : string) :
-    {n : nat | chain_inhabited s t n /\ forall m, chain_inhabited s t m -> n <= m }.
-Proof.
-  apply constructive_definite_description.
-  apply dec_inh_nat_subset_has_unique_least_element.
-  - intro n. apply chain_inhabited_dec.
-  - apply chain_inhabited_ex.
-Defined.
-
-Definition levenshtein (s t : string) : nat :=
-  proj1_sig (levenshtein_witness s t).
-
 Definition levenshtein_computed (s t : string) : nat :=
   projT1 (levenshtein_chain s t).
 
-Lemma levenshtein_is_least :
-  forall s t n, chain_inhabited s t n -> levenshtein s t <= n.
+Definition levenshtein (s t : string) : nat :=
+  levenshtein_computed s t.
+
+Lemma levenshtein_computed_length_bounds :
+  forall s t,
+    length t <= length s + levenshtein_computed s t
+    /\ length s <= length t + levenshtein_computed s t.
 Proof.
-  intros s t n Hn.
-  unfold levenshtein.
-  destruct (levenshtein_witness s t) as [m [Hm Hleast]]; simpl.
-  apply Hleast.
-  exact Hn.
+  intros s t.
+  unfold levenshtein_computed.
+  destruct (levenshtein_chain s t) as [n c].
+  simpl.
+  exact (chain_length_bounds s t n c).
 Qed.
 
 Lemma levenshtein_le_computed : forall s t, levenshtein s t <= projT1 (levenshtein_chain s t).
 Proof.
   intros s t.
-  apply (levenshtein_is_least s t (projT1 (levenshtein_chain s t))).
-  destruct (levenshtein_chain s t) as [n c].
-  simpl.
-  exists c.
-  exact I.
+  unfold levenshtein, levenshtein_computed.
+  lia.
 Qed.
 
 Lemma levenshtein_computed_skip_eq : forall a s t,
@@ -365,17 +400,550 @@ Proof.
     exact H.
 Qed.
 
+Lemma levenshtein_computed_insert_lower :
+  forall a s t,
+    levenshtein_computed s t <= S (levenshtein_computed (a :: s) t).
+Proof.
+  intros a0 s0 t0.
+  refine (
+    well_founded_induction
+      lt_wf
+      (fun m =>
+         forall a s t, length s + length t = m ->
+           levenshtein_computed s t <= S (levenshtein_computed (a :: s) t))
+      _
+      (length s0 + length t0)
+      a0 s0 t0 eq_refl).
+  intros m IH a s t Hm.
+  destruct s as [|x xs], t as [|y ys].
+  - simpl. lia.
+  - assert (Hlen :
+        length ys <= levenshtein_computed (a :: "") (y :: ys)).
+    {
+      pose proof (levenshtein_computed_length_bounds (a :: "") (y :: ys)) as [H1 _].
+      simpl in H1.
+      lia.
+    }
+    simpl.
+    lia.
+  - simpl. lia.
+  - destruct (ascii_dec x y) as [Hxy|Hxy].
+    + subst y.
+      rewrite levenshtein_computed_skip_eq.
+      destruct (ascii_dec a x) as [Hax|Hax].
+      * subst a.
+        rewrite levenshtein_computed_skip_eq.
+        assert (Hrec :
+          levenshtein_computed xs ys <=
+          S (levenshtein_computed (x :: xs) ys)).
+        {
+          apply (IH (length xs + length ys)).
+          - simpl in Hm. lia.
+          - reflexivity.
+        }
+        exact Hrec.
+      * unfold levenshtein_computed.
+        cbn.
+        destruct (ascii_dec a x) as [Hcontra|Hnax].
+        { exfalso. apply Hax. exact Hcontra. }
+        remember (levenshtein_chain (a :: x :: xs) ys) as p1.
+        remember (levenshtein_chain (x :: xs) (x :: ys)) as p2.
+        remember (levenshtein_chain (x :: xs) ys) as p3.
+        destruct p1 as [n1 r1], p2 as [n2 r2], p3 as [n3 r3].
+        cbn.
+        assert (H3 :
+          levenshtein_computed xs ys <= S n3).
+        {
+          assert (Hrec :
+            levenshtein_computed xs ys <=
+            S (levenshtein_computed (x :: xs) ys)).
+          {
+            apply (IH (length xs + length ys)).
+            - simpl in Hm. lia.
+            - reflexivity.
+          }
+          rewrite Heqp3 in Hrec.
+          cbn in Hrec.
+          exact Hrec.
+        }
+        assert (H1 :
+          levenshtein_computed xs ys <= S (S n1)).
+        {
+          assert (Hxys :
+            levenshtein_computed (x :: xs) ys <= S n1).
+          {
+            apply (IH (S (length xs) + length ys)).
+            - simpl in Hm. lia.
+            - rewrite Heqp1. reflexivity.
+          }
+          assert (Hrec :
+            levenshtein_computed xs ys <=
+            S (levenshtein_computed (x :: xs) ys)).
+          {
+            apply (IH (length xs + length ys)).
+            - simpl in Hm. lia.
+            - reflexivity.
+          }
+          lia.
+        }
+        assert (H2 :
+          levenshtein_computed xs ys <= S (S n2)).
+        {
+          rewrite Heqp2.
+          cbn.
+          rewrite levenshtein_computed_skip_eq.
+          lia.
+        }
+        eapply (min3_app_cases
+          (existT (fun n : nat => chain (a :: x :: xs) (x :: ys) n) (S n1)
+                  (insert_chain x (a :: x :: xs) ys n1 r1))
+          (existT (fun n : nat => chain (a :: x :: xs) (x :: ys) n) (S n2)
+                  (delete_chain a (x :: xs) (x :: ys) n2 r2))
+          (existT (fun n : nat => chain (a :: x :: xs) (x :: ys) n) (S n3)
+                  (update_chain a x (x :: xs) ys n3 Hnax r3))
+          (fun p => projT1 p)
+          (fun p => levenshtein_computed xs ys <= S (projT1 p))).
+        -- exact H1.
+        -- exact H2.
+        -- exact H3.
+    + unfold levenshtein_computed.
+      cbn.
+      remember (levenshtein_chain (x :: xs) ys) as q1.
+      remember (levenshtein_chain xs (y :: ys)) as q2.
+      remember (levenshtein_chain xs ys) as q3.
+      destruct q1 as [l1 c1], q2 as [l2 c2], q3 as [l3 c3].
+      cbn.
+      pose proof (min3_app_pf
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                (insert_chain y (x :: xs) ys l1 c1))
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                (delete_chain x xs (y :: ys) l2 c2))
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                (update_chain x y xs ys l3 Hxy c3))
+        (fun p => projT1 p)) as [HL1 [HL2 HL3]].
+      destruct (ascii_dec a y) as [Hay|Hay].
+      * subst a.
+        rewrite levenshtein_computed_skip_eq.
+        assert (Hq1 :
+          levenshtein_computed (x :: xs) ys = l1).
+        { rewrite Heqq1. reflexivity. }
+        lia.
+      * unfold levenshtein_computed.
+        cbn.
+        destruct (ascii_dec a y) as [Hcontra|Hnay].
+        { exfalso. apply Hay. exact Hcontra. }
+        remember (levenshtein_chain (a :: x :: xs) ys) as p1.
+        remember (levenshtein_chain (x :: xs) (y :: ys)) as p2.
+        remember (levenshtein_chain (x :: xs) ys) as p3.
+        destruct p1 as [n1 r1], p2 as [n2 r2], p3 as [n3 r3].
+        cbn.
+        assert (Hc1 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                    (insert_chain y (x :: xs) ys l1 c1))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                    (delete_chain x xs (y :: ys) l2 c2))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                    (update_chain x y xs ys l3 Hxy c3))
+            (fun p => projT1 p)) <= S l1).
+        {
+          exact HL1.
+        }
+        assert (H1 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                    (insert_chain y (x :: xs) ys l1 c1))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                    (delete_chain x xs (y :: ys) l2 c2))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                    (update_chain x y xs ys l3 Hxy c3))
+            (fun p => projT1 p)) <= S (S n1)).
+        {
+          assert (Hrec :
+            levenshtein_computed (x :: xs) ys <=
+            S (levenshtein_computed (a :: x :: xs) ys)).
+          {
+            apply (IH (S (length xs) + length ys)).
+            - simpl in Hm. lia.
+            - reflexivity.
+          }
+          rewrite Heqq1 in Hc1.
+          rewrite Heqp1 in Hrec.
+          cbn in Hc1, Hrec.
+          lia.
+        }
+        assert (H2 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                    (insert_chain y (x :: xs) ys l1 c1))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                    (delete_chain x xs (y :: ys) l2 c2))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                    (update_chain x y xs ys l3 Hxy c3))
+            (fun p => projT1 p)) <= S (S n2)).
+        { lia. }
+        assert (H3 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                    (insert_chain y (x :: xs) ys l1 c1))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                    (delete_chain x xs (y :: ys) l2 c2))
+            (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                    (update_chain x y xs ys l3 Hxy c3))
+            (fun p => projT1 p)) <= S (S n3)).
+        { lia. }
+        eapply (min3_app_cases
+          (existT (fun n : nat => chain (a :: x :: xs) (y :: ys) n) (S n1)
+                  (insert_chain y (a :: x :: xs) ys n1 r1))
+          (existT (fun n : nat => chain (a :: x :: xs) (y :: ys) n) (S n2)
+                  (delete_chain a (x :: xs) (y :: ys) n2 r2))
+          (existT (fun n : nat => chain (a :: x :: xs) (y :: ys) n) (S n3)
+                  (update_chain a y (x :: xs) ys n3 Hnay r3))
+          (fun p => projT1 p)
+          (fun p =>
+             projT1 (min3_app
+               (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l1)
+                       (insert_chain y (x :: xs) ys l1 c1))
+               (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l2)
+                       (delete_chain x xs (y :: ys) l2 c2))
+               (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S l3)
+                       (update_chain x y xs ys l3 Hxy c3))
+               (fun p0 => projT1 p0))
+             <= S (projT1 p))).
+        -- exact H1.
+        -- exact H2.
+        -- exact H3.
+Qed.
+
+Lemma levenshtein_computed_sym :
+  forall s t, levenshtein_computed s t = levenshtein_computed t s.
+Proof.
+  intros s0 t0.
+  refine (
+    well_founded_induction
+      lt_wf
+      (fun m =>
+         forall s t, length s + length t = m ->
+           levenshtein_computed s t = levenshtein_computed t s)
+      _
+      (length s0 + length t0)
+      s0 t0 eq_refl).
+  intros m IH s t Hm.
+  destruct s as [|x xs], t as [|y ys].
+  - reflexivity.
+  - simpl. reflexivity.
+  - simpl. reflexivity.
+  - destruct (ascii_dec x y) as [Hxy|Hxy].
+    + subst y.
+      rewrite levenshtein_computed_skip_eq.
+      rewrite (levenshtein_computed_skip_eq x ys xs).
+      apply (IH (length xs + length ys)).
+      simpl in Hm.
+      lia.
+    + unfold levenshtein_computed.
+      cbn.
+      destruct (ascii_dec x y) as [Hcontra|Hnxy].
+      { exfalso. apply Hxy. exact Hcontra. }
+      destruct (ascii_dec y x) as [Hyx|Hnyx].
+      { exfalso. apply Hxy. symmetry. exact Hyx. }
+      remember (levenshtein_chain (x :: xs) ys) as p1.
+      remember (levenshtein_chain xs (y :: ys)) as p2.
+      remember (levenshtein_chain xs ys) as p3.
+      remember (levenshtein_chain (y :: ys) xs) as q1.
+      remember (levenshtein_chain ys (x :: xs)) as q2.
+      remember (levenshtein_chain ys xs) as q3.
+      destruct p1 as [n1 c1], p2 as [n2 c2], p3 as [n3 c3].
+      destruct q1 as [m1 c4], q2 as [m2 c5], q3 as [m3 c6].
+      cbn.
+      assert (H12 : n1 = m2).
+      {
+        assert (Hrec :
+          levenshtein_computed (x :: xs) ys =
+          levenshtein_computed ys (x :: xs)).
+        {
+          apply (IH (S (length xs) + length ys)).
+          simpl in Hm.
+          lia.
+        }
+        rewrite Heqp1 in Hrec.
+        rewrite Heqq2 in Hrec.
+        cbn in Hrec.
+        exact Hrec.
+      }
+      assert (H21 : n2 = m1).
+      {
+        assert (Hrec :
+          levenshtein_computed xs (y :: ys) =
+          levenshtein_computed (y :: ys) xs).
+        {
+          apply (IH (length xs + S (length ys))).
+          simpl in Hm.
+          lia.
+        }
+        rewrite Heqp2 in Hrec.
+        rewrite Heqq1 in Hrec.
+        cbn in Hrec.
+        exact Hrec.
+      }
+      assert (H33 : n3 = m3).
+      {
+        assert (Hrec :
+          levenshtein_computed xs ys =
+          levenshtein_computed ys xs).
+        {
+          apply (IH (length xs + length ys)).
+          simpl in Hm.
+          lia.
+        }
+        rewrite Heqp3 in Hrec.
+        rewrite Heqq3 in Hrec.
+        cbn in Hrec.
+        exact Hrec.
+      }
+      rewrite (min3_app_value
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S n1)
+                (insert_chain y (x :: xs) ys n1 c1))
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S n2)
+                (delete_chain x xs (y :: ys) n2 c2))
+        (existT (fun n : nat => chain (x :: xs) (y :: ys) n) (S n3)
+                (update_chain x y xs ys n3 Hnxy c3))
+        (fun p => projT1 p)).
+      rewrite (min3_app_value
+        (existT (fun n : nat => chain (y :: ys) (x :: xs) n) (S m1)
+                (insert_chain x (y :: ys) xs m1 c4))
+        (existT (fun n : nat => chain (y :: ys) (x :: xs) n) (S m2)
+                (delete_chain y ys (x :: xs) m2 c5))
+        (existT (fun n : nat => chain (y :: ys) (x :: xs) n) (S m3)
+                (update_chain y x ys xs m3 Hnyx c6))
+        (fun p => projT1 p)).
+      cbn.
+      rewrite <- H12, <- H21, <- H33.
+      apply min3_comm12.
+Qed.
+
+Lemma levenshtein_computed_insert_lower_r :
+  forall a s t,
+    levenshtein_computed s t <= S (levenshtein_computed s (a :: t)).
+Proof.
+  intros a s t.
+  rewrite (levenshtein_computed_sym s t).
+  rewrite (levenshtein_computed_sym s (a :: t)).
+  apply levenshtein_computed_insert_lower.
+Qed.
+
+Lemma levenshtein_computed_delete_upper :
+  forall a s t,
+    levenshtein_computed (a :: s) t <= S (levenshtein_computed s t).
+Proof.
+  intros a s t.
+  destruct t as [|b ys].
+  - simpl. lia.
+  - destruct (ascii_dec a b) as [Hab|Hab].
+    + subst b.
+      rewrite levenshtein_computed_skip_eq.
+      apply levenshtein_computed_insert_lower_r.
+    + apply levenshtein_computed_mismatch_upper_delete.
+      exact Hab.
+Qed.
+
+Lemma levenshtein_computed_update_upper :
+  forall a a' s t,
+    a' <> a ->
+    levenshtein_computed (a' :: s) t <= S (levenshtein_computed (a :: s) t).
+Proof.
+  intros a0 a'0 s0 t0 Hneq0.
+  refine (
+    well_founded_induction
+      lt_wf
+      (fun m =>
+         forall a a' s t, a' <> a ->
+           length s + length t = m ->
+           levenshtein_computed (a' :: s) t <=
+           S (levenshtein_computed (a :: s) t))
+      _
+      (length s0 + length t0)
+      a0 a'0 s0 t0 Hneq0 eq_refl).
+  intros m IH a a' s t Hneq Hm.
+  destruct t as [|b ys].
+  - simpl. lia.
+  - destruct (ascii_dec a' b) as [Ha'b|Ha'b].
+    + subst b.
+      rewrite levenshtein_computed_skip_eq.
+      unfold levenshtein_computed.
+      cbn.
+      destruct (ascii_dec a a') as [Hcontra|Hna].
+      { exfalso. apply Hneq. symmetry. exact Hcontra. }
+      remember (levenshtein_chain (a :: s) ys) as p1.
+      remember (levenshtein_chain s (a' :: ys)) as p2.
+      remember (levenshtein_chain s ys) as p3.
+      destruct p1 as [n1 r1], p2 as [n2 r2], p3 as [n3 r3].
+      cbn.
+      assert (H1 : levenshtein_computed s ys <= S (S n1)).
+      {
+        assert (Hrec : levenshtein_computed s ys <= S (levenshtein_computed (a :: s) ys)).
+        { apply levenshtein_computed_insert_lower. }
+        rewrite Heqp1 in Hrec.
+        cbn in Hrec.
+        lia.
+      }
+      assert (H2 : levenshtein_computed s ys <= S (S n2)).
+      {
+        assert (Hrec : levenshtein_computed s ys <= S (levenshtein_computed s (a' :: ys))).
+        { apply levenshtein_computed_insert_lower_r. }
+        rewrite Heqp2 in Hrec.
+        cbn in Hrec.
+        lia.
+      }
+      assert (H3 : levenshtein_computed s ys <= S (S n3)).
+      { lia. }
+      eapply (min3_app_cases
+        (existT (fun n : nat => chain (a :: s) (a' :: ys) n) (S n1)
+                (insert_chain a' (a :: s) ys n1 r1))
+        (existT (fun n : nat => chain (a :: s) (a' :: ys) n) (S n2)
+                (delete_chain a s (a' :: ys) n2 r2))
+        (existT (fun n : nat => chain (a :: s) (a' :: ys) n) (S n3)
+                (update_chain a a' s ys n3 Hna r3))
+        (fun p => projT1 p)
+        (fun p => levenshtein_computed s ys <= S (projT1 p))).
+      * exact H1.
+      * exact H2.
+      * exact H3.
+    + unfold levenshtein_computed.
+      cbn.
+      destruct (ascii_dec a' b) as [Hcontra|Hna'b].
+      { exfalso. apply Ha'b. exact Hcontra. }
+      remember (levenshtein_chain (a' :: s) ys) as q1.
+      remember (levenshtein_chain s (b :: ys)) as q2.
+      remember (levenshtein_chain s ys) as q3.
+      destruct q1 as [l1 c1], q2 as [l2 c2], q3 as [l3 c3].
+      cbn.
+      pose proof (min3_app_pf
+        (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l1)
+                (insert_chain b (a' :: s) ys l1 c1))
+        (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l2)
+                (delete_chain a' s (b :: ys) l2 c2))
+        (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l3)
+                (update_chain a' b s ys l3 Hna'b c3))
+        (fun p => projT1 p)) as [HL1 [HL2 HL3]].
+      destruct (ascii_dec a b) as [Hab|Hab].
+      * subst b.
+        rewrite levenshtein_computed_skip_eq.
+        assert (Hq3 : levenshtein_computed s ys = l3).
+        { rewrite Heqq3. reflexivity. }
+        lia.
+      * unfold levenshtein_computed.
+        cbn.
+        destruct (ascii_dec a b) as [Hcontra2|Hnab].
+        { exfalso. apply Hab. exact Hcontra2. }
+        remember (levenshtein_chain (a :: s) ys) as p1.
+        remember (levenshtein_chain s (b :: ys)) as p2.
+        remember (levenshtein_chain s ys) as p3.
+        destruct p1 as [n1 r1], p2 as [n2 r2], p3 as [n3 r3].
+        cbn.
+        assert (H1 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l1)
+                    (insert_chain b (a' :: s) ys l1 c1))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l2)
+                    (delete_chain a' s (b :: ys) l2 c2))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l3)
+                    (update_chain a' b s ys l3 Hna'b c3))
+            (fun p => projT1 p)) <= S (S n1)).
+        {
+          assert (Hrec :
+            levenshtein_computed (a' :: s) ys <=
+            S (levenshtein_computed (a :: s) ys)).
+          {
+            apply (IH (length s + length ys)).
+            - simpl in Hm. lia.
+            - exact Hneq.
+            - reflexivity.
+          }
+          rewrite Heqq1 in HL1.
+          rewrite Heqp1 in Hrec.
+          cbn in HL1, Hrec.
+          lia.
+        }
+        assert (H2 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l1)
+                    (insert_chain b (a' :: s) ys l1 c1))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l2)
+                    (delete_chain a' s (b :: ys) l2 c2))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l3)
+                    (update_chain a' b s ys l3 Hna'b c3))
+            (fun p => projT1 p)) <= S (S n2)).
+        { lia. }
+        assert (H3 :
+          projT1 (min3_app
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l1)
+                    (insert_chain b (a' :: s) ys l1 c1))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l2)
+                    (delete_chain a' s (b :: ys) l2 c2))
+            (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l3)
+                    (update_chain a' b s ys l3 Hna'b c3))
+            (fun p => projT1 p)) <= S (S n3)).
+        { lia. }
+        eapply (min3_app_cases
+          (existT (fun n : nat => chain (a :: s) (b :: ys) n) (S n1)
+                  (insert_chain b (a :: s) ys n1 r1))
+          (existT (fun n : nat => chain (a :: s) (b :: ys) n) (S n2)
+                  (delete_chain a s (b :: ys) n2 r2))
+          (existT (fun n : nat => chain (a :: s) (b :: ys) n) (S n3)
+                  (update_chain a b s ys n3 Hnab r3))
+          (fun p => projT1 p)
+          (fun p =>
+             projT1 (min3_app
+               (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l1)
+                       (insert_chain b (a' :: s) ys l1 c1))
+               (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l2)
+                       (delete_chain a' s (b :: ys) l2 c2))
+               (existT (fun n : nat => chain (a' :: s) (b :: ys) n) (S l3)
+                       (update_chain a' b s ys l3 Hna'b c3))
+               (fun p0 => projT1 p0))
+             <= S (projT1 p))).
+        -- exact H1.
+        -- exact H2.
+        -- exact H3.
+Qed.
+
+Theorem levenshtein_computed_is_minimal :
+  forall s t n (c : chain s t n),
+    levenshtein_computed s t <= n.
+Proof.
+  intros s t n c.
+  induction c.
+  - reflexivity.
+  - rewrite levenshtein_computed_skip_eq.
+    exact IHc.
+  - destruct e.
+    + eapply Nat.le_trans.
+      * apply levenshtein_computed_insert_lower.
+      * lia.
+    + eapply Nat.le_trans.
+      * apply levenshtein_computed_delete_upper.
+      * lia.
+    + eapply Nat.le_trans.
+      * apply levenshtein_computed_update_upper.
+        exact neq.
+      * lia.
+Qed.
+
+Theorem levenshtein_eq_computed : forall s t, levenshtein s t = projT1 (levenshtein_chain s t).
+Proof.
+  intros s t.
+  reflexivity.
+Qed.
+
 Theorem levensthein_is_minimal (s t : string) :
   forall (n : nat) (c : chain s t n), levenshtein s t <= n.
 Proof.
   intros n c.
-  apply (levenshtein_is_least s t n).
-  exists c.
-  exact I.
+  unfold levenshtein.
+  apply (levenshtein_computed_is_minimal s t n c).
 Qed.
 
 (* Eval compute in (levenshtein_chain "pascal" "haskell"). *)
 
 Require Crane.Extraction.
 Crane Extraction "levenshtein" levenshtein_chain.
-


### PR DESCRIPTION
## Summary
- prove computed minimality:
  `forall (n : nat) (c : chain s t n), projT1 (levenshtein_chain s t) <= n`
- add bridge theorem:
  `levenshtein s t = projT1 (levenshtein_chain s t)`
- make `levenshtein` constructive by defining it as the computed value
- remove classical dependencies from this file

## Motivation
This closes the remaining proof gap in WIP Levenshtein correctness by connecting the specification-facing `levenshtein` value to the computed chain output and proving computed minimality directly.

## Validation
- `coqc tests/wip/levenshtein/Levenshtein.v`
- `dune build tests/wip/levenshtein/levenshtein.t.exe`

## Notes
- theorem name remains `levensthein_is_minimal` (existing spelling)