### PR TITLE
Add wip test for nested inductives with Stdlib list

### DIFF
--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -198,3 +198,13 @@
   (deps singleton_record.t.exe)
   (action (run ./singleton_record.t.exe))))
 
+(subdir nested_ind
+ (rule
+  (targets nested_ind.t.exe)
+  (deps NestedInd.vo nested_ind.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nested_ind.t.exe nested_ind.cpp nested_ind.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nested_ind.t.exe)
+  (action (run ./nested_ind.t.exe))))

--- a/tests/wip/nested_ind/NestedInd.v
+++ b/tests/wip/nested_ind/NestedInd.v
@@ -1,0 +1,136 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Nested inductives with Stdlib list — expression AST. *)
+(* The existing regression/nested_inductive uses a custom list type. *)
+(* This test uses Stdlib's list, exercising a different extraction path. *)
+
+From Stdlib Require Import List Nat.
+Import ListNotations.
+
+(* === Nested inductive: expr uses list expr in constructors === *)
+
+Inductive expr : Type :=
+| Lit : nat -> expr
+| Add : list expr -> expr
+| Mul : list expr -> expr.
+
+(* === Recursive functions via nested fix === *)
+(* The nested fix pattern is required because Rocq's guard checker
+   needs to see that recursive calls are on structural subterms
+   reached through the list. *)
+
+Fixpoint eval (e : expr) : nat :=
+  match e with
+  | Lit n => n
+  | Add es =>
+      (fix sum_all (l : list expr) : nat :=
+         match l with
+         | nil => 0
+         | cons e' rest => eval e' + sum_all rest
+         end) es
+  | Mul es =>
+      (fix prod_all (l : list expr) : nat :=
+         match l with
+         | nil => 1
+         | cons e' rest => eval e' * prod_all rest
+         end) es
+  end.
+
+Fixpoint expr_size (e : expr) : nat :=
+  match e with
+  | Lit _ => 1
+  | Add es =>
+      S ((fix aux (l : list expr) : nat :=
+            match l with
+            | nil => 0
+            | cons e' rest => expr_size e' + aux rest
+            end) es)
+  | Mul es =>
+      S ((fix aux (l : list expr) : nat :=
+            match l with
+            | nil => 0
+            | cons e' rest => expr_size e' + aux rest
+            end) es)
+  end.
+
+Fixpoint expr_depth (e : expr) : nat :=
+  match e with
+  | Lit _ => 0
+  | Add es =>
+      S ((fix aux (l : list expr) : nat :=
+            match l with
+            | nil => 0
+            | cons e' rest => max (expr_depth e') (aux rest)
+            end) es)
+  | Mul es =>
+      S ((fix aux (l : list expr) : nat :=
+            match l with
+            | nil => 0
+            | cons e' rest => max (expr_depth e') (aux rest)
+            end) es)
+  end.
+
+Fixpoint literals (e : expr) : list nat :=
+  match e with
+  | Lit n => [n]
+  | Add es =>
+      (fix aux (l : list expr) : list nat :=
+         match l with
+         | nil => nil
+         | cons e' rest => literals e' ++ aux rest
+         end) es
+  | Mul es =>
+      (fix aux (l : list expr) : list nat :=
+         match l with
+         | nil => nil
+         | cons e' rest => literals e' ++ aux rest
+         end) es
+  end.
+
+Fixpoint lit_map (f : nat -> nat) (e : expr) : expr :=
+  match e with
+  | Lit n => Lit (f n)
+  | Add es =>
+      Add ((fix aux (l : list expr) : list expr :=
+              match l with
+              | nil => nil
+              | cons e' rest => cons (lit_map f e') (aux rest)
+              end) es)
+  | Mul es =>
+      Mul ((fix aux (l : list expr) : list expr :=
+              match l with
+              | nil => nil
+              | cons e' rest => cons (lit_map f e') (aux rest)
+              end) es)
+  end.
+
+(* === Test values === *)
+
+(* 1 + 2 + 3 = 6 *)
+Definition test_add : expr := Add [Lit 1; Lit 2; Lit 3].
+
+(* 2 * 3 * 4 = 24 *)
+Definition test_mul : expr := Mul [Lit 2; Lit 3; Lit 4].
+
+(* (1 + 2) * (3 + 4) = 3 * 7 = 21 *)
+Definition test_nested : expr :=
+  Mul [Add [Lit 1; Lit 2]; Add [Lit 3; Lit 4]].
+
+Definition test_eval_add    : nat := eval test_add.        (* 6 *)
+Definition test_eval_mul    : nat := eval test_mul.        (* 24 *)
+Definition test_eval_nested : nat := eval test_nested.     (* 21 *)
+Definition test_size_nested : nat := expr_size test_nested. (* 7 *)
+Definition test_depth_nested : nat := expr_depth test_nested. (* 2 *)
+Definition test_literals    : list nat := literals test_nested. (* [1;2;3;4] *)
+
+(* lit_map: double all literals, then eval *)
+Definition test_doubled : nat :=
+  eval (lit_map (fun n => n * 2) test_nested). (* (2+4)*(6+8) = 6*14 = 84 *)
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nested_ind"
+  eval literals
+  test_add test_mul test_nested
+  test_eval_add test_eval_mul test_eval_nested
+  test_literals.

--- a/tests/wip/nested_ind/nested_ind.cpp
+++ b/tests/wip/nested_ind/nested_ind.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <nested_ind.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>

--- a/tests/wip/nested_ind/nested_ind.h
+++ b/tests/wip/nested_ind/nested_ind.h
@@ -1,0 +1,303 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct List {
+  template <typename A> struct list {
+  public:
+    struct nil {};
+    struct cons {
+      A _a0;
+      std::shared_ptr<List::list<A>> _a1;
+    };
+    using variant_t = std::variant<nil, cons>;
+
+  private:
+    variant_t v_;
+    explicit list(nil _v) : v_(std::move(_v)) {}
+    explicit list(cons _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<List::list<A>> nil_() {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::shared_ptr<List::list<A>>
+      cons_(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+      static std::unique_ptr<List::list<A>> nil_uptr() {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::unique_ptr<List::list<A>>
+      cons_uptr(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    std::shared_ptr<List::list<A>>
+    app(const std::shared_ptr<List::list<A>> &m) const {
+      return std::visit(
+          Overloaded{[&](const typename List::list<A>::nil _args)
+                         -> std::shared_ptr<List::list<A>> { return m; },
+                     [&](const typename List::list<A>::cons _args)
+                         -> std::shared_ptr<List::list<A>> {
+                       A a = _args._a0;
+                       std::shared_ptr<List::list<A>> l1 = _args._a1;
+                       return List::list<A>::ctor::cons_(a,
+                                                         std::move(l1)->app(m));
+                     }},
+          this->v());
+    }
+  };
+};
+
+struct Expr {
+  struct expr {
+  public:
+    struct Lit {
+      unsigned int _a0;
+    };
+    struct Add {
+      std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> _a0;
+    };
+    struct Mul {
+      std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> _a0;
+    };
+    using variant_t = std::variant<Lit, Add, Mul>;
+
+  private:
+    variant_t v_;
+    explicit expr(Lit _v) : v_(std::move(_v)) {}
+    explicit expr(Add _v) : v_(std::move(_v)) {}
+    explicit expr(Mul _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Expr::expr> Lit_(unsigned int a0) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(Lit{a0}));
+      }
+      static std::shared_ptr<Expr::expr>
+      Add_(const std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> &a0) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(Add{a0}));
+      }
+      static std::shared_ptr<Expr::expr>
+      Mul_(const std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> &a0) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(Mul{a0}));
+      }
+      static std::unique_ptr<Expr::expr> Lit_uptr(unsigned int a0) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(Lit{a0}));
+      }
+      static std::unique_ptr<Expr::expr> Add_uptr(
+          const std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> &a0) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(Add{a0}));
+      }
+      static std::unique_ptr<Expr::expr> Mul_uptr(
+          const std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> &a0) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(Mul{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    unsigned int eval() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Expr::expr::Lit _args) -> unsigned int {
+                unsigned int n = _args._a0;
+                return std::move(n);
+              },
+              [](const typename Expr::expr::Add _args) -> unsigned int {
+                std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> es =
+                    _args._a0;
+                std::function<unsigned int(
+                    std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>)>
+                    sum_all;
+                sum_all =
+                    [&](std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>
+                            l) -> unsigned int {
+                  return std::visit(
+                      Overloaded{[](const typename List::list<
+                                     std::shared_ptr<Expr::expr>>::nil _args)
+                                     -> unsigned int { return 0; },
+                                 [&](const typename List::list<
+                                     std::shared_ptr<Expr::expr>>::cons _args)
+                                     -> unsigned int {
+                                   std::shared_ptr<Expr::expr> e_ = _args._a0;
+                                   std::shared_ptr<
+                                       List::list<std::shared_ptr<Expr::expr>>>
+                                       rest = _args._a1;
+                                   return (std::move(e_)->eval() +
+                                           sum_all(std::move(rest)));
+                                 }},
+                      l->v());
+                };
+                return sum_all(es);
+              },
+              [](const typename Expr::expr::Mul _args) -> unsigned int {
+                std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> es =
+                    _args._a0;
+                std::function<unsigned int(
+                    std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>)>
+                    prod_all;
+                prod_all =
+                    [&](std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>
+                            l) -> unsigned int {
+                  return std::visit(
+                      Overloaded{[](const typename List::list<
+                                     std::shared_ptr<Expr::expr>>::nil _args)
+                                     -> unsigned int { return (0 + 1); },
+                                 [&](const typename List::list<
+                                     std::shared_ptr<Expr::expr>>::cons _args)
+                                     -> unsigned int {
+                                   std::shared_ptr<Expr::expr> e_ = _args._a0;
+                                   std::shared_ptr<
+                                       List::list<std::shared_ptr<Expr::expr>>>
+                                       rest = _args._a1;
+                                   return (std::move(e_)->eval() *
+                                           prod_all(std::move(rest)));
+                                 }},
+                      l->v());
+                };
+                return prod_all(es);
+              }},
+          this->v());
+    }
+    std::shared_ptr<List::list<unsigned int>> literals() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Expr::expr::Lit _args)
+                  -> std::shared_ptr<List::list<unsigned int>> {
+                unsigned int n = _args._a0;
+                return List::list<unsigned int>::ctor::cons_(
+                    std::move(n), List::list<unsigned int>::ctor::nil_());
+              },
+              [](const typename Expr::expr::Add _args)
+                  -> std::shared_ptr<List::list<unsigned int>> {
+                std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> es =
+                    _args._a0;
+                std::function<std::shared_ptr<List::list<unsigned int>>(
+                    std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>)>
+                    aux;
+                aux =
+                    [&](std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>
+                            l) -> std::shared_ptr<List::list<unsigned int>> {
+                  return std::visit(
+                      Overloaded{
+                          [](const typename List::list<
+                              std::shared_ptr<Expr::expr>>::nil _args)
+                              -> std::shared_ptr<List::list<unsigned int>> {
+                            return List::list<unsigned int>::ctor::nil_();
+                          },
+                          [&](const typename List::list<
+                              std::shared_ptr<Expr::expr>>::cons _args)
+                              -> std::shared_ptr<List::list<unsigned int>> {
+                            std::shared_ptr<Expr::expr> e_ = _args._a0;
+                            std::shared_ptr<
+                                List::list<std::shared_ptr<Expr::expr>>>
+                                rest = _args._a1;
+                            return std::move(e_)->literals()->app(
+                                aux(std::move(rest)));
+                          }},
+                      l->v());
+                };
+                return aux(es);
+              },
+              [](const typename Expr::expr::Mul _args)
+                  -> std::shared_ptr<List::list<unsigned int>> {
+                std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>> es =
+                    _args._a0;
+                std::function<std::shared_ptr<List::list<unsigned int>>(
+                    std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>)>
+                    aux;
+                aux =
+                    [&](std::shared_ptr<List::list<std::shared_ptr<Expr::expr>>>
+                            l) -> std::shared_ptr<List::list<unsigned int>> {
+                  return std::visit(
+                      Overloaded{
+                          [](const typename List::list<
+                              std::shared_ptr<Expr::expr>>::nil _args)
+                              -> std::shared_ptr<List::list<unsigned int>> {
+                            return List::list<unsigned int>::ctor::nil_();
+                          },
+                          [&](const typename List::list<
+                              std::shared_ptr<Expr::expr>>::cons _args)
+                              -> std::shared_ptr<List::list<unsigned int>> {
+                            std::shared_ptr<Expr::expr> e_ = _args._a0;
+                            std::shared_ptr<
+                                List::list<std::shared_ptr<Expr::expr>>>
+                                rest = _args._a1;
+                            return std::move(e_)->literals()->app(
+                                aux(std::move(rest)));
+                          }},
+                      l->v());
+                };
+                return aux(es);
+              }},
+          this->v());
+    }
+  };
+};
+
+const std::shared_ptr<Expr::expr> test_add =
+    Expr::expr::ctor::Add_(List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+        Expr::expr::ctor::Lit_((0 + 1)),
+        List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+            Expr::expr::ctor::Lit_(((0 + 1) + 1)),
+            List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                Expr::expr::ctor::Lit_((((0 + 1) + 1) + 1)),
+                List::list<std::shared_ptr<Expr::expr>>::ctor::nil_()))));
+
+const std::shared_ptr<Expr::expr> test_mul =
+    Expr::expr::ctor::Mul_(List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+        Expr::expr::ctor::Lit_(((0 + 1) + 1)),
+        List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+            Expr::expr::ctor::Lit_((((0 + 1) + 1) + 1)),
+            List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                Expr::expr::ctor::Lit_(((((0 + 1) + 1) + 1) + 1)),
+                List::list<std::shared_ptr<Expr::expr>>::ctor::nil_()))));
+
+const std::shared_ptr<Expr::expr> test_nested =
+    Expr::expr::ctor::Mul_(List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+        Expr::expr::ctor::Add_(
+            List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                Expr::expr::ctor::Lit_((0 + 1)),
+                List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                    Expr::expr::ctor::Lit_(((0 + 1) + 1)),
+                    List::list<std::shared_ptr<Expr::expr>>::ctor::nil_()))),
+        List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+            Expr::expr::ctor::Add_(
+                List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                    Expr::expr::ctor::Lit_((((0 + 1) + 1) + 1)),
+                    List::list<std::shared_ptr<Expr::expr>>::ctor::cons_(
+                        Expr::expr::ctor::Lit_(((((0 + 1) + 1) + 1) + 1)),
+                        List::list<
+                            std::shared_ptr<Expr::expr>>::ctor::nil_()))),
+            List::list<std::shared_ptr<Expr::expr>>::ctor::nil_())));
+
+const unsigned int test_eval_add = test_add->eval();
+
+const unsigned int test_eval_mul = test_mul->eval();
+
+const unsigned int test_eval_nested = test_nested->eval();
+
+const std::shared_ptr<List::list<unsigned int>> test_literals =
+    test_nested->literals();

--- a/tests/wip/nested_ind/nested_ind.t.cpp
+++ b/tests/wip/nested_ind/nested_ind.t.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "nested_ind.h"
+
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+// Helper: convert List::list<unsigned int> to std::vector
+std::vector<unsigned int>
+to_vector(const std::shared_ptr<List::list<unsigned int>> &l) {
+    std::vector<unsigned int> result;
+    auto cur = l;
+    while (true) {
+        auto ok = std::visit(
+            Overloaded{
+                [&](const List::list<unsigned int>::nil) -> bool {
+                    return false;
+                },
+                [&](const List::list<unsigned int>::cons args) -> bool {
+                    result.push_back(args._a0);
+                    cur = args._a1;
+                    return true;
+                }},
+            cur->v());
+        if (!ok) break;
+    }
+    return result;
+}
+
+int main() {
+    // Test 1: eval(1 + 2 + 3) = 6
+    {
+        ASSERT(test_eval_add == 6);
+        std::cout << "Test 1 (eval add): PASSED" << std::endl;
+    }
+
+    // Test 2: eval(2 * 3 * 4) = 24
+    {
+        ASSERT(test_eval_mul == 24);
+        std::cout << "Test 2 (eval mul): PASSED" << std::endl;
+    }
+
+    // Test 3: eval((1+2) * (3+4)) = 21
+    {
+        ASSERT(test_eval_nested == 21);
+        std::cout << "Test 3 (eval nested): PASSED" << std::endl;
+    }
+
+    // Test 4: literals of (1+2)*(3+4) = [1,2,3,4]
+    {
+        auto v = to_vector(test_literals);
+        ASSERT(v.size() == 4);
+        ASSERT(v[0] == 1);
+        ASSERT(v[1] == 2);
+        ASSERT(v[2] == 3);
+        ASSERT(v[3] == 4);
+        std::cout << "Test 4 (literals): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll nested_ind tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}


### PR DESCRIPTION
## Summary

Adds `tests/wip/nested_ind/` testing nested inductives using Stdlib's `list` — an expression AST where constructors contain `list expr`. The existing `tests/regression/nested_inductive` uses a custom `list` type; this test exercises the Stdlib `list` extraction path.

## New folder: `tests/wip/nested_ind/`

- `NestedInd.v` — expression AST (`Lit | Add (list expr) | Mul (list expr)`) with 5 recursive functions using the nested fix pattern:
  - `eval` — evaluate expression tree (works)
  - `literals` — collect all leaf values (works)
  - `expr_size` — count nodes (**crashes Crane**)
  - `expr_depth` — tree depth (**crashes Crane**)
  - `lit_map` — transform all literals (**crashes Crane**)
- `nested_ind.t.cpp` — 4 tests for the working functions (all pass)
- `nested_ind.h` / `nested_ind.cpp` — Crane-generated extraction

## Bug characterization

The `Translation.TODO` crash depends on how the nested fix result is used:

| Function | Nested fix returns | Wraps result in constructor? | Crashes? |
|---|---|---|---|
| `eval` | `nat` (sum/product) | No — returned directly | No |
| `literals` | `list nat` (append) | No — returned directly | No |
| `expr_size` | `nat` | Yes — `S (nested_fix ...)` | **Yes** |
| `expr_depth` | `nat` via `max` | Yes — `S (nested_fix ...)` | **Yes** |
| `lit_map` | `list expr` | Yes — `Add (nested_fix ...)` | **Yes** |

Crane handles nested fix when the result is returned directly, but crashes when the result is wrapped in a constructor (`S`, `Add`, `Mul`).

## Notes

- Dune stanza added to `tests/wip/dune`
- No existing tests modified
- `expr_size`, `expr_depth`, `lit_map` defined in `.v` but excluded from extraction to avoid crash

## Test plan

- [x] `NestedInd.vo` compiles locally (Rocq 9.0.0)
- [x] Crane extraction produces `.h`/`.cpp`
- [x] C++ compiles and all 4 tests pass