### PR TITLE
Add wip test for canonical structures extraction

### DIFF
--- a/tests/wip/canon_struct/CanonStruct.v
+++ b/tests/wip/canon_struct/CanonStruct.v
@@ -1,0 +1,22 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: canonical structures — instance resolution via unification. *)
+
+From Stdlib Require Import Nat Bool.
+
+Record EqType := mkEqType {
+  carrier : Type;
+  eqb : carrier -> carrier -> bool
+}.
+
+Canonical nat_eqType := mkEqType nat Nat.eqb.
+Canonical bool_eqType := mkEqType bool Bool.eqb.
+
+Definition same {E : EqType} (x y : carrier E) : bool := eqb E x y.
+
+Definition test_nat : bool := same 3 5.
+Definition test_bool : bool := same true false.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "canon_struct" same test_nat test_bool.

--- a/tests/wip/canon_struct/canon_struct.cpp
+++ b/tests/wip/canon_struct/canon_struct.cpp
@@ -1,0 +1,28 @@
+#include <algorithm>
+#include <any>
+#include <canon_struct.h>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+bool eqb(const bool b1, const bool b2) {
+  if (b1) {
+    if (b2) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    if (b2) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/tests/wip/canon_struct/canon_struct.h
+++ b/tests/wip/canon_struct/canon_struct.h
@@ -1,0 +1,64 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+bool eqb(const bool b1, const bool b2);
+
+struct EqType {
+  struct eqType {
+  public:
+    struct mkEqType {
+      std::function<bool(std::any, std::any)> _a0;
+    };
+    using variant_t = std::variant<mkEqType>;
+
+  private:
+    variant_t v_;
+    explicit eqType(mkEqType _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<EqType::eqType>
+      mkEqType_(std::function<bool(std::any, std::any)> a0) {
+        return std::shared_ptr<EqType::eqType>(
+            new EqType::eqType(mkEqType{a0}));
+      }
+      static std::unique_ptr<EqType::eqType>
+      mkEqType_uptr(std::function<bool(std::any, std::any)> a0) {
+        return std::unique_ptr<EqType::eqType>(
+            new EqType::eqType(mkEqType{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+using carrier = std::any;
+
+const std::shared_ptr<EqType::eqType> nat_eqType =
+    [](const unsigned int _x0, const unsigned int _x1) { return (_x0 == _x1); };
+
+const std::shared_ptr<EqType::eqType> bool_eqType = eqb;
+
+const bool test_nat =
+    nat_eqType->same((((0 + 1) + 1) + 1), (((((0 + 1) + 1) + 1) + 1) + 1));
+
+const bool test_bool = bool_eqType->same(true, false);

--- a/tests/wip/canon_struct/canon_struct.t.cpp
+++ b/tests/wip/canon_struct/canon_struct.t.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "canon_struct.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+  // Test 1: test_nat — same 3 5 = false
+  {
+    ASSERT(test_nat == false);
+    std::cout << "Test 1 (test_nat): PASSED" << std::endl;
+  }
+
+  // Test 2: test_bool — same true false = false
+  {
+    ASSERT(test_bool == false);
+    std::cout << "Test 2 (test_bool): PASSED" << std::endl;
+  }
+
+  if (testStatus == 0) {
+    std::cout << "\nAll canonical structure tests passed!" << std::endl;
+  } else {
+    std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+  }
+  return testStatus;
+}

--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -77,6 +77,16 @@
   (deps prim_proj.t.exe)
   (action (run ./prim_proj.t.exe))))
 
+(subdir canon_struct
+ (rule
+  (targets canon_struct.t.exe)
+  (deps CanonStruct.vo canon_struct.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} canon_struct.t.exe canon_struct.cpp canon_struct.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps canon_struct.t.exe)
+  (action (run ./canon_struct.t.exe))))
 (subdir nested_mod
  (rule
   (targets nested_mod.t.exe)


### PR DESCRIPTION
## Summary

Adds `tests/wip/canon_struct/` testing canonical structure instance resolution —
a different mechanism from typeclasses, resolved via unification rather than
instance search.

## What's tested

`CanonStruct.v` defines an `EqType` record with `Canonical` instances for `nat`
and `bool`, plus a generic `same` function dispatched through canonical resolution.

Extraction targets: `same`, `test_nat`, `test_bool`.

## Current extraction issues

Multiple bugs in generated C++:

1. `nat_eqType` assigned a raw lambda instead of `EqType::eqType::ctor::mkEqType_(...)`
2. `bool_eqType` assigned bare `eqb` — same type mismatch
3. `test_nat`/`test_bool` call `->same(...)` but `eqType` has no `same` method
4. `carrier` erased to `std::any` instead of the resolved concrete type
5. `same` function itself missing from generated files

## Verification

WSL Ubuntu, opam switch `default`, Rocq 9.0.0:

```
dune build tests/wip/canon_struct/CanonStruct.vo   # compiles clean
```

C++ does not compile due to the above issues.

## Files

- `tests/wip/canon_struct/CanonStruct.v` — new
- `tests/wip/canon_struct/canon_struct.t.cpp` — new
- `tests/wip/canon_struct/canon_struct.h` — Crane-generated
- `tests/wip/canon_struct/canon_struct.cpp` — Crane-generated
- `tests/wip/dune` — added `canon_struct` stanza, no existing tests changed