### PR TITLE
fix: remove spurious type_subst_list in gen_cpp_pat_lambda

### DIFF
--- a/src/translation.ml
+++ b/src/translation.ml
@@ -630,32 +630,10 @@ and gen_cpp_pat_lambda env (typ : ml_type) rty cname ids dummies body =
     | GlobRef.ConstructRef _ -> Id.of_string (Common.pp_global_name Type cname)
     | _ -> Id.of_string "unknown_ctor"
   in
-  (* Get type arguments from scrutinee to substitute in branch types *)
-  let type_args = match typ with
-    | Tglob (_, tys, _) -> tys
-    | _ -> []
-  in
-  (* Substitute type variables in return type and argument types *)
-  let rty = if type_args <> [] then
-    (try type_subst_list type_args rty with _ -> rty)
-    else rty
-  in
-  let ids = List.map (fun (id, ty) ->
-    let ty = if type_args <> [] then
-      (try type_subst_list type_args ty with _ -> ty)
-      else ty
-    in
-    (id, ty)) ids
-  in
   (* Build path: typename InductiveType<temps>::ConstructorName *)
   let constr = match typ with
   | Tglob (r, tys, _) ->
-    (* Simplify ML types first, then substitute type variables, then convert to C++ *)
     let tys = List.map type_simpl tys in
-    let tys = if type_args <> [] then
-      List.map (fun ty -> try type_subst_list type_args ty with _ -> ty) tys
-      else tys
-    in
     (* Filter out index type args - only keep parameters *)
     let tys = match r with
       | GlobRef.IndRef (kn, _) ->


### PR DESCRIPTION
## Summary
- Removes three `type_subst_list` calls in `gen_cpp_pat_lambda` that substituted the inductive's concrete type arguments into branch types already expressed in the function's type variable space
- This caused double substitution, breaking `get_elems` (`list<pair<T1,T1>>` became `list<pair<pair<T1,T1>,pair<T1,T1>>>`) and `fold_right` (return type `T1` became `T2`)
- MiniML extraction already gives branch types fully instantiated in the function's Tvar numbering — no rewriting needed
- The topological sort test in `top.t.cpp` was commented out because of this bug; it now compiles and runs correctly

## Test plan
- [x] All basics tests pass (including `top` with previously-broken topsort code)
- [x] All regression tests pass
- [x] Topological sort produces correct output: `[[3]; [2]; [1]]` for DAG `1->2, 1->3, 2->3`