### PR TITLE
Add wip test for Program Fixpoint extraction

### DIFF
--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -66,6 +66,17 @@
   (deps msort.t.exe)
   (action (run ./msort.t.exe))))
 
+(subdir program_fixpoint
+ (rule
+  (targets program_fixpoint.t.exe)
+  (deps ProgFix.vo program_fixpoint.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} program_fixpoint.t.exe program_fixpoint.cpp program_fixpoint.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps program_fixpoint.t.exe)
+  (action (run ./program_fixpoint.t.exe))))
+
 (subdir prim_proj
  (rule
   (targets prim_proj.t.exe)

--- a/tests/wip/program_fixpoint/ProgFix.v
+++ b/tests/wip/program_fixpoint/ProgFix.v
@@ -1,0 +1,21 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Program Fixpoint with measure — Fix_F_sub/Acc wrapper terms. *)
+
+From Stdlib Require Import Arith List Lia.
+From Stdlib Require Import Program.Wf.
+Import ListNotations.
+
+Program Fixpoint interleave (l1 l2 : list nat) {measure (length l1 + length l2)} : list nat :=
+  match l1 with
+  | [] => l2
+  | x :: xs => x :: interleave l2 xs
+  end.
+Next Obligation. simpl. lia. Qed.
+
+Definition test_interleave : list nat :=
+  interleave [1; 3; 5] [2; 4; 6].
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "program_fixpoint" interleave test_interleave.

--- a/tests/wip/program_fixpoint/program_fixpoint.cpp
+++ b/tests/wip/program_fixpoint/program_fixpoint.cpp
@@ -1,0 +1,84 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <program_fixpoint.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+std::shared_ptr<List::list<unsigned int>> interleave_func(
+    const std::shared_ptr<SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                                     std::shared_ptr<List::list<unsigned int>>>>
+        &_x0) {
+  return [&](const T1 _x0) {
+    return Fix_sub<
+        std::shared_ptr<SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                                   std::shared_ptr<List::list<unsigned int>>>>>(
+        [&](std::shared_ptr<
+                SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                           std::shared_ptr<List::list<unsigned int>>>>
+                recarg,
+            std::function<std::shared_ptr<List::list<unsigned int>>(
+                std::shared_ptr<Sig0::sig0<std::shared_ptr<
+                    SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                               std::shared_ptr<List::list<unsigned int>>>>>>)>
+                interleave_) {
+          std::shared_ptr<List::list<unsigned int>> l1 = recarg->projT1();
+          std::shared_ptr<List::list<unsigned int>> l2 = recarg->projT2();
+          std::function<std::shared_ptr<List::list<unsigned int>>(
+              std::shared_ptr<List::list<unsigned int>>,
+              std::shared_ptr<List::list<unsigned int>>)>
+              interleave = [&](std::shared_ptr<List::list<unsigned int>> l3,
+                               std::shared_ptr<List::list<unsigned int>> l4) {
+                return interleave_(
+                    SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                               std::shared_ptr<List::list<unsigned int>>>::
+                        ctor::existT_(l3, l4));
+              };
+          return [&](void) {
+            if (std::move(l1).use_count() == 1 &&
+                std::move(l1)->v().index() == 1) {
+              auto &_rf = std::get<1>(std::move(l1)->v_mut());
+              std::shared_ptr<List::list<unsigned int>> xs = std::move(_rf._a0);
+              unsigned int x = std::move(_rf._a1);
+              _rf._a0 = std::move(x);
+              _rf._a1 = std::move(interleave0)(l2, xs);
+              return std::move(l1);
+            } else {
+              return std::visit(
+                  Overloaded{
+                      [&](const typename List::list<unsigned int>::nil _args)
+                          -> std::function<std::shared_ptr<
+                              List::list<unsigned int>>(dummy_prop)> {
+                        return std::move(l2);
+                      },
+                      [&](const typename List::list<unsigned int>::cons _args)
+                          -> std::function<std::shared_ptr<
+                              List::list<unsigned int>>(dummy_prop)> {
+                        unsigned int x = _args._a0;
+                        std::shared_ptr<List::list<unsigned int>> xs =
+                            _args._a1;
+                        return List::list<unsigned int>::ctor::cons_(
+                            std::move(x),
+                            interleave0(std::move(l2), std::move(xs)));
+                      }},
+                  std::move(l1)->v());
+            }
+          }();
+        },
+        _x0);
+  }(_x0);
+}
+
+std::shared_ptr<List::list<unsigned int>>
+interleave(std::shared_ptr<List::list<unsigned int>> l1,
+           std::shared_ptr<List::list<unsigned int>> l2) {
+  return interleave_func(SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                                    std::shared_ptr<List::list<unsigned int>>>::
+                             ctor::existT_(std::move(l1), std::move(l2)));
+}

--- a/tests/wip/program_fixpoint/program_fixpoint.h
+++ b/tests/wip/program_fixpoint/program_fixpoint.h
@@ -1,0 +1,165 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct List {
+  template <typename A> struct list {
+  public:
+    struct nil {};
+    struct cons {
+      A _a0;
+      std::shared_ptr<List::list<A>> _a1;
+    };
+    using variant_t = std::variant<nil, cons>;
+
+  private:
+    variant_t v_;
+    explicit list(nil _v) : v_(std::move(_v)) {}
+    explicit list(cons _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<List::list<A>> nil_() {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::shared_ptr<List::list<A>>
+      cons_(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+      static std::unique_ptr<List::list<A>> nil_uptr() {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::unique_ptr<List::list<A>>
+      cons_uptr(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+struct Sig0 {
+  template <typename A> struct sig0 {
+  public:
+    struct exist {
+      A _a0;
+    };
+    using variant_t = std::variant<exist>;
+
+  private:
+    variant_t v_;
+    explicit sig0(exist _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Sig0::sig0<A>> exist_(A a0) {
+        return std::shared_ptr<Sig0::sig0<A>>(new Sig0::sig0<A>(exist{a0}));
+      }
+      static std::unique_ptr<Sig0::sig0<A>> exist_uptr(A a0) {
+        return std::unique_ptr<Sig0::sig0<A>>(new Sig0::sig0<A>(exist{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+struct SigT {
+  template <typename A, typename P> struct sigT {
+  public:
+    struct existT {
+      A _a0;
+      P _a1;
+    };
+    using variant_t = std::variant<existT>;
+
+  private:
+    variant_t v_;
+    explicit sigT(existT _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<SigT::sigT<A, P>> existT_(A a0, P a1) {
+        return std::shared_ptr<SigT::sigT<A, P>>(
+            new SigT::sigT<A, P>(existT{a0, a1}));
+      }
+      static std::unique_ptr<SigT::sigT<A, P>> existT_uptr(A a0, P a1) {
+        return std::unique_ptr<SigT::sigT<A, P>>(
+            new SigT::sigT<A, P>(existT{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    A projT1() const {
+      return std::visit(
+          Overloaded{[](const typename SigT::sigT<A, P>::existT _args) -> auto {
+            A a = _args._a0;
+            return a;
+          }},
+          this->v());
+    }
+    P projT2() const {
+      return std::visit(
+          Overloaded{[](const typename SigT::sigT<A, P>::existT _args) -> auto {
+            P h = _args._a1;
+            return h;
+          }},
+          this->v());
+    }
+  };
+};
+
+template <typename T1, typename T2,
+          MapsTo<T2, T1, std::function<T2(std::shared_ptr<Sig0::sig0<T1>>)>> F0>
+T2 Fix_F_sub(F0 &&f_sub, const T1 x) {
+  return f_sub(x, [&](axiom x0) { return Fix_F_sub<T1, T2>(f_sub, x0); });
+}
+
+template <typename T1, typename T2,
+          MapsTo<T2, T1, std::function<T2(std::shared_ptr<Sig0::sig0<T1>>)>> F1>
+T2 Fix_sub(const T1 _x0, F1 &&_x1) {
+  return Fix_F_sub<T1>(_x0, _x1);
+}
+
+std::shared_ptr<List::list<unsigned int>> interleave_func(
+    const std::shared_ptr<SigT::sigT<std::shared_ptr<List::list<unsigned int>>,
+                                     std::shared_ptr<List::list<unsigned int>>>>
+        &);
+
+std::shared_ptr<List::list<unsigned int>>
+interleave(std::shared_ptr<List::list<unsigned int>> l1,
+           std::shared_ptr<List::list<unsigned int>> l2);
+
+const std::shared_ptr<List::list<unsigned int>> test_interleave = interleave(
+    List::list<unsigned int>::ctor::cons_(
+        (0 + 1),
+        List::list<unsigned int>::ctor::cons_(
+            (((0 + 1) + 1) + 1), List::list<unsigned int>::ctor::cons_(
+                                     (((((0 + 1) + 1) + 1) + 1) + 1),
+                                     List::list<unsigned int>::ctor::nil_()))),
+    List::list<unsigned int>::ctor::cons_(
+        ((0 + 1) + 1), List::list<unsigned int>::ctor::cons_(
+                           ((((0 + 1) + 1) + 1) + 1),
+                           List::list<unsigned int>::ctor::cons_(
+                               ((((((0 + 1) + 1) + 1) + 1) + 1) + 1),
+                               List::list<unsigned int>::ctor::nil_()))));

--- a/tests/wip/program_fixpoint/program_fixpoint.t.cpp
+++ b/tests/wip/program_fixpoint/program_fixpoint.t.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "program_fixpoint.h"
+
+#include <iostream>
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+std::vector<unsigned int> list_to_vector(const std::shared_ptr<List::list<unsigned int>>& l) {
+  std::vector<unsigned int> result;
+  auto current = l;
+  while (true) {
+    bool done = false;
+    std::visit(
+      Overloaded{
+        [&](const typename List::list<unsigned int>::nil&) {
+          done = true;
+        },
+        [&](const typename List::list<unsigned int>::cons& c) {
+          result.push_back(c._a0);
+          current = c._a1;
+        }
+      },
+      current->v()
+    );
+    if (done) break;
+  }
+  return result;
+}
+
+std::shared_ptr<List::list<unsigned int>> vector_to_list(const std::vector<unsigned int>& vec) {
+  auto result = List::list<unsigned int>::ctor::nil_();
+  for (auto it = vec.rbegin(); it != vec.rend(); ++it) {
+    result = List::list<unsigned int>::ctor::cons_(*it, result);
+  }
+  return result;
+}
+
+int main() {
+  // Test 1: interleave two lists
+  {
+    auto l1 = vector_to_list({1, 3, 5});
+    auto l2 = vector_to_list({2, 4, 6});
+    auto result = interleave(l1, l2);
+    auto vec = list_to_vector(result);
+    ASSERT(vec.size() == 6);
+    ASSERT(vec[0] == 1);
+    ASSERT(vec[1] == 2);
+    ASSERT(vec[2] == 3);
+    ASSERT(vec[3] == 4);
+    ASSERT(vec[4] == 5);
+    ASSERT(vec[5] == 6);
+    std::cout << "Test 1 (interleave): PASSED" << std::endl;
+  }
+
+  // Test 2: interleave with empty
+  {
+    auto l1 = vector_to_list({1, 2, 3});
+    auto l2 = List::list<unsigned int>::ctor::nil_();
+    auto result = interleave(l1, l2);
+    auto vec = list_to_vector(result);
+    ASSERT(vec.size() == 3);
+    ASSERT(vec[0] == 1);
+    ASSERT(vec[1] == 2);
+    ASSERT(vec[2] == 3);
+    std::cout << "Test 2 (interleave with empty): PASSED" << std::endl;
+  }
+
+  // Test 3: test_interleave constant
+  {
+    auto vec = list_to_vector(test_interleave);
+    ASSERT(vec.size() == 6);
+    ASSERT(vec[0] == 1);
+    ASSERT(vec[1] == 2);
+    ASSERT(vec[2] == 3);
+    ASSERT(vec[3] == 4);
+    ASSERT(vec[4] == 5);
+    ASSERT(vec[5] == 6);
+    std::cout << "Test 3 (test_interleave): PASSED" << std::endl;
+  }
+
+  if (testStatus == 0) {
+    std::cout << "\nAll Program Fixpoint tests passed!" << std::endl;
+  } else {
+    std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+  }
+  return testStatus;
+}


### PR DESCRIPTION
## Summary

Adds `tests/wip/program_fixpoint/` testing `Program Fixpoint` with `{measure}` —
well-founded recursion that generates `Fix_F_sub`/`Acc` wrapper terms internally.

## What's tested

`ProgFix.v` defines `interleave` via `Program Fixpoint` with a measure on combined
list lengths, plus a `test_interleave` constant.

## Current extraction issues

Multiple bugs in generated C++:

1. `T1` — unresolved type variable used in lambda parameter
2. `axiom` — undefined type used as parameter in `Fix_F_sub`
3. `dummy_prop` — used as return type in `std::visit` lambdas
4. `interleave0` — called but never defined (should be `interleave`)
5. `[&](void) { ... }()` — invalid C++ lambda syntax
6. Proof infrastructure (`Fix_F_sub`, `Fix_sub`, `Acc`, `Sig0`, `SigT`) leaks
   through instead of being erased

Same class of bug as the `div_conq_split` T1 issue in `wip/msort`, but triggered
via a different Rocq mechanism (`Program` obligations vs manual well-foundedness).

## Verification

WSL Ubuntu, opam switch `default`, Rocq 9.0.0:

```
dune build tests/wip/program_fixpoint/ProgFix.vo   # compiles clean
```

C++ does not compile due to the above issues.

## Files

- `tests/wip/program_fixpoint/ProgFix.v` — new
- `tests/wip/program_fixpoint/program_fixpoint.t.cpp` — new
- `tests/wip/program_fixpoint/program_fixpoint.h` — Crane-generated
- `tests/wip/program_fixpoint/program_fixpoint.cpp` — Crane-generated
- `tests/wip/dune` — added `program_fixpoint` stanza, no existing tests changed