### PR TITLE
Fix typos across source, theories, and tests

### DIFF
--- a/src/minicpp.ml
+++ b/src/minicpp.ml
@@ -77,7 +77,7 @@ and cpp_expr =
   | CPPstring of Pstring.t
   | CPPuint   of Uint63.t
   | CPPparray of cpp_expr array * cpp_expr
-(*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace acces (in general, as is not just cpp_expressions)? *)
+(*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace access (in general, as is not just cpp_expressions)? *)
   | CPPrequires of (cpp_type * Id.t) list * (cpp_expr * cpp_constraint) list
   (* requires (T a, T b) { { eqb(a, b) } -> std::same_as<bool> } *)
   | CPPnew of cpp_type * cpp_expr list  (* new Type(args) or new Type{args} *)
@@ -124,7 +124,7 @@ and cpp_field =
   | Fdeleted_ctor
 
 (* C++ type schema.
-   The integer is the number of variable in the schema. *)
+   The integer is the number of variables in the schema. *)
 
 type cpp_schema = int * cpp_type
 

--- a/src/minicpp.mli
+++ b/src/minicpp.mli
@@ -77,7 +77,7 @@ and cpp_expr =
   | CPPstring of Pstring.t
   | CPPuint   of Uint63.t
   | CPPparray of cpp_expr array * cpp_expr
-(*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace acces (in general, as is not just cpp_expressions)? *)
+(*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace access (in general, as is not just cpp_expressions)? *)
   | CPPrequires of (cpp_type * Id.t) list * (cpp_expr * cpp_constraint) list
   (* requires (T a, T b) { { eqb(a, b) } -> std::same_as<bool> } *)
   | CPPnew of cpp_type * cpp_expr list  (* new Type(args) or new Type{args} *)
@@ -124,7 +124,7 @@ and cpp_field =
   | Fdeleted_ctor
 
 (* C++ type schema.
-   The integer is the number of variable in the schema. *)
+   The integer is the number of variables in the schema. *)
 
 type cpp_schema = int * cpp_type
 

--- a/src/miniml.ml
+++ b/src/miniml.ml
@@ -138,7 +138,7 @@ and ml_pattern =
   | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
 
 (* ML type schema.
-   The integer is the number of variable in the schema. *)
+   The integer is the number of variables in the schema. *)
 
 type ml_schema = int * ml_type
 

--- a/src/miniml.mli
+++ b/src/miniml.mli
@@ -138,7 +138,7 @@ and ml_pattern =
   | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
 
 (* ML type schema.
-   The integer is the number of variable in the schema. *)
+   The integer is the number of variables in the schema. *)
 
 type ml_schema = int * ml_type
 

--- a/src/mlutil.ml
+++ b/src/mlutil.ml
@@ -208,7 +208,7 @@ module Mlenv = struct
     | Tglob (_,l,_) -> List.fold_left find_free set l
     | _ -> set
 
-  (* The [free] set of an environment can be outdate after
+  (* The [free] set of an environment can be outdated after
      some unifications. [clean_free] takes care of that. *)
 
   let clean_free mle =
@@ -454,7 +454,7 @@ and eq_ml_branch (id1, _, p1, t1) (id2, _, p2, t2) =
   eq_ml_ast t1 t2
 
 (*s [ast_iter_rel f t] applies [f] on every [MLrel] in t. It takes care
-   of the number of bingings crossed before reaching the [MLrel]. *)
+   of the number of bindings crossed before reaching the [MLrel]. *)
 
 let ast_iter_rel f =
   let rec iter n = function
@@ -676,7 +676,7 @@ let ast_subst e =
 
 (*s Generalized substitution.
    [gen_subst v d t] applies to [t] the substitution coded in the
-   [v] array: [(Rel i)] becomes [v.(i-1)]. [d] is the correction applies
+   [v] array: [(Rel i)] becomes [v.(i-1)]. [d] is the correction applied
    to [Rel] greater than [Array.length v]. *)
 
 let gen_subst v d t =
@@ -1222,7 +1222,7 @@ let rec select_via_bl l args = match l,args with
   | _ -> assert false
 
 (*s [kill_some_lams] removes some head lambdas according to the signature [bl].
-   This list is build on the identifier list model: outermost lambda
+   This list is built on the identifier list model: outermost lambda
    is on the right.
    [Rels] corresponding to removed lambdas are not supposed to occur
    (except maybe in the case of Kimplicit), and

--- a/src/modutil.ml
+++ b/src/modutil.ml
@@ -74,7 +74,7 @@ let struct_iter do_decl do_spec do_mp s =
   List.iter
     (function (_,sel) -> List.iter (se_iter do_decl do_spec do_mp) sel) s
 
-(*s Apply some fonctions upon all references in [ml_type], [ml_ast],
+(*s Apply some functions upon all references in [ml_type], [ml_ast],
   [ml_decl], [ml_spec] and [ml_structure]. *)
 
 type do_ref = GlobRef.t -> unit

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -621,7 +621,7 @@ and gen_expr env (ml_e : ml_ast) : cpp_expr =
       let ty = find_type x in
       let ty = convert_ml_type_to_cpp_type env [] tvars ty in
       (match ty with
-      | Tfun (dom, cod) -> eta_fun env (MLglob (x, tys)) [] (* TODO: cound be only if contains '%' *)
+      | Tfun (dom, cod) -> eta_fun env (MLglob (x, tys)) [] (* TODO: could be only if contains '%' *)
       | _ -> CPPglob (x, List.map (convert_ml_type_to_cpp_type env [] tvars) tys))
   | MLglob (x, tys) ->
       let tvars = get_current_type_vars () in
@@ -2194,7 +2194,7 @@ let gen_dfun n b dom cod ty temps =
       |  (Tmod (TMconst, Tfun (dom, cod))) ->
         (x, Tref (Tref (Tvar (0, Some (Id.of_string ("F" ^ (string_of_int ((List.length ids) - i - 1))))))))
       | _ -> (x, ty)) ids in
-  (* TODO: below is needed for lambdas in recursive positiions, but is badddddd. *)
+  (* TODO: below is needed for lambdas in recursive positions, but is badddddd. *)
   (* let rec_fun_tys = List.map (fun (_,t, _) ->
     match t with
     | TTfun (dom, cod) -> Tref (Tmod (TMconst, Tfun (dom, cod)))

--- a/tests/basics/regexp/Regexp.v
+++ b/tests/basics/regexp/Regexp.v
@@ -450,7 +450,7 @@ Crane Extraction "regexp" Matcher.
 
 - An alternative to our derivative-based matcher is to build one based
   on the list monad.  That is, define an interp function of type
-  [regexp -> list int -> list (list int)] with the intution
+  [regexp -> list int -> list (list int)] with the intuition
   that:
 
    cs2 is in (interp r) (cs1 ++ cs2) iff [[r]] cs1

--- a/tests/monadic/io/IOtest.v
+++ b/tests/monadic/io/IOtest.v
@@ -21,7 +21,7 @@ Module iotest.
     print_endline "what is your name?" ;;
     s2 <- get_line ;;
     print_endline (cat "hello " s2) ;;
-    Ret (cat "I read the name " (cat s2 " frome the command line!")).
+    Ret (cat "I read the name " (cat s2 " from the command line!")).
 
   Definition test5 : IO void :=
     s <- read "file.txt" ;;

--- a/tests/wip/levenshtein/Levenshtein.v
+++ b/tests/wip/levenshtein/Levenshtein.v
@@ -935,7 +935,7 @@ Proof.
   reflexivity.
 Qed.
 
-Theorem levensthein_is_minimal (s t : string) :
+Theorem levenshtein_is_minimal (s t : string) :
   forall (n : nat) (c : chain s t n), levenshtein s t <= n.
 Proof.
   intros n c.

--- a/tests/wip/universe_poly/universe_poly.t.cpp
+++ b/tests/wip/universe_poly/universe_poly.t.cpp
@@ -43,7 +43,7 @@ int main() {
     // Test 3: poly_length
     {
         ASSERT(test_length == 3);
-        std::cout << "Test 5 (poly_length): PASSED" << std::endl;
+        std::cout << "Test 3 (poly_length): PASSED" << std::endl;
     }
 
     if (testStatus == 0) {

--- a/theories/Mapping/ArrayStd.v
+++ b/theories/Mapping/ArrayStd.v
@@ -15,7 +15,7 @@ Local Notation "[ ]" := (nil _) (format "[ ]").
 Local Notation "h :: t" := (cons _ h _ t) (at level 60, right associativity).
 
 (* fix unfolding issue by making it one-constructor inductive type?
-   (i.e. force explicit coersions) *)
+   (i.e. force explicit coercions) *)
 Definition array (A : Type) (x : int) : Type := vec A (nat_of_int x).
 
 Definition length {A : Type} {x : int} (v : array A x) : int := x.

--- a/theories/Monads/STM.v
+++ b/theories/Monads/STM.v
@@ -36,7 +36,7 @@ Definition isEmptySTM  {A} (v : vector A) : STM bool := trigger (iisEmptySTM v).
 
 Crane Extract Monad STM [ bind := bind , ret := Ret ] => "%t0".
 Crane Extract Inlined Constant atomically => "stm::atomically([&] { return %a0; })".
-(* Should this be incorported into the c++? *)
+(* Should this be incorporated into the c++? *)
 Crane Extract Inlined Constant retry => "stm::retry<%t0>()".
 Crane Extract Inlined Constant orElse => "stm::orElse<%t0>(%a0, %a1)".
 

--- a/theories/Monads/STMBDE.v
+++ b/theories/Monads/STMBDE.v
@@ -34,7 +34,7 @@ Definition getSTM {A} (v : vector A) (i : int) : STM A := trigger (igetSTM v i).
 Definition isEmptySTM  {A} (v : vector A) : STM bool := trigger (iisEmptySTM v).
 
 Crane Extract Inlined Constant STM => "%t0".
-Crane Extract Inlined Constant atomically => "stm::atomically([&] { return %a0; })". (* Should this be incorported into the c++? *)
+Crane Extract Inlined Constant atomically => "stm::atomically([&] { return %a0; })". (* Should this be incorporated into the c++? *)
 Crane Extract Inlined Constant retry => "stm::retry<%t0>()".
 (* Crane Extract Inlined Constant orElse => "stm::orElse<%t0>(%a0, %a1)". *)
 

--- a/theories/cpp/rc.h
+++ b/theories/cpp/rc.h
@@ -173,7 +173,7 @@ rc<T> make_rc(Args&&... args) {
     return rc<T>(ctrl);
 }
 
-} // namespace mini_rc
+} // namespace crane
 
 /*
 Usage example:

--- a/theories/cpp_bde/bde_rc.h
+++ b/theories/cpp_bde/bde_rc.h
@@ -294,8 +294,8 @@ struct Node {
 int main(){
     bslma::Allocator* alloc = bslma::Default::allocator(0);
 
-    rc<Node> root = make_rcA<Node>(alloc, 1);
-    root->left = make_rcA<Node>(alloc, 2);
+    rc<Node> root = make_rc<Node>(alloc, 1);
+    root->left = make_rc<Node>(alloc, 2);
     root->left->parent = root.downgrade();
 
     bsl::cout << root.useCount() << "\n"; // 1


### PR DESCRIPTION
## Summary
- Fix 15 distinct typos across 16 files (comments, strings, identifiers)
- Source (`src/`): acces→access, fonctions→functions, outdate→outdated, bingings→bindings, applies→applied, build→built, cound→could, positiions→positions, variable→variables
- Theories: incorported→incorporated, coersions→coercions, stale `make_rcA`→`make_rc` in comment, stale `namespace mini_rc`→`namespace crane` in comment
- Tests: intution→intuition, frome→from, levensthein→levenshtein (theorem name), misnumbered test output

## Test plan
- [x] Plugin builds (`dune build src/crane_plugin.cmxs`)
- [x] Theories build (`dune build theories`)
- [x] CI passes