### PR TITLE
int63: use int64_t with 63-bit masking for correct modular arithmetic

### DIFF
--- a/tests/basics/dune
+++ b/tests/basics/dune
@@ -265,4 +265,15 @@
   (deps stream.t.exe)
   (action (run ./stream.t.exe))))
 
+(subdir int63_arith
+ (rule
+  (targets int63_arith.t.exe)
+  (deps Int63Arith.vo int63_arith.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} int63_arith.t.exe int63_arith.cpp int63_arith.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps int63_arith.t.exe)
+  (action (run ./int63_arith.t.exe))))
+
 

--- a/tests/basics/int63_arith/Int63Arith.v
+++ b/tests/basics/int63_arith/Int63Arith.v
@@ -1,0 +1,33 @@
+(* Copyright 2025 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+From Corelib Require Import PrimInt63.
+
+Module Int63Arith.
+
+(* Wrapper functions — these force runtime computation in C++.
+   Without wrappers, Rocq reduces constant expressions at compile time
+   and the extracted code would just contain literal values,
+   bypassing the C++ arithmetic entirely. *)
+
+Definition test_add (x y : int) : int := add x y.
+Definition test_sub (x y : int) : int := sub x y.
+Definition test_mul (x y : int) : int := mul x y.
+Definition test_div (x y : int) : int := div x y.
+Definition test_mod (x y : int) : int := mod x y.
+
+Definition test_land (x y : int) : int := land x y.
+Definition test_lor  (x y : int) : int := lor  x y.
+Definition test_lxor (x y : int) : int := lxor x y.
+Definition test_lsl  (x n : int) : int := lsl  x n.
+Definition test_lsr  (x n : int) : int := lsr  x n.
+
+Definition test_eqb (x y : int) : bool := eqb x y.
+Definition test_ltb (x y : int) : bool := ltb x y.
+Definition test_leb (x y : int) : bool := leb x y.
+
+End Int63Arith.
+
+Require Crane.Extraction.
+Require Crane.Mapping.Std.
+
+Crane Extraction "int63_arith" Int63Arith.

--- a/tests/basics/int63_arith/int63_arith.cpp
+++ b/tests/basics/int63_arith/int63_arith.cpp
@@ -1,0 +1,65 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <int63_arith.h>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+int64_t Int63Arith::test_add(const int64_t _x0, const int64_t _x1) {
+  return ((_x0 + _x1) & 0x7FFFFFFFFFFFFFFFLL);
+}
+
+int64_t Int63Arith::test_sub(const int64_t _x0, const int64_t _x1) {
+  return ((_x0 - _x1) & 0x7FFFFFFFFFFFFFFFLL);
+}
+
+int64_t Int63Arith::test_mul(const int64_t _x0, const int64_t _x1) {
+  return ((_x0 * _x1) & 0x7FFFFFFFFFFFFFFFLL);
+}
+
+int64_t Int63Arith::test_div(const int64_t _x0, const int64_t _x1) {
+  return (_x1 == 0 ? 0 : _x0 / _x1);
+}
+
+int64_t Int63Arith::test_mod(const int64_t _x0, const int64_t _x1) {
+  return (_x1 == 0 ? 0 : _x0 % _x1);
+}
+
+int64_t Int63Arith::test_land(const int64_t _x0, const int64_t _x1) {
+  return (_x0 & _x1);
+}
+
+int64_t Int63Arith::test_lor(const int64_t _x0, const int64_t _x1) {
+  return (_x0 | _x1);
+}
+
+int64_t Int63Arith::test_lxor(const int64_t _x0, const int64_t _x1) {
+  return (_x0 ^ _x1);
+}
+
+int64_t Int63Arith::test_lsl(const int64_t _x0, const int64_t _x1) {
+  return (_x1 >= 63 ? 0 : ((_x0 << _x1) & 0x7FFFFFFFFFFFFFFFLL));
+}
+
+int64_t Int63Arith::test_lsr(const int64_t _x0, const int64_t _x1) {
+  return (_x1 >= 63 ? 0 : (_x0 >> _x1));
+}
+
+bool Int63Arith::test_eqb(const int64_t _x0, const int64_t _x1) {
+  return (_x0 == _x1);
+}
+
+bool Int63Arith::test_ltb(const int64_t _x0, const int64_t _x1) {
+  return (_x0 < _x1);
+}
+
+bool Int63Arith::test_leb(const int64_t _x0, const int64_t _x1) {
+  return (_x0 <= _x1);
+}

--- a/tests/basics/int63_arith/int63_arith.h
+++ b/tests/basics/int63_arith/int63_arith.h
@@ -1,0 +1,48 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct Int63Arith {
+  static int64_t test_add(const int64_t, const int64_t);
+
+  static int64_t test_sub(const int64_t, const int64_t);
+
+  static int64_t test_mul(const int64_t, const int64_t);
+
+  static int64_t test_div(const int64_t, const int64_t);
+
+  static int64_t test_mod(const int64_t, const int64_t);
+
+  static int64_t test_land(const int64_t, const int64_t);
+
+  static int64_t test_lor(const int64_t, const int64_t);
+
+  static int64_t test_lxor(const int64_t, const int64_t);
+
+  static int64_t test_lsl(const int64_t, const int64_t);
+
+  static int64_t test_lsr(const int64_t, const int64_t);
+
+  static bool test_eqb(const int64_t, const int64_t);
+
+  static bool test_ltb(const int64_t, const int64_t);
+
+  static bool test_leb(const int64_t, const int64_t);
+};

--- a/tests/basics/int63_arith/int63_arith.t.cpp
+++ b/tests/basics/int63_arith/int63_arith.t.cpp
@@ -1,0 +1,92 @@
+// Copyright 2025 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <int63_arith.h>
+
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <variant>
+
+// ============================================================================
+//                     STANDARD BDE ASSERT TEST FUNCTION
+// ----------------------------------------------------------------------------
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+
+  constexpr int64_t mask63 = 0x7FFFFFFFFFFFFFFFLL;
+
+  // ---- Basic arithmetic ----
+  ASSERT(Int63Arith::test_add(42, 58) == 100);
+  ASSERT(Int63Arith::test_sub(100, 42) == 58);
+  ASSERT(Int63Arith::test_mul(7, 6) == 42);
+  ASSERT(Int63Arith::test_div(100, 7) == 14);
+  ASSERT(Int63Arith::test_mod(100, 7) == 2);
+
+  // ---- Division/modulo by zero ----
+  ASSERT(Int63Arith::test_div(42, 0) == 0);
+  ASSERT(Int63Arith::test_mod(42, 0) == 0);
+
+  // ---- Bitwise ----
+  ASSERT(Int63Arith::test_land(0xFF, 0x0F) == 0x0F);
+  ASSERT(Int63Arith::test_lor(0xF0, 0x0F) == 0xFF);
+  ASSERT(Int63Arith::test_lxor(0xFF, 0x0F) == 0xF0);
+
+  // ---- Shifts ----
+  ASSERT(Int63Arith::test_lsl(1, 10) == 1024);
+  ASSERT(Int63Arith::test_lsr(1024, 5) == 32);
+  ASSERT(Int63Arith::test_lsl(1, 62) == INT64_C(4611686018427387904));
+  ASSERT(Int63Arith::test_lsr(INT64_C(4611686018427387904), 62) == 1);
+
+  // ---- Shift edge cases ----
+  ASSERT(Int63Arith::test_lsl(1, 63) == 0);     // shifted past 63-bit range
+  ASSERT(Int63Arith::test_lsl(1, 100) == 0);    // large shift
+  ASSERT(Int63Arith::test_lsr(mask63, 63) == 0); // shifted past range
+  ASSERT(Int63Arith::test_lsr(mask63, 62) == 1); // only top bit survives
+
+  // ---- Comparison ----
+  ASSERT(Int63Arith::test_eqb(42, 42) == true);
+  ASSERT(Int63Arith::test_eqb(42, 43) == false);
+  ASSERT(Int63Arith::test_ltb(41, 42) == true);
+  ASSERT(Int63Arith::test_ltb(42, 42) == false);
+  ASSERT(Int63Arith::test_leb(42, 42) == true);
+  ASSERT(Int63Arith::test_leb(43, 42) == false);
+
+  // ---- Overflow / wrapping ----
+  ASSERT(Int63Arith::test_add(mask63, 1) == 0);         // max + 1 wraps to 0
+  ASSERT(Int63Arith::test_sub(0, 1) == mask63);          // 0 - 1 wraps to max
+  ASSERT(Int63Arith::test_mul(mask63, 2) == (mask63 - 1)); // max * 2 = 2^64-2, masked = 2^63-2
+
+  // ---- Identity checks ----
+  ASSERT(Int63Arith::test_add(0, 0) == 0);
+  ASSERT(Int63Arith::test_mul(1, mask63) == mask63);
+  ASSERT(Int63Arith::test_div(mask63, 1) == mask63);
+  ASSERT(Int63Arith::test_mod(mask63, mask63) == 0);
+  ASSERT(Int63Arith::test_land(mask63, mask63) == mask63);
+  ASSERT(Int63Arith::test_lor(0, 0) == 0);
+  ASSERT(Int63Arith::test_lxor(mask63, mask63) == 0);
+
+  return testStatus;
+}

--- a/theories/Mapping/Std.v
+++ b/theories/Mapping/Std.v
@@ -33,16 +33,25 @@ Crane Extract Inlined Constant sub => "%a0.substr(%a1, %a2)" From "string".
 Crane Extract Inlined Constant length => "%a0.length()" From "string".
 
 
-(* TODO: unsafe as extracting int63 to int64 *)
+(* int63 primitives — int64_t with 63-bit masking.
+   All arithmetic results are masked to [0, 2^63) to match Rocq semantics.
+   Bitwise ops preserve the invariant (inputs have bit 63 = 0).
+   Shifts guard against UB when shift amount >= 63. *)
 From Corelib Require Import PrimInt63.
-Crane Extract Inlined Constant int => "int".
-Crane Extract Inlined Constant add => "%a0 + %a1".
-Crane Extract Inlined Constant sub => "%a0 - %a1".
-Crane Extract Inlined Constant mul => "%a0 * %a1".
-Crane Extract Inlined Constant mod => "%a0 % %a1".
-Crane Extract Inlined Constant eqb => "%a0 == %a1".
-Crane Extract Inlined Constant ltb => "%a0 < %a1".
-Crane Extract Inlined Constant leb => "%a0 <= %a1".
+Crane Extract Inlined Constant int => "int64_t" From "cstdint".
+Crane Extract Inlined Constant add => "((%a0 + %a1) & 0x7FFFFFFFFFFFFFFFLL)".
+Crane Extract Inlined Constant sub => "((%a0 - %a1) & 0x7FFFFFFFFFFFFFFFLL)".
+Crane Extract Inlined Constant mul => "((%a0 * %a1) & 0x7FFFFFFFFFFFFFFFLL)".
+Crane Extract Inlined Constant div => "(%a1 == 0 ? 0 : %a0 / %a1)".
+Crane Extract Inlined Constant mod => "(%a1 == 0 ? 0 : %a0 % %a1)".
+Crane Extract Inlined Constant eqb => "(%a0 == %a1)".
+Crane Extract Inlined Constant ltb => "(%a0 < %a1)".
+Crane Extract Inlined Constant leb => "(%a0 <= %a1)".
+Crane Extract Inlined Constant land => "(%a0 & %a1)".
+Crane Extract Inlined Constant lor => "(%a0 | %a1)".
+Crane Extract Inlined Constant lxor => "(%a0 ^ %a1)".
+Crane Extract Inlined Constant lsl => "(%a1 >= 63 ? 0 : ((%a0 << %a1) & 0x7FFFFFFFFFFFFFFFLL))".
+Crane Extract Inlined Constant lsr => "(%a1 >= 63 ? 0 : (%a0 >> %a1))".
 
 (* From Corelib Require PrimArray.
 Definition array (A : Type) {l : int} {def : A} := PrimArray.array A.


### PR DESCRIPTION
## Summary
- Replace `int` extraction with `int64_t` and mask all arithmetic results to `[0, 2^63)` to match Rocq's `PrimInt63` semantics
- Add 6 missing operation directives: `div`, `land`, `lor`, `lxor`, `lsl`, `lsr`
- Guard `div`/`mod` against division by zero (returns 0, matching Rocq)
- Guard `lsl`/`lsr` against shift >= 63 (returns 0, avoids C++ UB)
- New `int63_arith` test in `tests/basics/` with 30 assertions covering arithmetic, bitwise, shifts, comparisons, overflow wrapping, and edge cases

## Motivation
The previous extraction mapped `int63` to C++ `int` with no masking, silently producing wrong results on overflow. Six operations (`div`, bitwise, shifts) were missing entirely. This resolves the `TODO: unsafe as extracting int63 to int64` comment in `Std.v`.

## Test plan
- [x] `int63_arith` test passes (overflow, div-by-zero, shift edge cases)
- [x] All `basics/` tests pass
- [x] All `monadic/` tests pass
- [x] All `regression/` tests pass
- [ ] CI