### PR TITLE
Add PrimFloat extraction (IEEE 754 binary64 to C++ double)

### DIFF
--- a/src/cpp.ml
+++ b/src/cpp.ml
@@ -602,7 +602,7 @@ let rec lambda_needs_capture (params : (Minicpp.cpp_type * Names.Id.t option) li
         collect_from_expr (collect_from_expr (refs, decls) lhs) rhs
     (* Leaf expressions: no variables to collect *)
     | CPPglob _ | CPPvisit | CPPmk_shared _ | CPPmk_unique _ | CPPstring _
-    | CPPuint _ | CPPconvertible_to _ | CPPabort _ | CPPenum_val _ | CPPraw _ ->
+    | CPPuint _ | CPPfloat _ | CPPconvertible_to _ | CPPabort _ | CPPenum_val _ | CPPraw _ ->
         (refs, decls)
 
   and collect_from_stmt (refs, decls) stmt =
@@ -686,7 +686,7 @@ and expr_contains_capturing_lambda (e : Minicpp.cpp_expr) : bool =
   | CPPqualified (e', _) -> expr_contains_capturing_lambda e'
   | CPPrequires (_, constraints) -> List.exists (fun (e', _) -> expr_contains_capturing_lambda e') constraints
   | CPPbinop (_, lhs, rhs) -> expr_contains_capturing_lambda lhs || expr_contains_capturing_lambda rhs
-  | CPPvar _ | CPPvar' _ | CPPglob _ | CPPvisit | CPPmk_shared _ | CPPmk_unique _ | CPPstring _ | CPPuint _ | CPPthis | CPPconvertible_to _ | CPPabort _ | CPPenum_val _ | CPPraw _ -> false
+  | CPPvar _ | CPPvar' _ | CPPglob _ | CPPvisit | CPPmk_shared _ | CPPmk_unique _ | CPPstring _ | CPPuint _ | CPPfloat _ | CPPthis | CPPconvertible_to _ | CPPabort _ | CPPenum_val _ | CPPraw _ -> false
 
 and stmt_contains_capturing_lambda (s : Minicpp.cpp_stmt) : bool =
   let open Minicpp in
@@ -1191,6 +1191,7 @@ and pp_cpp_expr env args t =
           str (cpp_type ^ "(" ^ s ^ ")")
         else str s
       with Not_found -> str s)
+  | CPPfloat f -> str (Printf.sprintf "%h" (Float64.to_float f))
   | CPPrequires (ty_vars, exprs) ->
       let ty_vars_s = match ty_vars with [] -> mt () | _ ->
         str "(" ++ pp_list (fun (ty, id) -> (pp_cpp_type false [] ty) ++ spc () ++ Id.print id) ty_vars ++ str ") " in

--- a/src/minicpp.ml
+++ b/src/minicpp.ml
@@ -76,6 +76,7 @@ and cpp_expr =
   | CPPget' of cpp_expr * GlobRef.t (* access from a struct (or class) *)
   | CPPstring of Pstring.t
   | CPPuint   of Uint63.t
+  | CPPfloat  of Float64.t
   | CPPparray of cpp_expr array * cpp_expr
 (*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace access (in general, as is not just cpp_expressions)? *)
   | CPPrequires of (cpp_type * Id.t) list * (cpp_expr * cpp_constraint) list

--- a/src/minicpp.mli
+++ b/src/minicpp.mli
@@ -76,6 +76,7 @@ and cpp_expr =
   | CPPget' of cpp_expr * GlobRef.t (* access from a struct (or class) *)
   | CPPstring of Pstring.t
   | CPPuint   of Uint63.t
+  | CPPfloat  of Float64.t
   | CPPparray of cpp_expr array * cpp_expr
 (*| CPPnamespace of Id.t * cpp_expr    should we do this for namespace access (in general, as is not just cpp_expressions)? *)
   | CPPrequires of (cpp_type * Id.t) list * (cpp_expr * cpp_constraint) list

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -728,6 +728,7 @@ and gen_expr env (ml_e : ml_ast) : cpp_expr =
   (*| MLfix _ -> CPPvar (Id.of_string "FIX")*)
   | MLstring s -> CPPstring s
   | MLuint x -> CPPuint x
+  | MLfloat f -> CPPfloat f
   | MLparray (elems, def) ->
     let elems = Array.map (gen_expr env) elems in
     let def = gen_expr env def in
@@ -2044,7 +2045,7 @@ let rec tvar_subst_expr (tvars : Id.t list) (e : cpp_expr) : cpp_expr =
   | CPPqualified (e', qid) -> CPPqualified (subst_e e', qid)
   | CPPmk_shared ty -> CPPmk_shared (subst_ty ty)
   | CPPmk_unique ty -> CPPmk_unique (subst_ty ty)
-  | _ -> e  (* CPPvar, CPPvar', CPPvisit, CPPstring, CPPuint, CPPthis, CPPrequires *)
+  | _ -> e  (* CPPvar, CPPvar', CPPvisit, CPPstring, CPPuint, CPPfloat, CPPthis, CPPrequires *)
 
 and tvar_subst_stmt (tvars : Id.t list) (s : cpp_stmt) : cpp_stmt =
   let subst_ty = tvar_subst_type tvars in

--- a/tests/basics/dune
+++ b/tests/basics/dune
@@ -276,4 +276,13 @@
   (deps int63_arith.t.exe)
   (action (run ./int63_arith.t.exe))))
 
-
+(subdir prim_float
+ (rule
+  (targets prim_float_test.t.exe)
+  (deps PrimFloatTest.vo prim_float_test.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} prim_float_test.t.exe prim_float_test.cpp prim_float_test.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps prim_float_test.t.exe)
+  (action (run ./prim_float_test.t.exe))))

--- a/tests/basics/prim_float/PrimFloatTest.v
+++ b/tests/basics/prim_float/PrimFloatTest.v
@@ -1,0 +1,39 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Test: PrimFloat extraction — IEEE 754 binary64 arithmetic. *)
+
+From Corelib Require Import PrimFloat PrimInt63.
+From Crane Require Import Mapping.Std Mapping.PrimFloatStd.
+Require Crane.Extraction.
+
+Module PrimFloatTest.
+
+(* --- Constants --- *)
+
+Definition f_zero : pfloat := 0%float.
+Definition f_one : pfloat := 1%float.
+Definition f_neg_one : pfloat := pfloat_opp 1%float.
+
+(* --- Arithmetic wrappers (prevent compile-time reduction) --- *)
+
+Definition test_add (x y : pfloat) : pfloat := pfloat_add x y.
+Definition test_sub (x y : pfloat) : pfloat := pfloat_sub x y.
+Definition test_mul (x y : pfloat) : pfloat := pfloat_mul x y.
+Definition test_div (x y : pfloat) : pfloat := pfloat_div x y.
+Definition test_opp (x : pfloat) : pfloat := pfloat_opp x.
+Definition test_abs (x : pfloat) : pfloat := pfloat_abs x.
+Definition test_sqrt (x : pfloat) : pfloat := pfloat_sqrt x.
+
+(* --- Comparison wrappers --- *)
+
+Definition test_eqb (x y : pfloat) : bool := pfloat_eqb x y.
+Definition test_ltb (x y : pfloat) : bool := pfloat_ltb x y.
+Definition test_leb (x y : pfloat) : bool := pfloat_leb x y.
+
+(* --- Conversion --- *)
+
+Definition test_of_uint63 (n : int) : pfloat := pfloat_of_uint63 n.
+
+End PrimFloatTest.
+
+Crane Extraction "prim_float_test" PrimFloatTest.

--- a/tests/basics/prim_float/prim_float_test.cpp
+++ b/tests/basics/prim_float/prim_float_test.cpp
@@ -1,0 +1,52 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <prim_float_test.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+double PrimFloatTest::test_add(const double _x0, const double _x1) {
+  return (_x0 + _x1);
+}
+
+double PrimFloatTest::test_sub(const double _x0, const double _x1) {
+  return (_x0 - _x1);
+}
+
+double PrimFloatTest::test_mul(const double _x0, const double _x1) {
+  return (_x0 * _x1);
+}
+
+double PrimFloatTest::test_div(const double _x0, const double _x1) {
+  return (_x0 / _x1);
+}
+
+double PrimFloatTest::test_opp(const double _x0) { return (-_x0); }
+
+double PrimFloatTest::test_abs(const double _x0) { return std::abs(_x0); }
+
+double PrimFloatTest::test_sqrt(const double _x0) { return std::sqrt(_x0); }
+
+bool PrimFloatTest::test_eqb(const double _x0, const double _x1) {
+  return (_x0 == _x1);
+}
+
+bool PrimFloatTest::test_ltb(const double _x0, const double _x1) {
+  return (_x0 < _x1);
+}
+
+bool PrimFloatTest::test_leb(const double _x0, const double _x1) {
+  return (_x0 <= _x1);
+}
+
+double PrimFloatTest::test_of_uint63(const int64_t _x0) {
+  return static_cast<double>(_x0);
+}

--- a/tests/basics/prim_float/prim_float_test.h
+++ b/tests/basics/prim_float/prim_float_test.h
@@ -1,0 +1,51 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct PrimFloatTest {
+  static inline const double f_zero = 0x0p+0;
+
+  static inline const double f_one = 0x1p+0;
+
+  static inline const double f_neg_one = (-0x1p+0);
+
+  static double test_add(const double, const double);
+
+  static double test_sub(const double, const double);
+
+  static double test_mul(const double, const double);
+
+  static double test_div(const double, const double);
+
+  static double test_opp(const double);
+
+  static double test_abs(const double);
+
+  static double test_sqrt(const double);
+
+  static bool test_eqb(const double, const double);
+
+  static bool test_ltb(const double, const double);
+
+  static bool test_leb(const double, const double);
+
+  static double test_of_uint63(const int64_t);
+};

--- a/tests/basics/prim_float/prim_float_test.t.cpp
+++ b/tests/basics/prim_float/prim_float_test.t.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+//
+// Test harness for PrimFloat extraction — IEEE 754 binary64 arithmetic.
+
+#include <prim_float_test.h>
+
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <variant>
+
+// ============================================================================
+//                     STANDARD BDE ASSERT TEST FUNCTION
+// ----------------------------------------------------------------------------
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+             << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main() {
+    // ---- Constants ----
+    ASSERT(PrimFloatTest::f_zero == 0.0);
+    ASSERT(PrimFloatTest::f_one == 1.0);
+    ASSERT(PrimFloatTest::f_neg_one == -1.0);
+
+    // ---- Basic arithmetic ----
+    ASSERT(PrimFloatTest::test_add(2.5, 3.5) == 6.0);
+    ASSERT(PrimFloatTest::test_sub(10.0, 3.0) == 7.0);
+    ASSERT(PrimFloatTest::test_mul(4.0, 2.5) == 10.0);
+    ASSERT(PrimFloatTest::test_div(10.0, 4.0) == 2.5);
+
+    // ---- Unary ops ----
+    ASSERT(PrimFloatTest::test_opp(5.0) == -5.0);
+    ASSERT(PrimFloatTest::test_opp(-3.0) == 3.0);
+    ASSERT(PrimFloatTest::test_abs(-7.0) == 7.0);
+    ASSERT(PrimFloatTest::test_abs(7.0) == 7.0);
+    ASSERT(PrimFloatTest::test_sqrt(4.0) == 2.0);
+    ASSERT(PrimFloatTest::test_sqrt(9.0) == 3.0);
+
+    // ---- Comparison ----
+    ASSERT(PrimFloatTest::test_eqb(1.0, 1.0) == true);
+    ASSERT(PrimFloatTest::test_eqb(1.0, 2.0) == false);
+    ASSERT(PrimFloatTest::test_ltb(1.0, 2.0) == true);
+    ASSERT(PrimFloatTest::test_ltb(2.0, 1.0) == false);
+    ASSERT(PrimFloatTest::test_ltb(1.0, 1.0) == false);
+    ASSERT(PrimFloatTest::test_leb(1.0, 2.0) == true);
+    ASSERT(PrimFloatTest::test_leb(1.0, 1.0) == true);
+    ASSERT(PrimFloatTest::test_leb(2.0, 1.0) == false);
+
+    // ---- IEEE 754 special values ----
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    constexpr double nan_val = std::numeric_limits<double>::quiet_NaN();
+
+    // Division by zero produces infinity.
+    ASSERT(std::isinf(PrimFloatTest::test_div(1.0, 0.0)));
+    ASSERT(PrimFloatTest::test_div(1.0, 0.0) > 0);  // +inf
+    ASSERT(std::isinf(PrimFloatTest::test_div(-1.0, 0.0)));
+    ASSERT(PrimFloatTest::test_div(-1.0, 0.0) < 0);  // -inf
+
+    // 0/0 = NaN.
+    ASSERT(std::isnan(PrimFloatTest::test_div(0.0, 0.0)));
+
+    // NaN propagation.
+    ASSERT(std::isnan(PrimFloatTest::test_add(nan_val, 1.0)));
+    ASSERT(std::isnan(PrimFloatTest::test_mul(nan_val, 0.0)));
+
+    // NaN != NaN (IEEE 754).
+    ASSERT(PrimFloatTest::test_eqb(nan_val, nan_val) == false);
+
+    // NaN comparisons return false.
+    ASSERT(PrimFloatTest::test_ltb(nan_val, 1.0) == false);
+    ASSERT(PrimFloatTest::test_leb(nan_val, 1.0) == false);
+    ASSERT(PrimFloatTest::test_ltb(1.0, nan_val) == false);
+
+    // +0 == -0 (IEEE 754).
+    ASSERT(PrimFloatTest::test_eqb(0.0, -0.0) == true);
+
+    // ---- Conversion ----
+    ASSERT(PrimFloatTest::test_of_uint63(42) == 42.0);
+    ASSERT(PrimFloatTest::test_of_uint63(0) == 0.0);
+
+    // ---- sqrt of NaN is NaN ----
+    ASSERT(std::isnan(PrimFloatTest::test_sqrt(-1.0)));
+
+    if (testStatus == 0) {
+        std::cout << "All prim_float tests passed." << std::endl;
+    }
+    return testStatus;
+}

--- a/theories/Mapping/PrimFloatStd.v
+++ b/theories/Mapping/PrimFloatStd.v
@@ -1,0 +1,79 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+
+(* PrimFloatStd.v — Extraction mapping for Rocq's PrimFloat to C++ double.
+ *
+ * Rocq's PrimFloat is IEEE 754 binary64 (full 64-bit double precision).
+ * C++ [double] has identical semantics on all mainstream platforms:
+ *   - NaN != NaN (IEEE 754 standard, C++ == does this by default)
+ *   - +0 == -0 (IEEE 754 standard)
+ *   - Division by zero produces infinity, not UB (for floating-point)
+ *   - Round-to-nearest, ties-to-even (C++ default rounding mode)
+ *
+ * We define wrapper functions with a [pfloat_] prefix to avoid name
+ * collisions with PrimInt63's [eqb], [ltb], [leb], [sub], [add], [mul],
+ * [div] which live in Mapping.Std.
+ *
+ * Argument indices: PrimFloat operations have no implicit type parameters
+ * (unlike PrimArray), so indices start directly at %a0 = first explicit arg.
+ *
+ * Advanced operations (frshiftexp, ldshiftexp, normfr_mantissa, classify,
+ * next_up, next_down) are deferred — they need more complex mappings
+ * (e.g., pair returns, enum mappings for float_class).
+ *)
+
+From Crane Require Extraction.
+From Crane Require Import Mapping.Std.
+(* Import PrimFloat AFTER Mapping.Std so that [float], [add], [sub], etc.
+ * resolve to PrimFloat operations rather than PrimInt63 operations. *)
+From Corelib Require Import PrimFloat.
+
+(* --- Wrapper definitions ---
+ * Each wraps one PrimFloat primitive, giving it a unique name for extraction.
+ * This avoids name collisions with PrimInt63's [eqb], [ltb], [leb], etc.
+ * when both Mapping.Std and Mapping.PrimFloatStd are imported. *)
+
+Definition pfloat := float.
+
+(* Arithmetic *)
+Definition pfloat_add (x y : float) : float := add x y.
+Definition pfloat_sub (x y : float) : float := sub x y.
+Definition pfloat_mul (x y : float) : float := mul x y.
+Definition pfloat_div (x y : float) : float := div x y.
+Definition pfloat_opp (x : float) : float := opp x.
+Definition pfloat_abs (x : float) : float := abs x.
+Definition pfloat_sqrt (x : float) : float := sqrt x.
+
+(* Comparison *)
+Definition pfloat_eqb (x y : float) : bool := eqb x y.
+Definition pfloat_ltb (x y : float) : bool := ltb x y.
+Definition pfloat_leb (x y : float) : bool := leb x y.
+
+(* Conversion *)
+Definition pfloat_of_uint63 (n : PrimInt63.int) : float := of_uint63 n.
+
+(* --- Extraction directives --- *)
+
+(* Map the primitive float type to C++ double.
+ * [float] is the raw primitive type from PrimFloat.
+ * [pfloat] is our wrapper alias — mapped separately in case downstream
+ * code references it directly. *)
+Crane Extract Inlined Constant float => "double".
+Crane Extract Inlined Constant pfloat => "double".
+
+(* Arithmetic: C++ double arithmetic matches IEEE 754 exactly. *)
+Crane Extract Inlined Constant pfloat_add => "(%a0 + %a1)".
+Crane Extract Inlined Constant pfloat_sub => "(%a0 - %a1)".
+Crane Extract Inlined Constant pfloat_mul => "(%a0 * %a1)".
+Crane Extract Inlined Constant pfloat_div => "(%a0 / %a1)".
+Crane Extract Inlined Constant pfloat_opp => "(-%a0)".
+Crane Extract Inlined Constant pfloat_abs => "std::abs(%a0)" From "cmath".
+Crane Extract Inlined Constant pfloat_sqrt => "std::sqrt(%a0)" From "cmath".
+
+(* Comparison: C++ IEEE 754 semantics match Rocq (NaN != NaN, +0 == -0). *)
+Crane Extract Inlined Constant pfloat_eqb => "(%a0 == %a1)".
+Crane Extract Inlined Constant pfloat_ltb => "(%a0 < %a1)".
+Crane Extract Inlined Constant pfloat_leb => "(%a0 <= %a1)".
+
+(* Conversion: int63 to double. *)
+Crane Extract Inlined Constant pfloat_of_uint63 => "static_cast<double>(%a0)".


### PR DESCRIPTION
## Summary
- Add `CPPfloat of Float64.t` to the MiniCpp AST and handle `MLfloat` in `gen_expr`, fixing the `Translation.TODO` crash for float literals
- Float literals emit as C++ hex floats (`0x1p+0`) for exact round-trip fidelity
- Add `theories/Mapping/PrimFloatStd.v` with wrapper functions and extraction directives for arithmetic (`add/sub/mul/div/opp/abs/sqrt`), comparison (`eqb/ltb/leb`), and conversion (`of_uint63`)
- Add `tests/basics/prim_float/` test suite covering basic ops and IEEE 754 edge cases (NaN propagation, NaN != NaN, +0 == -0, division by zero → infinity)

## Test plan
- [x] Plugin compiles (`dune build src/crane_plugin.cmxs`)
- [x] Theories build (`dune build theories`)
- [x] prim_float test passes (`dune build @tests/basics/prim_float/runtest`)
- [x] Full basics regression passes (`dune build @tests/basics/runtest`)
- [x] Full regression suite passes (`dune build @tests/regression/runtest`)