### PR TITLE
feat: extract all-nullary inductives as enum class

### DIFF
--- a/src/minicpp.ml
+++ b/src/minicpp.ml
@@ -41,6 +41,7 @@ and cpp_stmt =
   | Sexpr of cpp_expr
   | Scustom_case of cpp_type * cpp_expr * cpp_type list * ((Id.t * cpp_type) list * cpp_type * cpp_stmt list) list * string
   | Sthrow of string  (* throw statement for unreachable/absurd cases *)
+  | Sswitch of cpp_expr * GlobRef.t * (Id.t * cpp_stmt list) list  (* switch on enum: scrutinee, enum type, branches *)
 
 (* add something for (mutual) fixpoints? *)
 and cpp_expr =
@@ -77,6 +78,7 @@ and cpp_expr =
   | CPPqualified of cpp_expr * Id.t  (* expr::id - for qualified name access like Type::ctor *)
   | CPPconvertible_to of cpp_type  (* std::convertible_to<T> constraint *)
   | CPPabort of string  (* unreachable code / absurd case - calls std::abort() *)
+  | CPPenum_val of GlobRef.t * Id.t  (* enum class value: EnumType::Constructor *)
 
 and cpp_constraint = cpp_expr
 
@@ -122,3 +124,4 @@ type cpp_decl =
   | Ddecl of GlobRef.t * cpp_type
   | Dconcept of GlobRef.t * cpp_expr (* template params are provided by an outer Dtemplate *)
   | Dstatic_assert of cpp_expr * string option
+  | Denum of GlobRef.t * Id.t list  (* enum class declaration: name, constructors *)

--- a/src/minicpp.mli
+++ b/src/minicpp.mli
@@ -41,6 +41,7 @@ and cpp_stmt =
   | Sexpr of cpp_expr
   | Scustom_case of cpp_type * cpp_expr * cpp_type list * ((Id.t * cpp_type) list * cpp_type * cpp_stmt list) list * string
   | Sthrow of string  (* throw statement for unreachable/absurd cases *)
+  | Sswitch of cpp_expr * GlobRef.t * (Id.t * cpp_stmt list) list  (* switch on enum: scrutinee, enum type, branches *)
 
 (* add something for (mutual) fixpoints? *)
 and cpp_expr =
@@ -77,6 +78,7 @@ and cpp_expr =
   | CPPqualified of cpp_expr * Id.t  (* expr::id - for qualified name access like Type::ctor *)
   | CPPconvertible_to of cpp_type  (* std::convertible_to<T> constraint *)
   | CPPabort of string  (* unreachable code / absurd case - calls std::abort() *)
+  | CPPenum_val of GlobRef.t * Id.t  (* enum class value: EnumType::Constructor *)
 
 and cpp_constraint = cpp_expr
 
@@ -122,3 +124,4 @@ type cpp_decl =
   | Ddecl of GlobRef.t * cpp_type
   | Dconcept of GlobRef.t * cpp_expr (* template params are provided by an outer Dtemplate *)
   | Dstatic_assert of cpp_expr * string option
+  | Denum of GlobRef.t * Id.t list  (* enum class declaration: name, constructors *)

--- a/src/table.ml
+++ b/src/table.ml
@@ -238,6 +238,13 @@ let rec is_typeclass_type_cpp = function
   | Minicpp.Tshared_ptr t -> is_typeclass_type_cpp t (* Unwrap shared_ptr *)
   | _ -> false
 
+(*s Enum inductives table. *)
+
+let enum_inductives = ref Refset'.empty
+let init_enum_inductives () = enum_inductives := Refset'.empty
+let add_enum_inductive r = enum_inductives := Refset'.add r !enum_inductives
+let is_enum_inductive r = Refset'.mem r !enum_inductives
+
 (*s Recursors table. *)
 
 (* NB: here we can use the equivalence between canonical
@@ -1296,6 +1303,6 @@ let extract_skip_or_module q =
 
 let reset_tables () =
   init_typedefs (); init_cst_types (); init_inductives ();
-  init_inductive_kinds (); init_recursors ();
+  init_inductive_kinds (); init_enum_inductives (); init_recursors ();
   init_projs (); init_axioms (); init_opaques (); reset_modfile ();
   init_glob_tys ()

--- a/src/table.mli
+++ b/src/table.mli
@@ -97,6 +97,9 @@ val is_typeclass : GlobRef.t -> bool
 val is_typeclass_type : ml_type -> bool
 val is_typeclass_type_cpp : Minicpp.cpp_type -> bool
 
+val add_enum_inductive : GlobRef.t -> unit
+val is_enum_inductive : GlobRef.t -> bool
+
 val add_recursors : Environ.env -> MutInd.t -> unit
 val is_recursor : GlobRef.t -> bool
 

--- a/src/translation.mli
+++ b/src/translation.mli
@@ -87,7 +87,7 @@ val gen_ind_header : variable list -> GlobRef.t -> GlobRef.t array -> ml_type li
     @param cnames Constructor references
     @param tys Constructor argument types
     @param method_candidates Functions to generate as methods: (func_ref, body, type, this_position) *)
-val gen_ind_header_v2 : variable list -> GlobRef.t -> GlobRef.t array -> ml_type list array -> (GlobRef.t * ml_ast * ml_type * int) list -> inductive_kind -> cpp_decl
+val gen_ind_header_v2 : ?is_mutual:bool -> variable list -> GlobRef.t -> GlobRef.t array -> ml_type list array -> (GlobRef.t * ml_ast * ml_type * int) list -> inductive_kind -> cpp_decl
 
 (** Generate methods for eponymous records.
     For records merged into module structs, this generates instance methods from functions

--- a/tests/regression/comparison/comparison.h
+++ b/tests/regression/comparison/comparison.h
@@ -18,59 +18,45 @@ template <class... Ts> struct Overloaded : Ts... {
 template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 
 struct Comparison {
-  struct cmp {
-  public:
-    struct CmpLt {};
-    struct CmpEq {};
-    struct CmpGt {};
-    using variant_t = std::variant<CmpLt, CmpEq, CmpGt>;
-
-  private:
-    variant_t v_;
-    explicit cmp(CmpLt _v) : v_(std::move(_v)) {}
-    explicit cmp(CmpEq _v) : v_(std::move(_v)) {}
-    explicit cmp(CmpGt _v) : v_(std::move(_v)) {}
-
-  public:
-    struct ctor {
-      ctor() = delete;
-      static std::shared_ptr<cmp> CmpLt_() {
-        return std::shared_ptr<cmp>(new cmp(CmpLt{}));
-      }
-      static std::shared_ptr<cmp> CmpEq_() {
-        return std::shared_ptr<cmp>(new cmp(CmpEq{}));
-      }
-      static std::shared_ptr<cmp> CmpGt_() {
-        return std::shared_ptr<cmp>(new cmp(CmpGt{}));
-      }
-    };
-    const variant_t &v() const { return v_; }
-  };
+  enum class cmp { CmpLt, CmpEq, CmpGt };
 
   template <typename T1>
-  static T1 cmp_rect(const T1 f, const T1 f0, const T1 f1,
-                     const std::shared_ptr<cmp> &c) {
-    return std::visit(
-        Overloaded{[&](const typename cmp::CmpLt _args) -> T1 { return f; },
-                   [&](const typename cmp::CmpEq _args) -> T1 { return f0; },
-                   [&](const typename cmp::CmpGt _args) -> T1 { return f1; }},
-        c->v());
+  static T1 cmp_rect(const T1 f, const T1 f0, const T1 f1, const cmp c) {
+    return [&](void) {
+      switch (c) {
+      case cmp::CmpLt: {
+        return f;
+      }
+      case cmp::CmpEq: {
+        return f0;
+      }
+      case cmp::CmpGt: {
+        return f1;
+      }
+      }
+    }();
   }
 
   template <typename T1>
-  static T1 cmp_rec(const T1 f, const T1 f0, const T1 f1,
-                    const std::shared_ptr<cmp> &c) {
-    return std::visit(
-        Overloaded{[&](const typename cmp::CmpLt _args) -> T1 { return f; },
-                   [&](const typename cmp::CmpEq _args) -> T1 { return f0; },
-                   [&](const typename cmp::CmpGt _args) -> T1 { return f1; }},
-        c->v());
+  static T1 cmp_rec(const T1 f, const T1 f0, const T1 f1, const cmp c) {
+    return [&](void) {
+      switch (c) {
+      case cmp::CmpLt: {
+        return f;
+      }
+      case cmp::CmpEq: {
+        return f0;
+      }
+      case cmp::CmpGt: {
+        return f1;
+      }
+      }
+    }();
   }
 
-  static unsigned int cmp_to_nat(const std::shared_ptr<cmp> &c);
+  static unsigned int cmp_to_nat(const cmp c);
 
-  static std::shared_ptr<cmp> compare_nats(const unsigned int a,
-                                           const unsigned int b);
+  static cmp compare_nats(const unsigned int a, const unsigned int b);
 
   static unsigned int max_nat(const unsigned int a, const unsigned int b);
 
@@ -79,25 +65,19 @@ struct Comparison {
   static unsigned int clamp(const unsigned int val0, const unsigned int lo,
                             const unsigned int hi);
 
-  static std::shared_ptr<cmp> flip_cmp(const std::shared_ptr<cmp> &c);
+  static cmp flip_cmp(const cmp c);
 
-  static inline const unsigned int test_lt_nat =
-      cmp_to_nat(cmp::ctor::CmpLt_());
+  static inline const unsigned int test_lt_nat = cmp_to_nat(cmp::CmpLt);
 
-  static inline const unsigned int test_eq_nat =
-      cmp_to_nat(cmp::ctor::CmpEq_());
+  static inline const unsigned int test_eq_nat = cmp_to_nat(cmp::CmpEq);
 
-  static inline const unsigned int test_gt_nat =
-      cmp_to_nat(cmp::ctor::CmpGt_());
+  static inline const unsigned int test_gt_nat = cmp_to_nat(cmp::CmpGt);
 
-  static inline const std::shared_ptr<cmp> test_compare_lt =
-      compare_nats(3u, 5u);
+  static inline const cmp test_compare_lt = compare_nats(3u, 5u);
 
-  static inline const std::shared_ptr<cmp> test_compare_eq =
-      compare_nats(5u, 5u);
+  static inline const cmp test_compare_eq = compare_nats(5u, 5u);
 
-  static inline const std::shared_ptr<cmp> test_compare_gt =
-      compare_nats(7u, 5u);
+  static inline const cmp test_compare_gt = compare_nats(7u, 5u);
 
   static inline const unsigned int test_max = max_nat(3u, 7u);
 
@@ -109,6 +89,5 @@ struct Comparison {
 
   static inline const unsigned int test_clamp_hi = clamp(9u, 3u, 7u);
 
-  static inline const std::shared_ptr<cmp> test_flip =
-      flip_cmp(cmp::ctor::CmpLt_());
+  static inline const cmp test_flip = flip_cmp(cmp::CmpLt);
 };

--- a/tests/regression/comparison/comparison.t.cpp
+++ b/tests/regression/comparison/comparison.t.cpp
@@ -35,10 +35,10 @@ int main() {
     ASSERT(Comparison::test_eq_nat == 1u);
     ASSERT(Comparison::test_gt_nat == 2u);
 
-    // Test compare_nats returns correct cmp variant
-    ASSERT(std::holds_alternative<Comparison::cmp::CmpLt>(Comparison::test_compare_lt->v()));
-    ASSERT(std::holds_alternative<Comparison::cmp::CmpEq>(Comparison::test_compare_eq->v()));
-    ASSERT(std::holds_alternative<Comparison::cmp::CmpGt>(Comparison::test_compare_gt->v()));
+    // Test compare_nats returns correct cmp value
+    ASSERT(Comparison::test_compare_lt == Comparison::cmp::CmpLt);
+    ASSERT(Comparison::test_compare_eq == Comparison::cmp::CmpEq);
+    ASSERT(Comparison::test_compare_gt == Comparison::cmp::CmpGt);
 
     // Test max/min
     ASSERT(Comparison::test_max == 7u);
@@ -50,7 +50,7 @@ int main() {
     ASSERT(Comparison::test_clamp_hi == 7u);   // 9 clamped to 7
 
     // Test flip
-    ASSERT(std::holds_alternative<Comparison::cmp::CmpGt>(Comparison::test_flip->v()));
+    ASSERT(Comparison::test_flip == Comparison::cmp::CmpGt);
 
     return testStatus;
 }

--- a/tests/regression/unit_type/unit_type.cpp
+++ b/tests/regression/unit_type/unit_type.cpp
@@ -10,23 +10,18 @@
 #include <utility>
 #include <variant>
 
-std::shared_ptr<Unit::unit> UnitType::return_unit(const unsigned int _x) {
-  return Unit::unit::ctor::tt_();
+unit UnitType::return_unit(const unsigned int _x) { return unit::tt; }
+
+unsigned int UnitType::take_unit(const unit _x) { return 5u; }
+
+unsigned int UnitType::match_unit(const unit u) {
+  return [&](void) {
+    switch (u) {
+    case unit::tt: {
+      return 7u;
+    }
+    }
+  }();
 }
 
-unsigned int UnitType::take_unit(const std::shared_ptr<Unit::unit> &_x) {
-  return 5u;
-}
-
-unsigned int UnitType::match_unit(const std::shared_ptr<Unit::unit> &u) {
-  return std::visit(
-      Overloaded{[](const typename Unit::unit::tt _args) -> unsigned int {
-        return 7u;
-      }},
-      u->v());
-}
-
-std::shared_ptr<Unit::unit>
-UnitType::unit_to_unit(const std::shared_ptr<Unit::unit> &u) {
-  return u;
-}
+unit UnitType::unit_to_unit(const unit u) { return u; }

--- a/tests/regression/unit_type/unit_type.h
+++ b/tests/regression/unit_type/unit_type.h
@@ -17,36 +17,16 @@ template <class... Ts> struct Overloaded : Ts... {
 };
 template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 
-struct Unit {
-  struct unit {
-  public:
-    struct tt {};
-    using variant_t = std::variant<tt>;
-
-  private:
-    variant_t v_;
-    explicit unit(tt _v) : v_(std::move(_v)) {}
-
-  public:
-    struct ctor {
-      ctor() = delete;
-      static std::shared_ptr<Unit::unit> tt_() {
-        return std::shared_ptr<Unit::unit>(new Unit::unit(tt{}));
-      }
-    };
-    const variant_t &v() const { return v_; }
-  };
-};
+enum class unit { tt };
 
 struct UnitType {
-  static inline const std::shared_ptr<Unit::unit> unit_val =
-      Unit::unit::ctor::tt_();
+  static inline const unit unit_val = unit::tt;
 
-  static std::shared_ptr<Unit::unit> return_unit(const unsigned int _x);
+  static unit return_unit(const unsigned int _x);
 
-  static unsigned int take_unit(const std::shared_ptr<Unit::unit> &_x);
+  static unsigned int take_unit(const unit _x);
 
-  static unsigned int match_unit(const std::shared_ptr<Unit::unit> &u);
+  static unsigned int match_unit(const unit u);
 
   template <typename A, typename B> struct pair {
   public:
@@ -92,36 +72,24 @@ struct UnitType {
         p->v());
   }
 
-  static inline const std::shared_ptr<
-      pair<unsigned int, std::shared_ptr<Unit::unit>>>
-      pair_with_unit =
-          pair<unsigned int, std::shared_ptr<Unit::unit>>::ctor::Pair_(
-              3u, Unit::unit::ctor::tt_());
+  static inline const std::shared_ptr<pair<unsigned int, unit>> pair_with_unit =
+      pair<unsigned int, unit>::ctor::Pair_(3u, unit::tt);
 
-  static inline const std::shared_ptr<
-      pair<std::shared_ptr<Unit::unit>, std::shared_ptr<Unit::unit>>>
-      unit_pair =
-          pair<std::shared_ptr<Unit::unit>, std::shared_ptr<Unit::unit>>::ctor::
-              Pair_(Unit::unit::ctor::tt_(), Unit::unit::ctor::tt_());
+  static inline const std::shared_ptr<pair<unit, unit>> unit_pair =
+      pair<unit, unit>::ctor::Pair_(unit::tt, unit::tt);
 
-  static std::shared_ptr<Unit::unit>
-  unit_to_unit(const std::shared_ptr<Unit::unit> &u);
+  static unit unit_to_unit(const unit u);
 
   template <typename T1, typename T2> static T2 seq(const T1 _x, const T2 b) {
     return b;
   }
 
   static inline const unsigned int sequenced =
-      seq<std::shared_ptr<Unit::unit>, unsigned int>(
-          Unit::unit::ctor::tt_(),
-          seq<std::shared_ptr<Unit::unit>, unsigned int>(
-              Unit::unit::ctor::tt_(), 5u));
+      seq<unit, unsigned int>(unit::tt, seq<unit, unsigned int>(unit::tt, 5u));
 
-  static inline const unsigned int test_take =
-      take_unit(Unit::unit::ctor::tt_());
+  static inline const unsigned int test_take = take_unit(unit::tt);
 
-  static inline const unsigned int test_match =
-      match_unit(Unit::unit::ctor::tt_());
+  static inline const unsigned int test_match = match_unit(unit::tt);
 
   static inline const unsigned int test_seq = sequenced;
 };


### PR DESCRIPTION
## Summary
- All-nullary, non-parameterized, non-mutual inductives now extract to C++ `enum class` with `switch`-based pattern matching instead of `std::variant` structs with `std::visit` + overloaded lambdas
- Adds three new AST nodes: `Denum`, `CPPenum_val`, `Sswitch`
- Enum registry (`add_enum_inductive`/`is_enum_inductive`) pre-scans the structure so both `.h` and `.cpp` generation see the registration
- Enum types produce bare value semantics (no `std::shared_ptr` wrapping)
- `Crane Extraction <global>` now prints both `.cpp` and `.h` output in the response window
- Routes `simple_extraction` through `print_structure_to_file` instead of `print_one_decl`

### Before
```cpp
struct Cmp {
  struct cmp {
    struct CmpLt { ... };
    struct CmpEq { ... };
    struct CmpGt { ... };
    using variant_t = std::variant<CmpLt, CmpEq, CmpGt>;
    // ... factory methods, v() accessor
  };
};
// match via std::visit + Overloaded lambdas
```

### After
```cpp
enum class cmp { CmpLt, CmpEq, CmpGt };
// match via switch (x) { case cmp::CmpLt: ... }
```

Fixes https://github.com/bloomberg/crane/issues/3

## Test plan
- [x] All 18 regression tests compile and run
- [x] All basics tests compile and run (only `nat_bde`/`top_bde` fail due to missing BDE — pre-existing)
- [x] `comparison` test exercises enum extraction end-to-end (`cmp` type)
- [x] `unit_type` test exercises single-constructor enum (`unit`)
- [x] `bool` is custom-extracted and unaffected
- [x] Parametric, mutual, and non-nullary inductives are unaffected