### PR TITLE
Remove dead Rust backend and handle non-Pusual patterns

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -94,10 +94,6 @@ let pp_apply_cpp st args = match args with
   | [] -> st
   | _  -> hov 2 (st ++ str "(" ++ prlist_with_sep (fun _ -> str ", ") identity args) ++ str ")"
 
-let pp_apply_rust st args = match args with
-  | [] -> st
-  | _  -> hov 2 (st ++ str "(" ++ prlist_with_sep (fun _ -> str ", ") identity args) ++ str ")"
-
 (** Same as [pp_apply], but with also protection of the head by parenthesis *)
 
 let pp_apply2 st par args =
@@ -497,7 +493,7 @@ and mp_renaming =
 let ref_renaming_fun (k,r) =
   let mp = modpath_of_r r in
   let l = mp_renaming mp in
-  let l = if (lang () != Cpp (*|| lang () != Rust*)) && not (modular ()) then [""] else l in
+  let l = if (lang () != Cpp) && not (modular ()) then [""] else l in
   let s =
     let idg = safe_basename_of_global r in
     match l with
@@ -681,15 +677,6 @@ let pp_cpp_gen k mp rls olab =
         if is_mp_bound base then pp_ocaml_bound base rls
         else pp_ocaml_extern k base rls
 
-let pp_rust_gen k mp rls olab =
-  match common_prefix_from_list mp (get_visible_mps ()) with
-    | Some prefix -> pp_ocaml_local k mp mp rls olab
-    | None ->
-        let base = base_mp mp in
-        if is_mp_bound base then pp_ocaml_bound base rls
-        else pp_ocaml_extern k base rls
-
-
 (* Main name printing function for a reference *)
 
 let pp_global_with_key k key r =
@@ -705,7 +692,6 @@ let pp_global_with_key k key r =
     let rls = List.rev ls in (* for what come next it's easier this way *)
     match lang () with
       | Cpp -> pp_cpp_gen k mp rls (Some l)
-      (* | Rust -> pp_rust_gen k mp rls (Some l) *)
 
 let pp_global k r =
   pp_global_with_key k (repr_of_r r) r
@@ -745,7 +731,7 @@ let ascii_type_ref () = Rocqlib.lib_ref ascii_type_name
 let check_extract_ascii () =
   try
     let char_type = match lang () with
-      | Cpp (*| Rust *) -> "char"
+      | Cpp -> "char"
     in
     String.equal (find_custom @@ ascii_type_ref ()) (char_type)
   with Not_found -> false
@@ -790,7 +776,7 @@ let string_type_ref () = Rocqlib.lib_ref string_type_name
 let check_extract_string () =
   try
     let string_type = match lang () with
-      | Cpp (*| Rust *) -> "string"
+      | Cpp -> "string"
     in
     String.equal (find_custom @@ string_type_ref ()) string_type
   with Not_found -> false

--- a/src/common.mli
+++ b/src/common.mli
@@ -47,7 +47,6 @@ val pp_par : bool -> Pp.t -> Pp.t
 (** [pp_apply] : a head part applied to arguments, possibly with parenthesis *)
 val pp_apply : Pp.t -> bool -> Pp.t list -> Pp.t
 val pp_apply_cpp : Pp.t -> Pp.t list -> Pp.t
-val pp_apply_rust : Pp.t -> Pp.t list -> Pp.t
 
 (** Same as [pp_apply], but with also protection of the head by parenthesis *)
 val pp_apply2 : Pp.t -> bool -> Pp.t list -> Pp.t

--- a/src/extract_env.ml
+++ b/src/extract_env.ml
@@ -483,7 +483,6 @@ let mono_environment ~opaque_access refs mpl =
 
 let descr () = match lang () with
   | Cpp -> Cpp.cpp_descr
-  (* | Rust -> Rust.rust_descr *)
 
 (* From a filename string "foo.cpp" or "foo", builds "foo.cpp" and "foo.h"
    Works similarly for the other languages. *)
@@ -607,7 +606,6 @@ let get_comment () =
 let executable_available exe =
   Sys.command ("which " ^ exe ^ " > /dev/null 2>&1") = 0
 
-let rust_format_available () = executable_available "rustfmt"
 let bde_format_available () = executable_available "bde-format"
 let clang_format_available () = executable_available "clang-format"
 let clang_available () = executable_available "clang"
@@ -622,10 +620,8 @@ let hyperfine_available () = executable_available "hyperfine"
 let format_buffer_to_string (buf : Buffer.t) : string =
   let use_bde = Table.format_style () = "BDE" in
   let formatter_cmd, available =
-    if lang () == Cpp then
-      if use_bde then "bde-format", bde_format_available ()
-      else "clang-format -style=" ^ Filename.quote (Table.format_style ()), clang_format_available ()
-    else "rustfmt", rust_format_available ()
+    if use_bde then "bde-format", bde_format_available ()
+    else "clang-format -style=" ^ Filename.quote (Table.format_style ()), clang_format_available ()
   in
   if not available then (
     Feedback.msg_warning Pp.(str (if use_bde then "bde-format" else "clang-format") ++ spc () ++ str "not found: skipping formatting");

--- a/src/g_extraction.mlg
+++ b/src/g_extraction.mlg
@@ -56,14 +56,12 @@ END
 
 let pr_language = function
   | Cpp -> str "C++"
- (* | Rust -> str "Rust" *)
 
 }
 
 VERNAC ARGUMENT EXTEND crane_language
 PRINTED BY { pr_language }
 | [ "C++" ] -> { Cpp }
-(*| [ "Rust" ] -> { Rust } *)
 END
 
 (* Extraction commands *)

--- a/src/table.ml
+++ b/src/table.ml
@@ -768,7 +768,7 @@ let { Goptions.get = file_comment } =
 
 (*s Crane Extraction Lang *)
 
-type lang = Cpp (* | Rust *)
+type lang = Cpp
 type benchmark_lang = BenchmarkOCaml | BenchmarkCpp
 
 let lang_ref = Summary.ref Cpp ~name:"CraneExtrLang"

--- a/src/table.mli
+++ b/src/table.mli
@@ -183,7 +183,7 @@ val file_comment : unit -> string
 
 (*s Target language. *)
 
-type lang = Cpp (* | Rust *)
+type lang = Cpp
 type benchmark_lang = BenchmarkOCaml | BenchmarkCpp
 
 val lang : unit -> lang


### PR DESCRIPTION
## Summary
- Remove `gen_rust_case` (unreachable — call site was commented out) and its commented-out call site in `translation.ml`
- Remove `pp_apply_rust`, `pp_rust_gen`, `rust_format_available` and all `(* | Rust ... *)` comments across `common.ml`, `common.mli`, `extract_env.ml`, `g_extraction.mlg`, `table.ml`, `table.mli`
- Simplify `format_buffer_to_string` — the `else "rustfmt"` branch was dead code since `lang()` is always `Cpp`
- Also in `translation.ml`: handle `Pcons`/`Pwild`/`Prel`/`Ptuple` patterns in `gen_enum_branches`, `gen_normal_visit_expr`, and `gen_custom_cpp_case` (defensive — these patterns aren't currently produced by extraction but were `raise TODO`). Handle `MLaxiom` in `gen_expr` with `CPPabort` instead of falling through to the catch-all.

## Test plan
- [x] Plugin compiles (`dune build src/crane_plugin.cmxs`)
- [x] All basics and regression tests pass (`dune build @tests/basics/runtest @tests/regression/runtest`)
- [x] No new test needed — Rust code was dead, pattern changes are defensive (extraction currently only produces `Pusual`)