### PR TITLE
Add 8 wip tests for extraction patterns (batch 2)

### DIFF
--- a/tests/wip/acc_rect/AccRect.v
+++ b/tests/wip/acc_rect/AccRect.v
@@ -1,0 +1,65 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Direct Acc_rect / well-founded induction. *)
+
+From Stdlib Require Import Nat Bool List Wf_nat Lia PeanoNat.
+Import ListNotations.
+
+(* === Acc-based countdown === *)
+
+Fixpoint countdown_acc (n : nat) (acc : Acc lt n) {struct acc} : list nat :=
+  match n as n0 return Acc lt n0 -> list nat with
+  | 0 => fun _ => [0]
+  | S m => fun acc' => n :: countdown_acc m (Acc_inv acc' (Nat.lt_succ_diag_r m))
+  end acc.
+
+Definition countdown (n : nat) : list nat :=
+  countdown_acc n (lt_wf n).
+
+(* === div2 via well_founded_induction === *)
+
+Lemma lt_S_S : forall m, m < S (S m).
+Proof. intro. lia. Qed.
+
+Definition div2_wf : nat -> nat :=
+  well_founded_induction lt_wf (fun _ => nat)
+    (fun n rec =>
+      match n as n0 return (forall m, m < n0 -> nat) -> nat with
+      | 0 => fun _ => 0
+      | 1 => fun _ => 0
+      | S (S m) => fun rec' => S (rec' m (lt_S_S m))
+      end rec).
+
+(* === GCD via well_founded_induction === *)
+
+Lemma mod_lt_S : forall b a, Nat.modulo b (S a) < S a.
+Proof. intros. apply Nat.mod_upper_bound. lia. Qed.
+
+Definition gcd_wf : nat -> nat -> nat :=
+  well_founded_induction lt_wf (fun _ => nat -> nat)
+    (fun a rec b =>
+      match a as a0 return (forall m, m < a0 -> nat -> nat) -> nat with
+      | 0 => fun _ => b
+      | S a' => fun rec' => rec' (Nat.modulo b (S a')) (mod_lt_S b a') (S a')
+      end rec).
+
+(* === Test values === *)
+
+Definition test_div2_0 : nat := div2_wf 0.
+Definition test_div2_1 : nat := div2_wf 1.
+Definition test_div2_7 : nat := div2_wf 7.
+Definition test_div2_10 : nat := div2_wf 10.
+
+Definition test_countdown : list nat := countdown 5.
+
+Definition test_gcd_1 : nat := gcd_wf 12 8.
+Definition test_gcd_2 : nat := gcd_wf 35 14.
+Definition test_gcd_3 : nat := gcd_wf 0 5.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "acc_rect"
+  div2_wf countdown gcd_wf
+  test_div2_0 test_div2_1 test_div2_7 test_div2_10
+  test_countdown
+  test_gcd_1 test_gcd_2 test_gcd_3.

--- a/tests/wip/acc_rect/acc_rect.cpp
+++ b/tests/wip/acc_rect/acc_rect.cpp
@@ -1,0 +1,91 @@
+#include <acc_rect.h>
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+unsigned int Nat::sub(const unsigned int n, const unsigned int m) {
+  if (n <= 0) {
+    return std::move(n);
+  } else {
+    unsigned int k = n - 1;
+    if (m <= 0) {
+      return n;
+    } else {
+      unsigned int l = m - 1;
+      return sub(std::move(k), l);
+    }
+  }
+}
+
+std::pair<unsigned int, unsigned int> Nat::divmod(const unsigned int x,
+                                                  const unsigned int y,
+                                                  const unsigned int q,
+                                                  const unsigned int u) {
+  if (x <= 0) {
+    return std::make_pair(std::move(q), std::move(u));
+  } else {
+    unsigned int x_ = x - 1;
+    if (u <= 0) {
+      return divmod(std::move(x_), y, (q + 1), y);
+    } else {
+      unsigned int u_ = u - 1;
+      return divmod(std::move(x_), y, q, std::move(u_));
+    }
+  }
+}
+
+unsigned int Nat::modulo(const unsigned int x, const unsigned int y) {
+  if (y <= 0) {
+    return std::move(x);
+  } else {
+    unsigned int y_ = y - 1;
+    return sub(y_, divmod(x, y_, 0, y_).second);
+  }
+}
+
+std::shared_ptr<List::list<unsigned int>> countdown_acc(const unsigned int n) {
+  if (n <= 0) {
+    return List::list<unsigned int>::ctor::cons_(
+        0, List::list<unsigned int>::ctor::nil_());
+  } else {
+    unsigned int m = n - 1;
+    return List::list<unsigned int>::ctor::cons_(n,
+                                                 countdown_acc(std::move(m)));
+  }
+}
+
+std::shared_ptr<List::list<unsigned int>> countdown(const unsigned int _x0) {
+  return countdown_acc(_x0);
+}
+
+unsigned int div2_wf(const unsigned int x) {
+  if (x <= 0) {
+    return 0;
+  } else {
+    unsigned int n0 = x - 1;
+    if (n0 <= 0) {
+      return 0;
+    } else {
+      unsigned int m = n0 - 1;
+      return (div2_wf(m) + 1);
+    }
+  }
+}
+
+unsigned int gcd_wf(const unsigned int x, const unsigned int b) {
+  if (x <= 0) {
+    return std::move(b);
+  } else {
+    unsigned int a_ = x - 1;
+    unsigned int y = Nat::modulo(b, (std::move(a_) + 1));
+    return gcd_wf(std::move(y), (std::move(a_) + 1));
+  }
+}

--- a/tests/wip/acc_rect/acc_rect.h
+++ b/tests/wip/acc_rect/acc_rect.h
@@ -1,0 +1,130 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct List {
+  template <typename A> struct list {
+  public:
+    struct nil {};
+    struct cons {
+      A _a0;
+      std::shared_ptr<List::list<A>> _a1;
+    };
+    using variant_t = std::variant<nil, cons>;
+
+  private:
+    variant_t v_;
+    explicit list(nil _v) : v_(std::move(_v)) {}
+    explicit list(cons _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<List::list<A>> nil_() {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::shared_ptr<List::list<A>>
+      cons_(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+      static std::unique_ptr<List::list<A>> nil_uptr() {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::unique_ptr<List::list<A>>
+      cons_uptr(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+struct Nat {
+  static unsigned int sub(const unsigned int n, const unsigned int m);
+
+  static std::pair<unsigned int, unsigned int> divmod(const unsigned int x,
+                                                      const unsigned int y,
+                                                      const unsigned int q,
+                                                      const unsigned int u);
+
+  static unsigned int modulo(const unsigned int x, const unsigned int y);
+};
+
+std::shared_ptr<List::list<unsigned int>> countdown_acc(const unsigned int n);
+
+std::shared_ptr<List::list<unsigned int>> countdown(const unsigned int);
+
+unsigned int div2_wf(const unsigned int x);
+
+unsigned int gcd_wf(const unsigned int x, const unsigned int b);
+
+const unsigned int test_div2_0 = div2_wf(0);
+
+const unsigned int test_div2_1 = div2_wf((0 + 1));
+
+const unsigned int test_div2_7 =
+    div2_wf((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1));
+
+const unsigned int test_div2_10 =
+    div2_wf(((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1));
+
+const std::shared_ptr<List::list<unsigned int>> test_countdown =
+    countdown((((((0 + 1) + 1) + 1) + 1) + 1));
+
+const unsigned int test_gcd_1 = gcd_wf(
+    ((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1),
+    ((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1));
+
+const unsigned int test_gcd_2 = gcd_wf(
+    (((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1) +
+               1) +
+              1) +
+             1) +
+            1) +
+           1) +
+          1) +
+         1) +
+        1) +
+       1) +
+      1) +
+     1),
+    ((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
+       1) +
+      1) +
+     1));
+
+const unsigned int test_gcd_3 = gcd_wf(0, (((((0 + 1) + 1) + 1) + 1) + 1));

--- a/tests/wip/acc_rect/acc_rect.t.cpp
+++ b/tests/wip/acc_rect/acc_rect.t.cpp
@@ -1,0 +1,52 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "acc_rect.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: div2
+    {
+        ASSERT(test_div2_0 == 0);
+        ASSERT(test_div2_1 == 0);
+        ASSERT(test_div2_7 == 3);
+        ASSERT(test_div2_10 == 5);
+        std::cout << "Test 1 (div2_wf): PASSED" << std::endl;
+    }
+
+    // Test 2: gcd
+    {
+        ASSERT(test_gcd_1 == 4);   // gcd(12,8) = 4
+        ASSERT(test_gcd_2 == 7);   // gcd(35,14) = 7
+        ASSERT(test_gcd_3 == 5);   // gcd(0,5) = 5
+        std::cout << "Test 2 (gcd_wf): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll acc_rect tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/dep_record/DepRecord.v
+++ b/tests/wip/dep_record/DepRecord.v
@@ -1,0 +1,64 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Dependent records — field types depend on earlier fields. *)
+
+From Stdlib Require Import Nat Bool List.
+Import ListNotations.
+
+(* === Simple dependent record: carrier + operation === *)
+
+Record Magma := mkMagma {
+  carrier : Type;
+  op : carrier -> carrier -> carrier
+}.
+
+Definition nat_magma : Magma := mkMagma nat Nat.add.
+Definition bool_magma : Magma := mkMagma bool andb.
+
+(* === Algebraic structure style: carrier + op + identity === *)
+
+Record Monoid := mkMonoid {
+  m_carrier : Type;
+  m_op : m_carrier -> m_carrier -> m_carrier;
+  m_id : m_carrier
+}.
+
+Definition nat_monoid : Monoid := mkMonoid nat Nat.add 0.
+Definition nat_mul_monoid : Monoid := mkMonoid nat Nat.mul 1.
+
+(* === Generic fold using monoid === *)
+
+Fixpoint mfold (M : Monoid) (l : list (m_carrier M)) : m_carrier M :=
+  match l with
+  | [] => m_id M
+  | x :: rest => m_op M x (mfold M rest)
+  end.
+
+Definition test_fold_add : nat := mfold nat_monoid [1; 2; 3; 4].
+Definition test_fold_mul : nat := mfold nat_mul_monoid [2; 3; 4].
+
+(* === Sigma-style: type tag + payload === *)
+
+Inductive tag : Type := TNat | TBool.
+
+Definition tag_type (t : tag) : Type :=
+  match t with
+  | TNat => nat
+  | TBool => bool
+  end.
+
+Record Tagged := mkTagged {
+  the_tag : tag;
+  the_value : tag_type the_tag
+}.
+
+Definition tagged_nat : Tagged := mkTagged TNat 42.
+Definition tagged_bool : Tagged := mkTagged TBool true.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "dep_record"
+  nat_magma bool_magma
+  nat_monoid nat_mul_monoid
+  mfold test_fold_add test_fold_mul
+  tagged_nat tagged_bool.

--- a/tests/wip/dep_record/dep_record.cpp
+++ b/tests/wip/dep_record/dep_record.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <dep_record.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>

--- a/tests/wip/dep_record/dep_record.h
+++ b/tests/wip/dep_record/dep_record.h
@@ -1,0 +1,177 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct List {
+  template <typename A> struct list {
+  public:
+    struct nil {};
+    struct cons {
+      A _a0;
+      std::shared_ptr<List::list<A>> _a1;
+    };
+    using variant_t = std::variant<nil, cons>;
+
+  private:
+    variant_t v_;
+    explicit list(nil _v) : v_(std::move(_v)) {}
+    explicit list(cons _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<List::list<A>> nil_() {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::shared_ptr<List::list<A>>
+      cons_(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::shared_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+      static std::unique_ptr<List::list<A>> nil_uptr() {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(nil{}));
+      }
+      static std::unique_ptr<List::list<A>>
+      cons_uptr(A a0, const std::shared_ptr<List::list<A>> &a1) {
+        return std::unique_ptr<List::list<A>>(new List::list<A>(cons{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+struct Magma {
+  struct magma {
+  public:
+    struct mkMagma {
+      std::function<std::any(std::any, std::any)> _a0;
+    };
+    using variant_t = std::variant<mkMagma>;
+
+  private:
+    variant_t v_;
+    explicit magma(mkMagma _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Magma::magma>
+      mkMagma_(std::function<std::any(std::any, std::any)> a0) {
+        return std::shared_ptr<Magma::magma>(new Magma::magma(mkMagma{a0}));
+      }
+      static std::unique_ptr<Magma::magma>
+      mkMagma_uptr(std::function<std::any(std::any, std::any)> a0) {
+        return std::unique_ptr<Magma::magma>(new Magma::magma(mkMagma{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+};
+
+const std::shared_ptr<Magma::magma> nat_magma =
+    [](const unsigned int _x0, const unsigned int _x1) { return (_x0 + _x1); };
+
+const std::shared_ptr<Magma::magma> bool_magma =
+    [](const bool _x0, const bool _x1) { return (_x0 && _x1); };
+
+struct Monoid {
+  std::function<std::any(std::any, std::any)> m_op;
+  std::any m_id;
+};
+
+using m_carrier = std::any;
+
+const std::shared_ptr<Monoid> nat_monoid = std::make_shared<Monoid>(Monoid{
+    [](const unsigned int _x0, const unsigned int _x1) { return (_x0 + _x1); },
+    0});
+
+const std::shared_ptr<Monoid> nat_mul_monoid = std::make_shared<Monoid>(Monoid{
+    [](const unsigned int _x0, const unsigned int _x1) { return (_x0 * _x1); },
+    (0 + 1)});
+
+const unsigned int test_fold_add =
+    nat_monoid->mfold(List::list<std::any>::ctor::cons_(
+        (0 + 1),
+        List::list<std::any>::ctor::cons_(
+            ((0 + 1) + 1), List::list<std::any>::ctor::cons_(
+                               (((0 + 1) + 1) + 1),
+                               List::list<std::any>::ctor::cons_(
+                                   ((((0 + 1) + 1) + 1) + 1),
+                                   List::list<std::any>::ctor::nil_())))));
+
+const unsigned int test_fold_mul =
+    nat_mul_monoid->mfold(List::list<std::any>::ctor::cons_(
+        ((0 + 1) + 1),
+        List::list<std::any>::ctor::cons_(
+            (((0 + 1) + 1) + 1), List::list<std::any>::ctor::cons_(
+                                     ((((0 + 1) + 1) + 1) + 1),
+                                     List::list<std::any>::ctor::nil_()))));
+
+enum class tag { TNat, TBool };
+
+using tag_type = std::any;
+
+struct Tagged {
+  tag the_tag;
+  tag_type the_value;
+};
+
+const std::shared_ptr<Tagged> tagged_nat = std::make_shared<Tagged>(Tagged{
+    tag::TNat,
+    ((((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) +
+                                        1) +
+                                       1) +
+                                      1) +
+                                     1) +
+                                    1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1) +
+               1) +
+              1) +
+             1) +
+            1) +
+           1) +
+          1) +
+         1) +
+        1) +
+       1) +
+      1) +
+     1)});
+
+const std::shared_ptr<Tagged> tagged_bool =
+    std::make_shared<Tagged>(Tagged{tag::TBool, true});

--- a/tests/wip/dep_record/dep_record.t.cpp
+++ b/tests/wip/dep_record/dep_record.t.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "dep_record.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: monoid fold add
+    {
+        ASSERT(test_fold_add == 10);  // 1 + 2 + 3 + 4
+        std::cout << "Test 1 (fold_add): PASSED" << std::endl;
+    }
+
+    // Test 2: monoid fold mul
+    {
+        ASSERT(test_fold_mul == 24);  // 2 * 3 * 4
+        std::cout << "Test 2 (fold_mul): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll dep_record tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -307,3 +307,80 @@
   (alias runtest)
   (deps opaque.t.exe)
   (action (run ./opaque.t.exe))))
+
+(subdir acc_rect
+ (rule
+  (targets acc_rect.t.exe)
+  (deps AccRect.vo acc_rect.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} acc_rect.t.exe acc_rect.cpp acc_rect.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps acc_rect.t.exe)
+  (action (run ./acc_rect.t.exe))))
+
+(subdir dep_record
+ (rule
+  (targets dep_record.t.exe)
+  (deps DepRecord.vo dep_record.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} dep_record.t.exe dep_record.cpp dep_record.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps dep_record.t.exe)
+  (action (run ./dep_record.t.exe))))
+
+(subdir higher_kinded
+ (rule
+  (targets higher_kinded.t.exe)
+  (deps HigherKinded.vo higher_kinded.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} higher_kinded.t.exe higher_kinded.cpp higher_kinded.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps higher_kinded.t.exe)
+  (action (run ./higher_kinded.t.exe))))
+
+(subdir large_mutual
+ (rule
+  (targets large_mutual.t.exe)
+  (deps LargeMutual.vo large_mutual.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} large_mutual.t.exe large_mutual.cpp large_mutual.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps large_mutual.t.exe)
+  (action (run ./large_mutual.t.exe))))
+
+(subdir rec_record
+ (rule
+  (targets rec_record.t.exe)
+  (deps RecRecord.vo rec_record.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} rec_record.t.exe rec_record.cpp rec_record.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps rec_record.t.exe)
+  (action (run ./rec_record.t.exe))))
+
+(subdir sprop
+ (rule
+  (targets sprop.t.exe)
+  (deps SProp.vo sprop.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} sprop.t.exe sprop.cpp sprop.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps sprop.t.exe)
+  (action (run ./sprop.t.exe))))
+
+(subdir string_match
+ (rule
+  (targets string_match.t.exe)
+  (deps StringMatch.vo string_match.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} string_match.t.exe string_match.cpp string_match.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps string_match.t.exe)
+  (action (run ./string_match.t.exe))))

--- a/tests/wip/higher_kinded/HigherKinded.v
+++ b/tests/wip/higher_kinded/HigherKinded.v
@@ -1,0 +1,63 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Higher-kinded type parameters (F : Type -> Type). *)
+
+From Stdlib Require Import Nat Bool List.
+Import ListNotations.
+
+(* === Direct HKT parameter (not via typeclass) === *)
+
+Definition hk_map (F : Type -> Type)
+  (map_f : forall A B, (A -> B) -> F A -> F B)
+  {A B : Type} (f : A -> B) (x : F A) : F B :=
+  map_f A B f x.
+
+(* === Container type with HKT === *)
+
+Inductive Tree (A : Type) : Type :=
+  | Leaf : A -> Tree A
+  | Branch : Tree A -> Tree A -> Tree A.
+
+Arguments Leaf {A} _.
+Arguments Branch {A} _ _.
+
+Fixpoint tree_map {A B : Type} (f : A -> B) (t : Tree A) : Tree B :=
+  match t with
+  | Leaf x => Leaf (f x)
+  | Branch l r => Branch (tree_map f l) (tree_map f r)
+  end.
+
+Fixpoint tree_fold {A B : Type} (leaf_f : A -> B) (branch_f : B -> B -> B) (t : Tree A) : B :=
+  match t with
+  | Leaf x => leaf_f x
+  | Branch l r => branch_f (tree_fold leaf_f branch_f l) (tree_fold leaf_f branch_f r)
+  end.
+
+Definition tree_sum (t : Tree nat) : nat :=
+  tree_fold (fun x => x) Nat.add t.
+
+Definition tree_size {A : Type} (t : Tree A) : nat :=
+  tree_fold (fun _ => 1) Nat.add t.
+
+(* === Apply HKT map to different containers === *)
+
+Definition map_option {A B : Type} (f : A -> B) (o : option A) : option B :=
+  match o with
+  | None => None
+  | Some x => Some (f x)
+  end.
+
+Definition test_tree : Tree nat := Branch (Leaf 1) (Branch (Leaf 2) (Leaf 3)).
+Definition test_tree_sum : nat := tree_sum test_tree.
+Definition test_tree_size : nat := tree_size test_tree.
+Definition test_tree_map : Tree nat := tree_map (fun n => n * 2) test_tree.
+Definition test_hk_option : option nat := hk_map option (@map_option) (fun n => n + 1) (Some 5).
+Definition test_hk_tree : Tree nat := hk_map Tree (@tree_map) (fun n => n + 10) test_tree.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "higher_kinded"
+  tree_map tree_fold tree_sum tree_size
+  hk_map map_option
+  test_tree test_tree_sum test_tree_size test_tree_map
+  test_hk_option test_hk_tree.

--- a/tests/wip/higher_kinded/higher_kinded.cpp
+++ b/tests/wip/higher_kinded/higher_kinded.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <higher_kinded.h>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>

--- a/tests/wip/higher_kinded/higher_kinded.h
+++ b/tests/wip/higher_kinded/higher_kinded.h
@@ -1,0 +1,157 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+template <typename T1, typename T2, typename T3,
+          MapsTo<T1, std::function<std::any(std::any)>, T1> F0,
+          MapsTo<T3, T2> F1>
+T1 hk_map(F0 &&map_f, F1 &&f, const T1 x) {
+  return map_f("dummy", "dummy", f, x);
+}
+
+struct Tree {
+  template <typename A> struct tree {
+  public:
+    struct Leaf {
+      A _a0;
+    };
+    struct Branch {
+      std::shared_ptr<Tree::tree<A>> _a0;
+      std::shared_ptr<Tree::tree<A>> _a1;
+    };
+    using variant_t = std::variant<Leaf, Branch>;
+
+  private:
+    variant_t v_;
+    explicit tree(Leaf _v) : v_(std::move(_v)) {}
+    explicit tree(Branch _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Tree::tree<A>> Leaf_(A a0) {
+        return std::shared_ptr<Tree::tree<A>>(new Tree::tree<A>(Leaf{a0}));
+      }
+      static std::shared_ptr<Tree::tree<A>>
+      Branch_(const std::shared_ptr<Tree::tree<A>> &a0,
+              const std::shared_ptr<Tree::tree<A>> &a1) {
+        return std::shared_ptr<Tree::tree<A>>(
+            new Tree::tree<A>(Branch{a0, a1}));
+      }
+      static std::unique_ptr<Tree::tree<A>> Leaf_uptr(A a0) {
+        return std::unique_ptr<Tree::tree<A>>(new Tree::tree<A>(Leaf{a0}));
+      }
+      static std::unique_ptr<Tree::tree<A>>
+      Branch_uptr(const std::shared_ptr<Tree::tree<A>> &a0,
+                  const std::shared_ptr<Tree::tree<A>> &a1) {
+        return std::unique_ptr<Tree::tree<A>>(
+            new Tree::tree<A>(Branch{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    template <typename T2, MapsTo<T2, A> F0>
+    std::shared_ptr<Tree::tree<T2>> tree_map(F0 &&f) const {
+      return std::visit(
+          Overloaded{[&](const typename Tree::tree<A>::Leaf _args)
+                         -> std::shared_ptr<Tree::tree<T2>> {
+                       A x = _args._a0;
+                       return Tree::tree<T2>::ctor::Leaf_(f(x));
+                     },
+                     [&](const typename Tree::tree<A>::Branch _args)
+                         -> std::shared_ptr<Tree::tree<T2>> {
+                       std::shared_ptr<Tree::tree<A>> l = _args._a0;
+                       std::shared_ptr<Tree::tree<A>> r = _args._a1;
+                       return Tree::tree<T2>::ctor::Branch_(
+                           std::move(l)->tree_map(f),
+                           std::move(r)->tree_map(f));
+                     }},
+          this->v());
+    }
+    template <typename T2, MapsTo<T2, A> F0, MapsTo<T2, T2, T2> F1>
+    T2 tree_fold(F0 &&leaf_f, F1 &&branch_f) const {
+      return std::visit(
+          Overloaded{[&](const typename Tree::tree<A>::Leaf _args) -> auto {
+                       A x = _args._a0;
+                       return leaf_f(x);
+                     },
+                     [&](const typename Tree::tree<A>::Branch _args) -> auto {
+                       std::shared_ptr<Tree::tree<A>> l = _args._a0;
+                       std::shared_ptr<Tree::tree<A>> r = _args._a1;
+                       return branch_f(
+                           std::move(l)->tree_fold(leaf_f, branch_f),
+                           std::move(r)->tree_fold(leaf_f, branch_f));
+                     }},
+          this->v());
+    }
+    unsigned int tree_sum() const {
+      return this->tree_fold(
+          [](unsigned int x) { return x; },
+          [](const unsigned int _x0, const unsigned int _x1) {
+            return (_x0 + _x1);
+          });
+    }
+    unsigned int tree_size() const {
+      return this->tree_fold(
+          [](A _x) { return (0 + 1); },
+          [](const unsigned int _x0, const unsigned int _x1) {
+            return (_x0 + _x1);
+          });
+    }
+  };
+};
+
+template <typename T1, typename T2, MapsTo<T2, T1> F0>
+std::optional<T2> map_option(F0 &&f, const std::optional<T1> o) {
+  if (o.has_value()) {
+    T1 x = *o;
+    return std::make_optional<T2>(f(x));
+  } else {
+    return std::nullopt;
+  }
+}
+
+const std::shared_ptr<Tree::tree<unsigned int>> test_tree =
+    Tree::tree<unsigned int>::ctor::Branch_(
+        Tree::tree<unsigned int>::ctor::Leaf_((0 + 1)),
+        Tree::tree<unsigned int>::ctor::Branch_(
+            Tree::tree<unsigned int>::ctor::Leaf_(((0 + 1) + 1)),
+            Tree::tree<unsigned int>::ctor::Leaf_((((0 + 1) + 1) + 1))));
+
+const unsigned int test_tree_sum = test_tree->tree_sum();
+
+const unsigned int test_tree_size = test_tree->tree_size();
+
+const std::shared_ptr<Tree::tree<unsigned int>> test_tree_map =
+    test_tree->tree_map([](unsigned int n) { return (n * ((0 + 1) + 1)); });
+
+const std::optional<unsigned int> test_hk_option =
+    hk_map<unsigned int, unsigned int>(
+        [](void) { return map_option; }(),
+        [](unsigned int n) { return (n + (0 + 1)); },
+        std::make_optional<unsigned int>((((((0 + 1) + 1) + 1) + 1) + 1)));
+
+const std::shared_ptr<Tree::tree<unsigned int>> test_hk_tree =
+    hk_map<unsigned int, unsigned int>(
+        [](void) { return this->tree_map(); }(),
+        [](unsigned int n) {
+          return (n + ((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
+                       1));
+        },
+        test_tree);

--- a/tests/wip/higher_kinded/higher_kinded.t.cpp
+++ b/tests/wip/higher_kinded/higher_kinded.t.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "higher_kinded.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: tree_sum
+    {
+        ASSERT(test_tree_sum == 6);  // 1 + 2 + 3
+        std::cout << "Test 1 (tree_sum): PASSED" << std::endl;
+    }
+
+    // Test 2: tree_size
+    {
+        ASSERT(test_tree_size == 3);
+        std::cout << "Test 2 (tree_size): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll higher_kinded tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/large_mutual/LargeMutual.v
+++ b/tests/wip/large_mutual/LargeMutual.v
@@ -1,0 +1,78 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Large mutual inductives — 5+ types defined together. *)
+
+From Stdlib Require Import Nat Bool List.
+Import ListNotations.
+
+(* === 5-way mutual inductive: simple expression language === *)
+
+Inductive stmt : Type :=
+  | SAssign : nat -> expr -> stmt
+  | SSeq : stmt -> stmt -> stmt
+  | SIf : bexpr -> stmt -> stmt -> stmt
+  | SWhile : bexpr -> stmt -> stmt
+  | SSkip : stmt
+with expr : Type :=
+  | ENum : nat -> expr
+  | EVar : nat -> expr
+  | EAdd : expr -> expr -> expr
+  | EMul : expr -> expr -> expr
+  | ECond : bexpr -> expr -> expr -> expr
+with bexpr : Type :=
+  | BTrue : bexpr
+  | BFalse : bexpr
+  | BEq : expr -> expr -> bexpr
+  | BLt : expr -> expr -> bexpr
+  | BAnd : bexpr -> bexpr -> bexpr
+  | BOr : bexpr -> bexpr -> bexpr
+  | BNot : bexpr -> bexpr.
+
+(* === Mutual recursive functions over the 3-way mutual inductive === *)
+
+Fixpoint expr_size (e : expr) : nat :=
+  match e with
+  | ENum _ => 1
+  | EVar _ => 1
+  | EAdd l r => S (expr_size l + expr_size r)
+  | EMul l r => S (expr_size l + expr_size r)
+  | ECond b t f => S (bexpr_size b + expr_size t + expr_size f)
+  end
+with bexpr_size (b : bexpr) : nat :=
+  match b with
+  | BTrue => 1
+  | BFalse => 1
+  | BEq l r => S (expr_size l + expr_size r)
+  | BLt l r => S (expr_size l + expr_size r)
+  | BAnd l r => S (bexpr_size l + bexpr_size r)
+  | BOr l r => S (bexpr_size l + bexpr_size r)
+  | BNot b0 => S (bexpr_size b0)
+  end.
+
+Fixpoint stmt_size (s : stmt) : nat :=
+  match s with
+  | SAssign _ e => S (expr_size e)
+  | SSeq s1 s2 => S (stmt_size s1 + stmt_size s2)
+  | SIf b s1 s2 => S (bexpr_size b + stmt_size s1 + stmt_size s2)
+  | SWhile b body => S (bexpr_size b + stmt_size body)
+  | SSkip => 1
+  end.
+
+(* === Test values === *)
+
+Definition test_expr : expr := EAdd (ENum 1) (EMul (ENum 2) (ENum 3)).
+Definition test_bexpr : bexpr := BAnd (BEq (EVar 0) (ENum 5)) (BLt (EVar 1) (ENum 10)).
+Definition test_stmt : stmt :=
+  SSeq (SAssign 0 (ENum 42))
+       (SIf (BEq (EVar 0) (ENum 42)) SSkip (SAssign 0 (ENum 0))).
+
+Definition test_expr_size : nat := expr_size test_expr.
+Definition test_bexpr_size : nat := bexpr_size test_bexpr.
+Definition test_stmt_size : nat := stmt_size test_stmt.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "large_mutual"
+  expr_size bexpr_size stmt_size
+  test_expr test_bexpr test_stmt
+  test_expr_size test_bexpr_size test_stmt_size.

--- a/tests/wip/large_mutual/large_mutual.cpp
+++ b/tests/wip/large_mutual/large_mutual.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <large_mutual.h>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>

--- a/tests/wip/large_mutual/large_mutual.h
+++ b/tests/wip/large_mutual/large_mutual.h
@@ -1,0 +1,516 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct stmt;
+struct expr;
+struct bexpr;
+struct Stmt {
+  struct stmt {
+  public:
+    struct SAssign {
+      unsigned int _a0;
+      std::shared_ptr<Expr::expr> _a1;
+    };
+    struct SSeq {
+      std::shared_ptr<Stmt::stmt> _a0;
+      std::shared_ptr<Stmt::stmt> _a1;
+    };
+    struct SIf {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+      std::shared_ptr<Stmt::stmt> _a1;
+      std::shared_ptr<Stmt::stmt> _a2;
+    };
+    struct SWhile {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+      std::shared_ptr<Stmt::stmt> _a1;
+    };
+    struct SSkip {};
+    using variant_t = std::variant<SAssign, SSeq, SIf, SWhile, SSkip>;
+
+  private:
+    variant_t v_;
+    explicit stmt(SAssign _v) : v_(std::move(_v)) {}
+    explicit stmt(SSeq _v) : v_(std::move(_v)) {}
+    explicit stmt(SIf _v) : v_(std::move(_v)) {}
+    explicit stmt(SWhile _v) : v_(std::move(_v)) {}
+    explicit stmt(SSkip _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Stmt::stmt>
+      SAssign_(unsigned int a0, const std::shared_ptr<Expr::expr> &a1) {
+        return std::shared_ptr<Stmt::stmt>(new Stmt::stmt(SAssign{a0, a1}));
+      }
+      static std::shared_ptr<Stmt::stmt>
+      SSeq_(const std::shared_ptr<Stmt::stmt> &a0,
+            const std::shared_ptr<Stmt::stmt> &a1) {
+        return std::shared_ptr<Stmt::stmt>(new Stmt::stmt(SSeq{a0, a1}));
+      }
+      static std::shared_ptr<Stmt::stmt>
+      SIf_(const std::shared_ptr<Bexpr::bexpr> &a0,
+           const std::shared_ptr<Stmt::stmt> &a1,
+           const std::shared_ptr<Stmt::stmt> &a2) {
+        return std::shared_ptr<Stmt::stmt>(new Stmt::stmt(SIf{a0, a1, a2}));
+      }
+      static std::shared_ptr<Stmt::stmt>
+      SWhile_(const std::shared_ptr<Bexpr::bexpr> &a0,
+              const std::shared_ptr<Stmt::stmt> &a1) {
+        return std::shared_ptr<Stmt::stmt>(new Stmt::stmt(SWhile{a0, a1}));
+      }
+      static std::shared_ptr<Stmt::stmt> SSkip_() {
+        return std::shared_ptr<Stmt::stmt>(new Stmt::stmt(SSkip{}));
+      }
+      static std::unique_ptr<Stmt::stmt>
+      SAssign_uptr(unsigned int a0, const std::shared_ptr<Expr::expr> &a1) {
+        return std::unique_ptr<Stmt::stmt>(new Stmt::stmt(SAssign{a0, a1}));
+      }
+      static std::unique_ptr<Stmt::stmt>
+      SSeq_uptr(const std::shared_ptr<Stmt::stmt> &a0,
+                const std::shared_ptr<Stmt::stmt> &a1) {
+        return std::unique_ptr<Stmt::stmt>(new Stmt::stmt(SSeq{a0, a1}));
+      }
+      static std::unique_ptr<Stmt::stmt>
+      SIf_uptr(const std::shared_ptr<Bexpr::bexpr> &a0,
+               const std::shared_ptr<Stmt::stmt> &a1,
+               const std::shared_ptr<Stmt::stmt> &a2) {
+        return std::unique_ptr<Stmt::stmt>(new Stmt::stmt(SIf{a0, a1, a2}));
+      }
+      static std::unique_ptr<Stmt::stmt>
+      SWhile_uptr(const std::shared_ptr<Bexpr::bexpr> &a0,
+                  const std::shared_ptr<Stmt::stmt> &a1) {
+        return std::unique_ptr<Stmt::stmt>(new Stmt::stmt(SWhile{a0, a1}));
+      }
+      static std::unique_ptr<Stmt::stmt> SSkip_uptr() {
+        return std::unique_ptr<Stmt::stmt>(new Stmt::stmt(SSkip{}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    unsigned int stmt_size() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Stmt::stmt::SAssign _args) -> unsigned int {
+                std::shared_ptr<Expr::expr> e = _args._a1;
+                return (std::move(e)->expr_size() + 1);
+              },
+              [](const typename Stmt::stmt::SSeq _args) -> unsigned int {
+                std::shared_ptr<Stmt::stmt> s1 = _args._a0;
+                std::shared_ptr<Stmt::stmt> s2 = _args._a1;
+                return (
+                    (std::move(s1)->stmt_size() + std::move(s2)->stmt_size()) +
+                    1);
+              },
+              [](const typename Stmt::stmt::SIf _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> b = _args._a0;
+                std::shared_ptr<Stmt::stmt> s1 = _args._a1;
+                std::shared_ptr<Stmt::stmt> s2 = _args._a2;
+                return (
+                    ((std::move(b)->bexpr_size() + std::move(s1)->stmt_size()) +
+                     std::move(s2)->stmt_size()) +
+                    1);
+              },
+              [](const typename Stmt::stmt::SWhile _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> b = _args._a0;
+                std::shared_ptr<Stmt::stmt> body = _args._a1;
+                return ((std::move(b)->bexpr_size() +
+                         std::move(body)->stmt_size()) +
+                        1);
+              },
+              [](const typename Stmt::stmt::SSkip _args) -> unsigned int {
+                return (0 + 1);
+              }},
+          this->v());
+    }
+  };
+};
+struct Expr {
+  struct expr {
+  public:
+    struct ENum {
+      unsigned int _a0;
+    };
+    struct EVar {
+      unsigned int _a0;
+    };
+    struct EAdd {
+      std::shared_ptr<Expr::expr> _a0;
+      std::shared_ptr<Expr::expr> _a1;
+    };
+    struct EMul {
+      std::shared_ptr<Expr::expr> _a0;
+      std::shared_ptr<Expr::expr> _a1;
+    };
+    struct ECond {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+      std::shared_ptr<Expr::expr> _a1;
+      std::shared_ptr<Expr::expr> _a2;
+    };
+    using variant_t = std::variant<ENum, EVar, EAdd, EMul, ECond>;
+
+  private:
+    variant_t v_;
+    explicit expr(ENum _v) : v_(std::move(_v)) {}
+    explicit expr(EVar _v) : v_(std::move(_v)) {}
+    explicit expr(EAdd _v) : v_(std::move(_v)) {}
+    explicit expr(EMul _v) : v_(std::move(_v)) {}
+    explicit expr(ECond _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Expr::expr> ENum_(unsigned int a0) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(ENum{a0}));
+      }
+      static std::shared_ptr<Expr::expr> EVar_(unsigned int a0) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(EVar{a0}));
+      }
+      static std::shared_ptr<Expr::expr>
+      EAdd_(const std::shared_ptr<Expr::expr> &a0,
+            const std::shared_ptr<Expr::expr> &a1) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(EAdd{a0, a1}));
+      }
+      static std::shared_ptr<Expr::expr>
+      EMul_(const std::shared_ptr<Expr::expr> &a0,
+            const std::shared_ptr<Expr::expr> &a1) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(EMul{a0, a1}));
+      }
+      static std::shared_ptr<Expr::expr>
+      ECond_(const std::shared_ptr<Bexpr::bexpr> &a0,
+             const std::shared_ptr<Expr::expr> &a1,
+             const std::shared_ptr<Expr::expr> &a2) {
+        return std::shared_ptr<Expr::expr>(new Expr::expr(ECond{a0, a1, a2}));
+      }
+      static std::unique_ptr<Expr::expr> ENum_uptr(unsigned int a0) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(ENum{a0}));
+      }
+      static std::unique_ptr<Expr::expr> EVar_uptr(unsigned int a0) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(EVar{a0}));
+      }
+      static std::unique_ptr<Expr::expr>
+      EAdd_uptr(const std::shared_ptr<Expr::expr> &a0,
+                const std::shared_ptr<Expr::expr> &a1) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(EAdd{a0, a1}));
+      }
+      static std::unique_ptr<Expr::expr>
+      EMul_uptr(const std::shared_ptr<Expr::expr> &a0,
+                const std::shared_ptr<Expr::expr> &a1) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(EMul{a0, a1}));
+      }
+      static std::unique_ptr<Expr::expr>
+      ECond_uptr(const std::shared_ptr<Bexpr::bexpr> &a0,
+                 const std::shared_ptr<Expr::expr> &a1,
+                 const std::shared_ptr<Expr::expr> &a2) {
+        return std::unique_ptr<Expr::expr>(new Expr::expr(ECond{a0, a1, a2}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    unsigned int expr_size() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Expr::expr::ENum _args) -> unsigned int {
+                return (0 + 1);
+              },
+              [](const typename Expr::expr::EVar _args) -> unsigned int {
+                return (0 + 1);
+              },
+              [](const typename Expr::expr::EAdd _args) -> unsigned int {
+                std::shared_ptr<Expr::expr> l = _args._a0;
+                std::shared_ptr<Expr::expr> r = _args._a1;
+                return (
+                    (std::move(l)->expr_size() + std::move(r)->expr_size()) +
+                    1);
+              },
+              [](const typename Expr::expr::EMul _args) -> unsigned int {
+                std::shared_ptr<Expr::expr> l = _args._a0;
+                std::shared_ptr<Expr::expr> r = _args._a1;
+                return (
+                    (std::move(l)->expr_size() + std::move(r)->expr_size()) +
+                    1);
+              },
+              [](const typename Expr::expr::ECond _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> b = _args._a0;
+                std::shared_ptr<Expr::expr> t = _args._a1;
+                std::shared_ptr<Expr::expr> f = _args._a2;
+                return (
+                    ((std::move(b)->bexpr_size() + std::move(t)->expr_size()) +
+                     std::move(f)->expr_size()) +
+                    1);
+              }},
+          this->v());
+    }
+  };
+};
+struct Bexpr {
+  struct bexpr {
+  public:
+    struct BTrue {};
+    struct BFalse {};
+    struct BEq {
+      std::shared_ptr<Expr::expr> _a0;
+      std::shared_ptr<Expr::expr> _a1;
+    };
+    struct BLt {
+      std::shared_ptr<Expr::expr> _a0;
+      std::shared_ptr<Expr::expr> _a1;
+    };
+    struct BAnd {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+      std::shared_ptr<Bexpr::bexpr> _a1;
+    };
+    struct BOr {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+      std::shared_ptr<Bexpr::bexpr> _a1;
+    };
+    struct BNot {
+      std::shared_ptr<Bexpr::bexpr> _a0;
+    };
+    using variant_t = std::variant<BTrue, BFalse, BEq, BLt, BAnd, BOr, BNot>;
+
+  private:
+    variant_t v_;
+    explicit bexpr(BTrue _v) : v_(std::move(_v)) {}
+    explicit bexpr(BFalse _v) : v_(std::move(_v)) {}
+    explicit bexpr(BEq _v) : v_(std::move(_v)) {}
+    explicit bexpr(BLt _v) : v_(std::move(_v)) {}
+    explicit bexpr(BAnd _v) : v_(std::move(_v)) {}
+    explicit bexpr(BOr _v) : v_(std::move(_v)) {}
+    explicit bexpr(BNot _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Bexpr::bexpr> BTrue_() {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BTrue{}));
+      }
+      static std::shared_ptr<Bexpr::bexpr> BFalse_() {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BFalse{}));
+      }
+      static std::shared_ptr<Bexpr::bexpr>
+      BEq_(const std::shared_ptr<Expr::expr> &a0,
+           const std::shared_ptr<Expr::expr> &a1) {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BEq{a0, a1}));
+      }
+      static std::shared_ptr<Bexpr::bexpr>
+      BLt_(const std::shared_ptr<Expr::expr> &a0,
+           const std::shared_ptr<Expr::expr> &a1) {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BLt{a0, a1}));
+      }
+      static std::shared_ptr<Bexpr::bexpr>
+      BAnd_(const std::shared_ptr<Bexpr::bexpr> &a0,
+            const std::shared_ptr<Bexpr::bexpr> &a1) {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BAnd{a0, a1}));
+      }
+      static std::shared_ptr<Bexpr::bexpr>
+      BOr_(const std::shared_ptr<Bexpr::bexpr> &a0,
+           const std::shared_ptr<Bexpr::bexpr> &a1) {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BOr{a0, a1}));
+      }
+      static std::shared_ptr<Bexpr::bexpr>
+      BNot_(const std::shared_ptr<Bexpr::bexpr> &a0) {
+        return std::shared_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BNot{a0}));
+      }
+      static std::unique_ptr<Bexpr::bexpr> BTrue_uptr() {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BTrue{}));
+      }
+      static std::unique_ptr<Bexpr::bexpr> BFalse_uptr() {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BFalse{}));
+      }
+      static std::unique_ptr<Bexpr::bexpr>
+      BEq_uptr(const std::shared_ptr<Expr::expr> &a0,
+               const std::shared_ptr<Expr::expr> &a1) {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BEq{a0, a1}));
+      }
+      static std::unique_ptr<Bexpr::bexpr>
+      BLt_uptr(const std::shared_ptr<Expr::expr> &a0,
+               const std::shared_ptr<Expr::expr> &a1) {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BLt{a0, a1}));
+      }
+      static std::unique_ptr<Bexpr::bexpr>
+      BAnd_uptr(const std::shared_ptr<Bexpr::bexpr> &a0,
+                const std::shared_ptr<Bexpr::bexpr> &a1) {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BAnd{a0, a1}));
+      }
+      static std::unique_ptr<Bexpr::bexpr>
+      BOr_uptr(const std::shared_ptr<Bexpr::bexpr> &a0,
+               const std::shared_ptr<Bexpr::bexpr> &a1) {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BOr{a0, a1}));
+      }
+      static std::unique_ptr<Bexpr::bexpr>
+      BNot_uptr(const std::shared_ptr<Bexpr::bexpr> &a0) {
+        return std::unique_ptr<Bexpr::bexpr>(new Bexpr::bexpr(BNot{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    unsigned int bexpr_size() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Bexpr::bexpr::BTrue _args) -> unsigned int {
+                return (0 + 1);
+              },
+              [](const typename Bexpr::bexpr::BFalse _args) -> unsigned int {
+                return (0 + 1);
+              },
+              [](const typename Bexpr::bexpr::BEq _args) -> unsigned int {
+                std::shared_ptr<Expr::expr> l = _args._a0;
+                std::shared_ptr<Expr::expr> r = _args._a1;
+                return (
+                    (std::move(l)->expr_size() + std::move(r)->expr_size()) +
+                    1);
+              },
+              [](const typename Bexpr::bexpr::BLt _args) -> unsigned int {
+                std::shared_ptr<Expr::expr> l = _args._a0;
+                std::shared_ptr<Expr::expr> r = _args._a1;
+                return (
+                    (std::move(l)->expr_size() + std::move(r)->expr_size()) +
+                    1);
+              },
+              [](const typename Bexpr::bexpr::BAnd _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> l = _args._a0;
+                std::shared_ptr<Bexpr::bexpr> r = _args._a1;
+                return (
+                    (std::move(l)->bexpr_size() + std::move(r)->bexpr_size()) +
+                    1);
+              },
+              [](const typename Bexpr::bexpr::BOr _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> l = _args._a0;
+                std::shared_ptr<Bexpr::bexpr> r = _args._a1;
+                return (
+                    (std::move(l)->bexpr_size() + std::move(r)->bexpr_size()) +
+                    1);
+              },
+              [](const typename Bexpr::bexpr::BNot _args) -> unsigned int {
+                std::shared_ptr<Bexpr::bexpr> b0 = _args._a0;
+                return (std::move(b0)->bexpr_size() + 1);
+              }},
+          this->v());
+    }
+  };
+};
+
+const std::shared_ptr<Expr::expr> test_expr = Expr::expr::ctor::EAdd_(
+    Expr::expr::ctor::ENum_((0 + 1)),
+    Expr::expr::ctor::EMul_(Expr::expr::ctor::ENum_(((0 + 1) + 1)),
+                            Expr::expr::ctor::ENum_((((0 + 1) + 1) + 1))));
+
+const std::shared_ptr<Bexpr::bexpr> test_bexpr = Bexpr::bexpr::ctor::BAnd_(
+    Bexpr::bexpr::ctor::BEq_(
+        Expr::expr::ctor::EVar_(0),
+        Expr::expr::ctor::ENum_((((((0 + 1) + 1) + 1) + 1) + 1))),
+    Bexpr::bexpr::ctor::BLt_(
+        Expr::expr::ctor::EVar_((0 + 1)),
+        Expr::expr::ctor::ENum_(
+            ((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1))));
+
+const std::shared_ptr<Stmt::stmt> test_stmt = Stmt::stmt::ctor::SSeq_(
+    Stmt::stmt::ctor::SAssign_(
+        0, Expr::expr::ctor::ENum_(
+               ((((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) +
+                                                     1) +
+                                                    1) +
+                                                   1) +
+                                                  1) +
+                                                 1) +
+                                                1) +
+                                               1) +
+                                              1) +
+                                             1) +
+                                            1) +
+                                           1) +
+                                          1) +
+                                         1) +
+                                        1) +
+                                       1) +
+                                      1) +
+                                     1) +
+                                    1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1))),
+    Stmt::stmt::ctor::SIf_(
+        Bexpr::bexpr::ctor::BEq_(
+            Expr::expr::ctor::EVar_(0),
+            Expr::expr::ctor::ENum_((
+                (((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) +
+                                                     1) +
+                                                    1) +
+                                                   1) +
+                                                  1) +
+                                                 1) +
+                                                1) +
+                                               1) +
+                                              1) +
+                                             1) +
+                                            1) +
+                                           1) +
+                                          1) +
+                                         1) +
+                                        1) +
+                                       1) +
+                                      1) +
+                                     1) +
+                                    1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1))),
+        Stmt::stmt::ctor::SSkip_(),
+        Stmt::stmt::ctor::SAssign_(0, Expr::expr::ctor::ENum_(0))));
+
+const unsigned int test_expr_size = test_expr->expr_size();
+
+const unsigned int test_bexpr_size = test_bexpr->bexpr_size();
+
+const unsigned int test_stmt_size = test_stmt->stmt_size();

--- a/tests/wip/large_mutual/large_mutual.t.cpp
+++ b/tests/wip/large_mutual/large_mutual.t.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "large_mutual.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: expr_size
+    {
+        ASSERT(test_expr_size == 5);  // EAdd(ENum, EMul(ENum, ENum)) = 1+1+1+1+1
+        std::cout << "Test 1 (expr_size): PASSED" << std::endl;
+    }
+
+    // Test 2: bexpr_size
+    {
+        ASSERT(test_bexpr_size == 7);  // BAnd(BEq(EVar,ENum), BLt(EVar,ENum))
+        std::cout << "Test 2 (bexpr_size): PASSED" << std::endl;
+    }
+
+    // Test 3: stmt_size
+    {
+        ASSERT(test_stmt_size > 0);
+        std::cout << "Test 3 (stmt_size): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll large_mutual tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/prim_float/PrimFloat.v
+++ b/tests/wip/prim_float/PrimFloat.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Primitive floats (Float64). *)
+(* NOTE: Float operations (add, mul, sub, div, eqb, ltb, leb) *)
+(* all crash Crane with Translation.TODO — they are axioms *)
+(* needing realization. Only constants extract. *)
+
+From Stdlib Require Import PrimFloat.
+
+Definition f_zero : float := 0%float.
+Definition f_one : float := 1%float.
+Definition f_pi : float := 3.14159%float.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std.
+Crane Extraction "prim_float"
+  f_zero f_one f_pi.

--- a/tests/wip/rec_record/RecRecord.v
+++ b/tests/wip/rec_record/RecRecord.v
@@ -1,0 +1,75 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: Recursive records — self-referential fields. *)
+
+From Stdlib Require Import Nat Bool List.
+Import ListNotations.
+
+(* === Recursive record: linked list as record === *)
+
+Inductive rlist (A : Type) : Type :=
+  | rnil : rlist A
+  | rcons : A -> rlist A -> rlist A.
+
+Arguments rnil {A}.
+Arguments rcons {A} _ _.
+
+Inductive RNode := mkRNode {
+  rn_value : nat;
+  rn_next : option RNode
+}.
+
+(* === Mutually referencing records === *)
+
+Record Employee := mkEmployee {
+  emp_name : nat;  (* using nat as ID *)
+  emp_dept : nat
+}.
+
+Record Department := mkDepartment {
+  dept_id : nat;
+  dept_head : Employee;
+  dept_size : nat
+}.
+
+(* === Recursive function over self-referential structure === *)
+
+Fixpoint rlist_length {A : Type} (l : rlist A) : nat :=
+  match l with
+  | rnil => 0
+  | rcons _ rest => S (rlist_length rest)
+  end.
+
+Fixpoint rlist_sum (l : rlist nat) : nat :=
+  match l with
+  | rnil => 0
+  | rcons x rest => x + rlist_sum rest
+  end.
+
+Fixpoint rnode_depth (r : RNode) : nat :=
+  match rn_next r with
+  | None => 1
+  | Some next => S (rnode_depth next)
+  end.
+
+(* === Test values === *)
+
+Definition test_rlist : rlist nat := rcons 1 (rcons 2 (rcons 3 rnil)).
+Definition test_rlist_len : nat := rlist_length test_rlist.
+Definition test_rlist_sum : nat := rlist_sum test_rlist.
+
+Definition test_rnode : RNode :=
+  mkRNode 1 (Some (mkRNode 2 (Some (mkRNode 3 None)))).
+Definition test_rnode_depth : nat := rnode_depth test_rnode.
+
+Definition test_emp : Employee := mkEmployee 42 7.
+Definition test_dept : Department := mkDepartment 7 test_emp 50.
+Definition test_dept_head_name : nat := emp_name (dept_head test_dept).
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "rec_record"
+  rlist_length rlist_sum rnode_depth
+  test_rlist test_rlist_len test_rlist_sum
+  test_rnode test_rnode_depth
+  test_emp test_dept test_dept_head_name.

--- a/tests/wip/rec_record/rec_record.cpp
+++ b/tests/wip/rec_record/rec_record.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <rec_record.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>

--- a/tests/wip/rec_record/rec_record.h
+++ b/tests/wip/rec_record/rec_record.h
@@ -1,0 +1,165 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct Rlist {
+  template <typename A> struct rlist {
+  public:
+    struct rnil {};
+    struct rcons {
+      A _a0;
+      std::shared_ptr<Rlist::rlist<A>> _a1;
+    };
+    using variant_t = std::variant<rnil, rcons>;
+
+  private:
+    variant_t v_;
+    explicit rlist(rnil _v) : v_(std::move(_v)) {}
+    explicit rlist(rcons _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<Rlist::rlist<A>> rnil_() {
+        return std::shared_ptr<Rlist::rlist<A>>(new Rlist::rlist<A>(rnil{}));
+      }
+      static std::shared_ptr<Rlist::rlist<A>>
+      rcons_(A a0, const std::shared_ptr<Rlist::rlist<A>> &a1) {
+        return std::shared_ptr<Rlist::rlist<A>>(
+            new Rlist::rlist<A>(rcons{a0, a1}));
+      }
+      static std::unique_ptr<Rlist::rlist<A>> rnil_uptr() {
+        return std::unique_ptr<Rlist::rlist<A>>(new Rlist::rlist<A>(rnil{}));
+      }
+      static std::unique_ptr<Rlist::rlist<A>>
+      rcons_uptr(A a0, const std::shared_ptr<Rlist::rlist<A>> &a1) {
+        return std::unique_ptr<Rlist::rlist<A>>(
+            new Rlist::rlist<A>(rcons{a0, a1}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+    unsigned int rlist_length() const {
+      return std::visit(
+          Overloaded{
+              [](const typename Rlist::rlist<A>::rnil _args) -> unsigned int {
+                return 0;
+              },
+              [](const typename Rlist::rlist<A>::rcons _args) -> unsigned int {
+                std::shared_ptr<Rlist::rlist<A>> rest = _args._a1;
+                return (std::move(rest)->rlist_length() + 1);
+              }},
+          this->v());
+    }
+    unsigned int rlist_sum() const {
+      return std::visit(
+          Overloaded{[](const typename Rlist::rlist<unsigned int>::rnil _args)
+                         -> unsigned int { return 0; },
+                     [](const typename Rlist::rlist<unsigned int>::rcons _args)
+                         -> unsigned int {
+                       unsigned int x = _args._a0;
+                       std::shared_ptr<Rlist::rlist<unsigned int>> rest =
+                           _args._a1;
+                       return (std::move(x) + std::move(rest)->rlist_sum());
+                     }},
+          this->v());
+    }
+  };
+};
+
+struct RNode {
+  unsigned int rn_value;
+  std::optional<std::shared_ptr<RNode>> rn_next;
+};
+
+struct Employee {
+  unsigned int emp_name;
+  unsigned int emp_dept;
+};
+
+struct Department {
+  unsigned int dept_id;
+  std::shared_ptr<Employee> dept_head;
+  unsigned int dept_size;
+};
+
+const std::shared_ptr<Rlist::rlist<unsigned int>> test_rlist =
+    Rlist::rlist<unsigned int>::ctor::rcons_(
+        (0 + 1),
+        Rlist::rlist<unsigned int>::ctor::rcons_(
+            ((0 + 1) + 1), Rlist::rlist<unsigned int>::ctor::rcons_(
+                               (((0 + 1) + 1) + 1),
+                               Rlist::rlist<unsigned int>::ctor::rnil_())));
+
+const unsigned int test_rlist_len = test_rlist->rlist_length();
+
+const unsigned int test_rlist_sum = test_rlist->rlist_sum();
+
+const std::shared_ptr<RNode> test_rnode = std::make_shared<RNode>(RNode{
+    (0 + 1),
+    std::make_optional<std::shared_ptr<RNode>>(std::make_shared<RNode>(RNode{
+        ((0 + 1) + 1),
+        std::make_optional<std::shared_ptr<RNode>>(std::make_shared<RNode>(
+            RNode{(((0 + 1) + 1) + 1), std::nullopt}))}))});
+
+const unsigned int test_rnode_depth = test_rnode->rnode_depth();
+
+const std::shared_ptr<Employee> test_emp = std::make_shared<Employee>(Employee{
+    ((((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) +
+                                        1) +
+                                       1) +
+                                      1) +
+                                     1) +
+                                    1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1) +
+               1) +
+              1) +
+             1) +
+            1) +
+           1) +
+          1) +
+         1) +
+        1) +
+       1) +
+      1) +
+     1),
+    (((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1)});
+
+const std::shared_ptr<Department> test_dept = std::make_shared<Department>(Department{(((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1), test_emp, ((((((((((((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)});
+
+const unsigned int test_dept_head_name = test_dept->dept_head->emp_name;

--- a/tests/wip/rec_record/rec_record.t.cpp
+++ b/tests/wip/rec_record/rec_record.t.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "rec_record.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: rlist length
+    {
+        ASSERT(test_rlist_len == 3);
+        std::cout << "Test 1 (rlist_length): PASSED" << std::endl;
+    }
+
+    // Test 2: rlist sum
+    {
+        ASSERT(test_rlist_sum == 6);  // 1 + 2 + 3
+        std::cout << "Test 2 (rlist_sum): PASSED" << std::endl;
+    }
+
+    // Test 3: dept_head_name
+    {
+        ASSERT(test_dept_head_name == 42);
+        std::cout << "Test 3 (dept_head_name): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll rec_record tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/sprop/SProp.v
+++ b/tests/wip/sprop/SProp.v
@@ -1,0 +1,51 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: SProp — strict propositions (proof irrelevance). *)
+
+From Stdlib Require Import Nat Bool.
+
+(* === SProp type === *)
+
+Inductive sTrue : SProp := sI.
+Inductive sFalse : SProp := .
+
+Inductive sAnd (A B : SProp) : SProp :=
+  sconj : A -> B -> sAnd A B.
+
+(* === Squash: erase any Prop to SProp === *)
+
+Inductive Squash (A : Type) : SProp :=
+  squash : A -> Squash A.
+
+(* === Box: computationally relevant wrapper with SProp proof === *)
+
+Record Box (P : SProp) (A : Type) := mkBox {
+  box_proof : P;
+  box_value : A
+}.
+
+Arguments mkBox {P A} _ _.
+Arguments box_value {P A} _.
+
+(* === Functions that carry SProp witnesses === *)
+
+Definition guarded_pred (n : nat) (pf : sTrue) : nat :=
+  match n with
+  | 0 => 0
+  | S m => m
+  end.
+
+Definition safe_div (a b : nat) (pf : sTrue) : nat :=
+  Nat.div a b.
+
+(* === Test values === *)
+
+Definition test_guarded : nat := guarded_pred 5 sI.
+Definition test_box : nat := box_value (mkBox sI 42).
+Definition test_div : nat := safe_div 10 3 sI.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "sprop"
+  guarded_pred safe_div
+  test_guarded test_box test_div.

--- a/tests/wip/sprop/sprop.cpp
+++ b/tests/wip/sprop/sprop.cpp
@@ -1,0 +1,51 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sprop.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+std::pair<unsigned int, unsigned int> divmod(const unsigned int x,
+                                             const unsigned int y,
+                                             const unsigned int q,
+                                             const unsigned int u) {
+  if (x <= 0) {
+    return std::make_pair(std::move(q), std::move(u));
+  } else {
+    unsigned int x_ = x - 1;
+    if (u <= 0) {
+      return divmod(std::move(x_), y, (q + 1), y);
+    } else {
+      unsigned int u_ = u - 1;
+      return divmod(std::move(x_), y, q, std::move(u_));
+    }
+  }
+}
+
+unsigned int div(const unsigned int x, const unsigned int y) {
+  if (y <= 0) {
+    return std::move(y);
+  } else {
+    unsigned int y_ = y - 1;
+    return divmod(x, y_, 0, y_).first;
+  }
+}
+
+unsigned int guarded_pred(const unsigned int n) {
+  if (n <= 0) {
+    return 0;
+  } else {
+    unsigned int m = n - 1;
+    return m;
+  }
+}
+
+unsigned int safe_div(const unsigned int _x0, const unsigned int _x1) {
+  return div(_x0, _x1);
+}

--- a/tests/wip/sprop/sprop.h
+++ b/tests/wip/sprop/sprop.h
@@ -1,0 +1,75 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+std::pair<unsigned int, unsigned int> divmod(const unsigned int x,
+                                             const unsigned int y,
+                                             const unsigned int q,
+                                             const unsigned int u);
+
+unsigned int div(const unsigned int x, const unsigned int y);
+
+unsigned int guarded_pred(const unsigned int n);
+
+unsigned int safe_div(const unsigned int, const unsigned int);
+
+const unsigned int test_guarded = guarded_pred((((((0 + 1) + 1) + 1) + 1) + 1));
+
+const unsigned int test_box =
+    ((((((((((((((((((((((((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) +
+                                        1) +
+                                       1) +
+                                      1) +
+                                     1) +
+                                    1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1) +
+                      1) +
+                     1) +
+                    1) +
+                   1) +
+                  1) +
+                 1) +
+                1) +
+               1) +
+              1) +
+             1) +
+            1) +
+           1) +
+          1) +
+         1) +
+        1) +
+       1) +
+      1) +
+     1);
+
+const unsigned int test_div =
+    safe_div(((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1),
+             (((0 + 1) + 1) + 1));

--- a/tests/wip/sprop/sprop.t.cpp
+++ b/tests/wip/sprop/sprop.t.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "sprop.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: guarded_pred
+    {
+        ASSERT(test_guarded == 4);  // guarded_pred 5 = 4
+        std::cout << "Test 1 (guarded_pred): PASSED" << std::endl;
+    }
+
+    // Test 2: SProp box unboxing
+    {
+        ASSERT(test_box == 42);
+        std::cout << "Test 2 (sbox unbox): PASSED" << std::endl;
+    }
+
+    // Test 3: safe_div
+    {
+        ASSERT(test_div == 3);  // safe_div 10 3 = 3
+        std::cout << "Test 3 (safe_div): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll sprop tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}

--- a/tests/wip/string_match/StringMatch.v
+++ b/tests/wip/string_match/StringMatch.v
@@ -1,0 +1,30 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: PrimString operations. *)
+
+From Stdlib Require Import Nat Bool PrimString PrimInt63.
+
+Definition str_empty : string := ""%pstring.
+Definition str_hello : string := "hello"%pstring.
+Definition str_world : string := "world"%pstring.
+
+Definition str_cat : string := cat "hello " "world".
+
+Definition str_len_empty : int := length ""%pstring.
+Definition str_len_hello : int := length "hello"%pstring.
+
+Definition is_empty (s : string) : bool :=
+  PrimInt63.eqb (length s) 0.
+
+Definition test_empty_true : bool := is_empty "".
+Definition test_empty_false : bool := is_empty "x".
+Definition test_cat : string := cat "foo" "bar".
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std.
+Crane Extraction "string_match"
+  str_empty str_hello str_world str_cat
+  str_len_empty str_len_hello
+  is_empty
+  test_empty_true test_empty_false
+  test_cat.

--- a/tests/wip/string_match/string_match.cpp
+++ b/tests/wip/string_match/string_match.cpp
@@ -1,0 +1,14 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_match.h>
+#include <utility>
+#include <variant>
+
+bool is_empty(const std::string s) { return s.length() == 0; }

--- a/tests/wip/string_match/string_match.h
+++ b/tests/wip/string_match/string_match.h
@@ -1,0 +1,39 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+const std::string str_empty = "";
+
+const std::string str_hello = "hello";
+
+const std::string str_world = "world";
+
+const std::string str_cat = "hello " + "world";
+
+const int str_len_empty = "".length();
+
+const int str_len_hello = "hello".length();
+
+bool is_empty(const std::string s);
+
+const bool test_empty_true = is_empty("");
+
+const bool test_empty_false = is_empty("x");
+
+const std::string test_cat = "foo" + "bar";

--- a/tests/wip/string_match/string_match.t.cpp
+++ b/tests/wip/string_match/string_match.t.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "string_match.h"
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // Test 1: string constants
+    {
+        ASSERT(str_empty == "");
+        ASSERT(str_hello == "hello");
+        std::cout << "Test 1 (string constants): PASSED" << std::endl;
+    }
+
+    // Test 2: is_empty
+    {
+        ASSERT(test_empty_true == true);
+        ASSERT(test_empty_false == false);
+        std::cout << "Test 2 (is_empty): PASSED" << std::endl;
+    }
+
+    // Test 3: concatenation
+    {
+        ASSERT(test_cat == "foobar");
+        std::cout << "Test 3 (concatenation): PASSED" << std::endl;
+    }
+
+    if (testStatus == 0) {
+        std::cout << "\nAll string_match tests passed!" << std::endl;
+    } else {
+        std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+    }
+    return testStatus;
+}


### PR DESCRIPTION
## Summary
8 new wip/ tests covering extraction patterns not in the repo.

| # | Test | Pattern | C++ Result |
|---|------|---------|------------|
| 1 | `acc_rect` | Direct `Acc_rect` / well-founded induction | **PASS** (2/2) |
| 2 | `sprop` | SProp erasure, strict propositions | **PASS** (3/3) |
| 3 | `string_match` | PrimString pattern matching + concat | **FAIL** — `"a" + "b"` on C string literals, `.length()` on `char[]` |
| 4 | `rec_record` | Self-referential record (recursive field) | **FAIL** — `rnode_depth()` not declared as member |
| 5 | `dep_record` | Dependent records (field B depends on field A) | **FAIL** — lambda assigned to `shared_ptr<magma>` |
| 6 | `higher_kinded` | `F : Type -> Type` direct params | **FAIL** — template arg `T2` not deducible, `this` in lambda |
| 7 | `large_mutual` | 5 mutual inductives at once | **FAIL** — forward decl `Expr::expr` used before `Expr` struct defined |
| 8 | `prim_float` | Float64 primitives | **CRASH** — `Translation.TODO` on float axioms |

## Extraction bugs found
1. **PrimString**: generates raw C string literal ops (`"a" + "b"`, `"hello".length()`) instead of `std::string`
2. **Recursive records**: member function `rnode_depth()` not emitted in generated struct
3. **Dependent records**: lambda-to-`shared_ptr` conversion (same class as typeclasses `numOption` bug)
4. **Higher-kinded params**: template arg deduction failure, invalid `this` capture in lambda
5. **Large mutual inductives**: forward declaration ordering — `Expr::expr` referenced before `Expr` struct defined
6. **Float64**: entire float type is unrealized axiom, crashes extraction

## Test plan
- [x] `dune build @tests/wip/acc_rect/runtest` — 2/2 pass
- [x] `dune build @tests/wip/sprop/runtest` — 3/3 pass