### PR TITLE
tests: add crane repro test cases

### DIFF
--- a/tests/regression/bool_dec_bde/BoolDecBde.v
+++ b/tests/regression/bool_dec_bde/BoolDecBde.v
@@ -1,0 +1,19 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 10b: BDE mapping for Bool.bool_dec must stay directly compilable. *)
+
+From Stdlib Require Import Bool.
+
+Module BoolDecBde.
+
+Definition eqb_dec (a b : bool) : bool :=
+  if Bool.bool_dec a b then true else false.
+
+Definition t1 : bool := eqb_dec true true.
+Definition t2 : bool := eqb_dec true false.
+
+End BoolDecBde.
+
+Require Crane.Extraction.
+From Crane Require Mapping.BDE.
+Crane Extraction "bool_dec_bde" BoolDecBde.

--- a/tests/regression/bool_dec_bde/bool_dec_bde.cpp
+++ b/tests/regression/bool_dec_bde/bool_dec_bde.cpp
@@ -1,0 +1,35 @@
+#include <algorithm>
+#include <any>
+#include <bool_dec_bde.h>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+bool BoolDecBde::eqb_dec(const bool a, const bool b) {
+  if (Bool::bool_dec(a, b)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Bool::bool_dec(const bool b1, const bool b2) {
+  if (b1) {
+    if (b2) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    if (b2) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/tests/regression/bool_dec_bde/bool_dec_bde.h
+++ b/tests/regression/bool_dec_bde/bool_dec_bde.h
@@ -1,0 +1,30 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct Bool {
+  static bool bool_dec(const bool b1, const bool b2);
+};
+
+struct BoolDecBde {
+  static bool eqb_dec(const bool a, const bool b);
+
+  static inline const bool t1 = eqb_dec(true, true);
+
+  static inline const bool t2 = eqb_dec(true, false);
+};

--- a/tests/regression/bool_dec_bde/bool_dec_bde.t.cpp
+++ b/tests/regression/bool_dec_bde/bool_dec_bde.t.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <bool_dec_bde.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(BoolDecBde::t1 == true);
+    ASSERT(BoolDecBde::t2 == false);
+    return testStatus;
+}

--- a/tests/regression/bool_dec_std/BoolDecStd.v
+++ b/tests/regression/bool_dec_std/BoolDecStd.v
@@ -1,0 +1,19 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 10a: Std mapping for Bool.bool_dec must stay directly compilable. *)
+
+From Stdlib Require Import Bool.
+
+Module BoolDecStd.
+
+Definition eqb_dec (a b : bool) : bool :=
+  if Bool.bool_dec a b then true else false.
+
+Definition t1 : bool := eqb_dec true true.
+Definition t2 : bool := eqb_dec true false.
+
+End BoolDecStd.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std.
+Crane Extraction "bool_dec_std" BoolDecStd.

--- a/tests/regression/bool_dec_std/bool_dec_std.cpp
+++ b/tests/regression/bool_dec_std/bool_dec_std.cpp
@@ -1,0 +1,35 @@
+#include <algorithm>
+#include <any>
+#include <bool_dec_std.h>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+bool BoolDecStd::eqb_dec(const bool a, const bool b) {
+  if (Bool::bool_dec(a, b)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Bool::bool_dec(const bool b1, const bool b2) {
+  if (b1) {
+    if (b2) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    if (b2) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/tests/regression/bool_dec_std/bool_dec_std.h
+++ b/tests/regression/bool_dec_std/bool_dec_std.h
@@ -1,0 +1,30 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct Bool {
+  static bool bool_dec(const bool b1, const bool b2);
+};
+
+struct BoolDecStd {
+  static bool eqb_dec(const bool a, const bool b);
+
+  static inline const bool t1 = eqb_dec(true, true);
+
+  static inline const bool t2 = eqb_dec(true, false);
+};

--- a/tests/regression/bool_dec_std/bool_dec_std.t.cpp
+++ b/tests/regression/bool_dec_std/bool_dec_std.t.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <bool_dec_std.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(BoolDecStd::t1 == true);
+    ASSERT(BoolDecStd::t2 == false);
+    return testStatus;
+}

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -673,3 +673,90 @@
   (alias runtest)
   (deps equations.t.exe)
   (action (run ./equations.t.exe))))
+(subdir wrapper_collision_pos
+ (rule
+  (targets wrapper_collision_pos.t.exe)
+  (deps WrapperCollisionPos.vo wrapper_collision_pos.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} wrapper_collision_pos.t.exe wrapper_collision_pos.cpp wrapper_collision_pos.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps wrapper_collision_pos.t.exe)
+  (action (run ./wrapper_collision_pos.t.exe))))
+
+(subdir wrapper_decl_merge
+ (rule
+  (targets wrapper_decl_merge.t.exe)
+  (deps WrapperDeclMerge.vo wrapper_decl_merge.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} wrapper_decl_merge.t.exe wrapper_decl_merge.cpp wrapper_decl_merge.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps wrapper_decl_merge.t.exe)
+  (action (run ./wrapper_decl_merge.t.exe))))
+
+(subdir func_only_submodule
+ (rule
+  (targets func_only_submodule.t.exe)
+  (deps FuncOnlySubmodule.vo func_only_submodule.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} func_only_submodule.t.exe func_only_submodule.cpp func_only_submodule.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps func_only_submodule.t.exe)
+  (action (run ./func_only_submodule.t.exe))))
+
+(subdir forward_spec_ascii
+ (rule
+  (targets forward_spec_ascii.t.exe)
+  (deps ForwardSpecAscii.vo forward_spec_ascii.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} forward_spec_ascii.t.exe forward_spec_ascii.cpp forward_spec_ascii.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps forward_spec_ascii.t.exe)
+  (action (run ./forward_spec_ascii.t.exe))))
+
+(subdir signature_parity_fix
+ (rule
+  (targets signature_parity_fix.t.exe)
+  (deps SignatureParityFix.vo signature_parity_fix.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} signature_parity_fix.t.exe signature_parity_fix.cpp signature_parity_fix.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps signature_parity_fix.t.exe)
+  (action (run ./signature_parity_fix.t.exe))))
+
+(subdir bool_dec_std
+ (rule
+  (targets bool_dec_std.t.exe)
+  (deps BoolDecStd.vo bool_dec_std.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} bool_dec_std.t.exe bool_dec_std.cpp bool_dec_std.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps bool_dec_std.t.exe)
+  (action (run ./bool_dec_std.t.exe))))
+
+(subdir bool_dec_bde
+ (rule
+  (targets bool_dec_bde.t.exe)
+  (deps BoolDecBde.vo bool_dec_bde.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} bool_dec_bde.t.exe bool_dec_bde.cpp bool_dec_bde.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps bool_dec_bde.t.exe)
+  (action (run ./bool_dec_bde.t.exe))))
+
+(subdir move_capture_reuse
+ (rule
+  (targets move_capture_reuse.t.exe)
+  (deps MoveCaptureReuse.vo move_capture_reuse.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} move_capture_reuse.t.exe move_capture_reuse.cpp move_capture_reuse.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps move_capture_reuse.t.exe)
+  (action (run ./move_capture_reuse.t.exe))))

--- a/tests/regression/forward_spec_ascii/ForwardSpecAscii.v
+++ b/tests/regression/forward_spec_ascii/ForwardSpecAscii.v
@@ -1,0 +1,27 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 4: same-module helper forward specs must be emitted before methods use them. *)
+
+From Stdlib Require Import Nat.
+
+Module ForwardSpecAscii.
+
+Inductive node : Type :=
+| ANode : nat -> node
+| BNode : nat -> node.
+
+Definition helper_nat (n : nat) : nat := S n.
+
+Definition bump_node (x : node) : nat :=
+  match x with
+  | ANode n => helper_nat n
+  | BNode n => helper_nat n
+  end.
+
+Definition t : nat := bump_node (ANode 2).
+
+End ForwardSpecAscii.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "forward_spec_ascii" ForwardSpecAscii.

--- a/tests/regression/forward_spec_ascii/forward_spec_ascii.cpp
+++ b/tests/regression/forward_spec_ascii/forward_spec_ascii.cpp
@@ -1,0 +1,31 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <forward_spec_ascii.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int ForwardSpecAscii::helper_nat(const unsigned int n) {
+  return (std::move(n) + 1);
+}
+
+unsigned int
+ForwardSpecAscii::bump_node(const std::shared_ptr<ForwardSpecAscii::node> &x) {
+  return std::visit(
+      Overloaded{[](const typename ForwardSpecAscii::node::ANode _args)
+                     -> unsigned int {
+                   unsigned int n = _args._a0;
+                   return helper_nat(std::move(n));
+                 },
+                 [](const typename ForwardSpecAscii::node::BNode _args)
+                     -> unsigned int {
+                   unsigned int n = _args._a0;
+                   return helper_nat(std::move(n));
+                 }},
+      x->v());
+}

--- a/tests/regression/forward_spec_ascii/forward_spec_ascii.h
+++ b/tests/regression/forward_spec_ascii/forward_spec_ascii.h
@@ -1,0 +1,90 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct ForwardSpecAscii {
+  struct node {
+  public:
+    struct ANode {
+      unsigned int _a0;
+    };
+    struct BNode {
+      unsigned int _a0;
+    };
+    using variant_t = std::variant<ANode, BNode>;
+
+  private:
+    variant_t v_;
+    explicit node(ANode _v) : v_(std::move(_v)) {}
+    explicit node(BNode _v) : v_(std::move(_v)) {}
+
+  public:
+    struct ctor {
+      ctor() = delete;
+      static std::shared_ptr<node> ANode_(unsigned int a0) {
+        return std::shared_ptr<node>(new node(ANode{a0}));
+      }
+      static std::shared_ptr<node> BNode_(unsigned int a0) {
+        return std::shared_ptr<node>(new node(BNode{a0}));
+      }
+      static std::unique_ptr<node> ANode_uptr(unsigned int a0) {
+        return std::unique_ptr<node>(new node(ANode{a0}));
+      }
+      static std::unique_ptr<node> BNode_uptr(unsigned int a0) {
+        return std::unique_ptr<node>(new node(BNode{a0}));
+      }
+    };
+    const variant_t &v() const { return v_; }
+    variant_t &v_mut() { return v_; }
+  };
+
+  template <typename T1, MapsTo<T1, unsigned int> F0,
+            MapsTo<T1, unsigned int> F1>
+  static T1 node_rect(F0 &&f, F1 &&f0, const std::shared_ptr<node> &n) {
+    return std::visit(Overloaded{[&](const typename node::ANode _args) -> T1 {
+                                   unsigned int n0 = _args._a0;
+                                   return f(std::move(n0));
+                                 },
+                                 [&](const typename node::BNode _args) -> T1 {
+                                   unsigned int n0 = _args._a0;
+                                   return f0(std::move(n0));
+                                 }},
+                      n->v());
+  }
+
+  template <typename T1, MapsTo<T1, unsigned int> F0,
+            MapsTo<T1, unsigned int> F1>
+  static T1 node_rec(F0 &&f, F1 &&f0, const std::shared_ptr<node> &n) {
+    return std::visit(Overloaded{[&](const typename node::ANode _args) -> T1 {
+                                   unsigned int n0 = _args._a0;
+                                   return f(std::move(n0));
+                                 },
+                                 [&](const typename node::BNode _args) -> T1 {
+                                   unsigned int n0 = _args._a0;
+                                   return f0(std::move(n0));
+                                 }},
+                      n->v());
+  }
+
+  static unsigned int helper_nat(const unsigned int n);
+
+  static unsigned int bump_node(const std::shared_ptr<node> &x);
+
+  static inline const unsigned int t =
+      bump_node(node::ctor::ANode_(((0 + 1) + 1)));
+};

--- a/tests/regression/forward_spec_ascii/forward_spec_ascii.t.cpp
+++ b/tests/regression/forward_spec_ascii/forward_spec_ascii.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <forward_spec_ascii.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(ForwardSpecAscii::t == 3u);
+    return testStatus;
+}

--- a/tests/regression/func_only_submodule/FuncOnlySubmodule.v
+++ b/tests/regression/func_only_submodule/FuncOnlySubmodule.v
@@ -1,0 +1,21 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 3: missing wrapper emission for function-only nested submodule. *)
+
+From Stdlib Require Import Nat.
+
+Module FuncOnlySubmodule.
+
+Module Outer.
+  Module Inner.
+    Definition bump (n : nat) : nat := S n.
+  End Inner.
+End Outer.
+
+Definition t : nat := Outer.Inner.bump 0.
+
+End FuncOnlySubmodule.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "func_only_submodule" FuncOnlySubmodule.

--- a/tests/regression/func_only_submodule/func_only_submodule.cpp
+++ b/tests/regression/func_only_submodule/func_only_submodule.cpp
@@ -1,0 +1,15 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <func_only_submodule.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int FuncOnlySubmodule::Outer::Inner::bump(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/func_only_submodule/func_only_submodule.h
+++ b/tests/regression/func_only_submodule/func_only_submodule.h
@@ -1,0 +1,28 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct FuncOnlySubmodule {
+  struct Outer {
+    struct Inner {
+      static unsigned int bump(const unsigned int n);
+    };
+  };
+
+  static inline const unsigned int t = Outer::Inner::bump(0);
+};

--- a/tests/regression/func_only_submodule/func_only_submodule.t.cpp
+++ b/tests/regression/func_only_submodule/func_only_submodule.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <func_only_submodule.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(FuncOnlySubmodule::t == 1u);
+    return testStatus;
+}

--- a/tests/regression/move_capture_reuse/MoveCaptureReuse.v
+++ b/tests/regression/move_capture_reuse/MoveCaptureReuse.v
@@ -1,0 +1,26 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 11: runtime move-capture reuse in repeated closure selector path. *)
+
+From Stdlib Require Import Nat List.
+Import ListNotations.
+
+Module MoveCaptureReuse.
+
+Definition prefix_each (prefix : list nat) (xss : list (list nat)) : list (list nat) :=
+  List.map (fun xs => prefix ++ xs) xss.
+
+Definition sample : list (list nat) :=
+  prefix_each [1] [[10]; [20]].
+
+Definition len_sum : nat :=
+  match sample with
+  | a :: b :: _ => List.length a + List.length b
+  | _ => 0
+  end.
+
+End MoveCaptureReuse.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "move_capture_reuse" MoveCaptureReuse.

--- a/tests/regression/move_capture_reuse/move_capture_reuse.cpp
+++ b/tests/regression/move_capture_reuse/move_capture_reuse.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <move_capture_reuse.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>>
+MoveCaptureReuse::prefix_each(
+    std::shared_ptr<List<unsigned int>> prefix,
+    const std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>> &xss) {
+  return xss->template map<std::shared_ptr<List<unsigned int>>>(
+      [&](std::shared_ptr<List<unsigned int>> xs) { return prefix->app(xs); });
+}

--- a/tests/regression/move_capture_reuse/move_capture_reuse.h
+++ b/tests/regression/move_capture_reuse/move_capture_reuse.h
@@ -1,0 +1,152 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+template <typename A> struct List {
+public:
+  struct nil {};
+  struct cons {
+    A _a0;
+    std::shared_ptr<List<A>> _a1;
+  };
+  using variant_t = std::variant<nil, cons>;
+
+private:
+  variant_t v_;
+  explicit List(nil _v) : v_(std::move(_v)) {}
+  explicit List(cons _v) : v_(std::move(_v)) {}
+
+public:
+  struct ctor {
+    ctor() = delete;
+    static std::shared_ptr<List<A>> nil_() {
+      return std::shared_ptr<List<A>>(new List<A>(nil{}));
+    }
+    static std::shared_ptr<List<A>> cons_(A a0,
+                                          const std::shared_ptr<List<A>> &a1) {
+      return std::shared_ptr<List<A>>(new List<A>(cons{a0, a1}));
+    }
+    static std::unique_ptr<List<A>> nil_uptr() {
+      return std::unique_ptr<List<A>>(new List<A>(nil{}));
+    }
+    static std::unique_ptr<List<A>>
+    cons_uptr(A a0, const std::shared_ptr<List<A>> &a1) {
+      return std::unique_ptr<List<A>>(new List<A>(cons{a0, a1}));
+    }
+  };
+  const variant_t &v() const { return v_; }
+  variant_t &v_mut() { return v_; }
+  template <typename T1, MapsTo<T1, A> F0>
+  std::shared_ptr<List<T1>> map(F0 &&f) const {
+    return std::visit(
+        Overloaded{
+            [](const typename List<A>::nil _args) -> std::shared_ptr<List<T1>> {
+              return List<T1>::ctor::nil_();
+            },
+            [&](const typename List<A>::cons _args)
+                -> std::shared_ptr<List<T1>> {
+              A a = _args._a0;
+              std::shared_ptr<List<A>> l0 = _args._a1;
+              return List<T1>::ctor::cons_(f(a),
+                                           std::move(l0)->template map<T1>(f));
+            }},
+        this->v());
+  }
+  unsigned int length() const {
+    return std::visit(
+        Overloaded{
+            [](const typename List<A>::nil _args) -> unsigned int { return 0; },
+            [](const typename List<A>::cons _args) -> unsigned int {
+              std::shared_ptr<List<A>> l_ = _args._a1;
+              return (std::move(l_)->length() + 1);
+            }},
+        this->v());
+  }
+  std::shared_ptr<List<A>> app(const std::shared_ptr<List<A>> &m) const {
+    return std::visit(Overloaded{[&](const typename List<A>::nil _args)
+                                     -> std::shared_ptr<List<A>> { return m; },
+                                 [&](const typename List<A>::cons _args)
+                                     -> std::shared_ptr<List<A>> {
+                                   A a = _args._a0;
+                                   std::shared_ptr<List<A>> l1 = _args._a1;
+                                   return List<A>::ctor::cons_(
+                                       a, std::move(l1)->app(m));
+                                 }},
+                      this->v());
+  }
+};
+
+struct MoveCaptureReuse {
+  static std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>> prefix_each(
+      std::shared_ptr<List<unsigned int>> prefix,
+      const std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>> &xss);
+
+  static inline const std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>>
+      sample = prefix_each(
+          List<unsigned int>::ctor::cons_((0 + 1),
+                                          List<unsigned int>::ctor::nil_()),
+          List<std::shared_ptr<List<unsigned int>>>::ctor::cons_(
+              List<unsigned int>::ctor::cons_(
+                  ((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1),
+                  List<unsigned int>::ctor::nil_()),
+              List<std::shared_ptr<List<unsigned int>>>::ctor::cons_(
+                  List<unsigned int>::ctor::cons_(
+                      ((((((((((((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
+                                   1) +
+                                  1) +
+                                 1) +
+                                1) +
+                               1) +
+                              1) +
+                             1) +
+                            1) +
+                           1) +
+                          1) +
+                         1) +
+                        1) +
+                       1),
+                      List<unsigned int>::ctor::nil_()),
+                  List<std::shared_ptr<List<unsigned int>>>::ctor::nil_())));
+
+  static inline const unsigned int len_sum = []() {
+    return std::visit(
+        Overloaded{
+            [](const typename List<std::shared_ptr<List<unsigned int>>>::nil
+                   _args) -> unsigned int { return 0; },
+            [](const typename List<std::shared_ptr<List<unsigned int>>>::cons
+                   _args) -> unsigned int {
+              std::shared_ptr<List<unsigned int>> a = _args._a0;
+              std::shared_ptr<List<std::shared_ptr<List<unsigned int>>>> l =
+                  _args._a1;
+              return std::visit(
+                  Overloaded{
+                      [](const typename List<
+                          std::shared_ptr<List<unsigned int>>>::nil _args)
+                          -> unsigned int { return 0; },
+                      [&](const typename List<
+                          std::shared_ptr<List<unsigned int>>>::cons _args)
+                          -> unsigned int {
+                        std::shared_ptr<List<unsigned int>> b = _args._a0;
+                        return (std::move(a)->length() +
+                                std::move(b)->length());
+                      }},
+                  std::move(l)->v());
+            }},
+        sample->v());
+  }();
+};

--- a/tests/regression/move_capture_reuse/move_capture_reuse.t.cpp
+++ b/tests/regression/move_capture_reuse/move_capture_reuse.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <move_capture_reuse.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(MoveCaptureReuse::len_sum == 4u);
+    return testStatus;
+}

--- a/tests/regression/signature_parity_fix/SignatureParityFix.v
+++ b/tests/regression/signature_parity_fix/SignatureParityFix.v
@@ -1,0 +1,23 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 9: header/source signature parity for extracted helper functions. *)
+
+From Stdlib Require Import Nat.
+
+Module SignatureParityFix.
+
+Definition f (seed : nat) : nat :=
+  let fix aux (n : nat) : nat :=
+      match n with
+      | O => seed
+      | S n' => aux n'
+      end
+  in aux (S seed).
+
+Definition t : nat := f 4.
+
+End SignatureParityFix.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "signature_parity_fix" SignatureParityFix.

--- a/tests/regression/signature_parity_fix/signature_parity_fix.cpp
+++ b/tests/regression/signature_parity_fix/signature_parity_fix.cpp
@@ -1,0 +1,24 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <signature_parity_fix.h>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int SignatureParityFix::f(const unsigned int seed) {
+  std::function<unsigned int(unsigned int)> aux;
+  aux = [&](unsigned int n) -> unsigned int {
+    if (n <= 0) {
+      return seed;
+    } else {
+      unsigned int n_ = n - 1;
+      return aux(n_);
+    }
+  };
+  return aux((seed + 1));
+}

--- a/tests/regression/signature_parity_fix/signature_parity_fix.h
+++ b/tests/regression/signature_parity_fix/signature_parity_fix.h
@@ -1,0 +1,24 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct SignatureParityFix {
+  static unsigned int f(const unsigned int seed);
+
+  static inline const unsigned int t = f(((((0 + 1) + 1) + 1) + 1));
+};

--- a/tests/regression/signature_parity_fix/signature_parity_fix.t.cpp
+++ b/tests/regression/signature_parity_fix/signature_parity_fix.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <signature_parity_fix.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(SignatureParityFix::t == 4u);
+    return testStatus;
+}

--- a/tests/regression/wrapper_collision_pos/WrapperCollisionPos.v
+++ b/tests/regression/wrapper_collision_pos/WrapperCollisionPos.v
@@ -1,0 +1,28 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 1: wrapper name collision when distinct modules share basename Pos. *)
+
+From Stdlib Require Import Nat.
+
+Module WrapperCollisionPos.
+
+Module Left.
+  Module Pos.
+    Definition id_left (n : nat) : nat := n.
+  End Pos.
+End Left.
+
+Module Right.
+  Module Pos.
+    Definition inc_right (n : nat) : nat := S n.
+  End Pos.
+End Right.
+
+Definition t1 : nat := Left.Pos.id_left 1.
+Definition t2 : nat := Right.Pos.inc_right 1.
+
+End WrapperCollisionPos.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "wrapper_collision_pos" WrapperCollisionPos.

--- a/tests/regression/wrapper_collision_pos/wrapper_collision_pos.cpp
+++ b/tests/regression/wrapper_collision_pos/wrapper_collision_pos.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <wrapper_collision_pos.h>
+
+unsigned int WrapperCollisionPos::Left::Pos::id_left(const unsigned int n) {
+  return std::move(n);
+}
+
+unsigned int WrapperCollisionPos::Right::Pos::inc_right(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/wrapper_collision_pos/wrapper_collision_pos.h
+++ b/tests/regression/wrapper_collision_pos/wrapper_collision_pos.h
@@ -1,0 +1,36 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct WrapperCollisionPos {
+  struct Left {
+    struct Pos {
+      static unsigned int id_left(const unsigned int n);
+    };
+  };
+
+  struct Right {
+    struct Pos {
+      static unsigned int inc_right(const unsigned int n);
+    };
+  };
+
+  static inline const unsigned int t1 = Left::Pos::id_left((0 + 1));
+
+  static inline const unsigned int t2 = Right::Pos::inc_right((0 + 1));
+};

--- a/tests/regression/wrapper_collision_pos/wrapper_collision_pos.t.cpp
+++ b/tests/regression/wrapper_collision_pos/wrapper_collision_pos.t.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <wrapper_collision_pos.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(WrapperCollisionPos::t1 == 1u);
+    ASSERT(WrapperCollisionPos::t2 == 2u);
+    return testStatus;
+}

--- a/tests/regression/wrapper_decl_merge/WrapperDeclMerge.v
+++ b/tests/regression/wrapper_decl_merge/WrapperDeclMerge.v
@@ -1,0 +1,28 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 2: wrapper declaration overwrite instead of merge for shared wrapper target. *)
+
+From Stdlib Require Import Nat.
+
+Module WrapperDeclMerge.
+
+Module A.
+  Module Nat.
+    Definition fa (n : nat) : nat := n.
+  End Nat.
+End A.
+
+Module B.
+  Module Nat.
+    Definition fb (n : nat) : nat := S n.
+  End Nat.
+End B.
+
+Definition x : nat := A.Nat.fa 4.
+Definition y : nat := B.Nat.fb 4.
+
+End WrapperDeclMerge.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "wrapper_decl_merge" WrapperDeclMerge.

--- a/tests/regression/wrapper_decl_merge/wrapper_decl_merge.cpp
+++ b/tests/regression/wrapper_decl_merge/wrapper_decl_merge.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <wrapper_decl_merge.h>
+
+unsigned int WrapperDeclMerge::A::Nat::fa(const unsigned int n) {
+  return std::move(n);
+}
+
+unsigned int WrapperDeclMerge::B::Nat::fb(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/wrapper_decl_merge/wrapper_decl_merge.h
+++ b/tests/regression/wrapper_decl_merge/wrapper_decl_merge.h
@@ -1,0 +1,36 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct WrapperDeclMerge {
+  struct A {
+    struct Nat {
+      static unsigned int fa(const unsigned int n);
+    };
+  };
+
+  struct B {
+    struct Nat {
+      static unsigned int fb(const unsigned int n);
+    };
+  };
+
+  static inline const unsigned int x = A::Nat::fa(((((0 + 1) + 1) + 1) + 1));
+
+  static inline const unsigned int y = B::Nat::fb(((((0 + 1) + 1) + 1) + 1));
+};

--- a/tests/regression/wrapper_decl_merge/wrapper_decl_merge.t.cpp
+++ b/tests/regression/wrapper_decl_merge/wrapper_decl_merge.t.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <wrapper_decl_merge.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(WrapperDeclMerge::x == 4u);
+    ASSERT(WrapperDeclMerge::y == 5u);
+    return testStatus;
+}

--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -171,3 +171,47 @@
   (deps sigma_compute.t.exe)
   (action (run ./sigma_compute.t.exe))))
 
+(subdir qualified_shadow_ascii
+ (rule
+  (targets qualified_shadow_ascii.t.exe)
+  (deps QualifiedShadowAscii.vo qualified_shadow_ascii.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} qualified_shadow_ascii.t.exe qualified_shadow_ascii.cpp qualified_shadow_ascii.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps qualified_shadow_ascii.t.exe)
+  (action (run ./qualified_shadow_ascii.t.exe))))
+
+(subdir enum_switch_qualified
+ (rule
+  (targets enum_switch_qualified.t.exe)
+  (deps EnumSwitchQualified.vo enum_switch_qualified.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} enum_switch_qualified.t.exe enum_switch_qualified.cpp enum_switch_qualified.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps enum_switch_qualified.t.exe)
+  (action (run ./enum_switch_qualified.t.exe))))
+
+(subdir identifier_escape_param
+ (rule
+  (targets identifier_escape_param.t.exe)
+  (deps IdentifierEscapeParam.vo identifier_escape_param.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} identifier_escape_param.t.exe identifier_escape_param.cpp identifier_escape_param.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps identifier_escape_param.t.exe)
+  (action (run ./identifier_escape_param.t.exe))))
+
+(subdir keyword_double_global
+ (rule
+  (targets keyword_double_global.t.exe)
+  (deps KeywordDoubleGlobal.vo keyword_double_global.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} keyword_double_global.t.exe keyword_double_global.cpp keyword_double_global.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps keyword_double_global.t.exe)
+  (action (run ./keyword_double_global.t.exe))))
+

--- a/tests/wip/enum_switch_qualified/EnumSwitchQualified.v
+++ b/tests/wip/enum_switch_qualified/EnumSwitchQualified.v
@@ -1,0 +1,31 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 6: enum switch generation must preserve correct module qualification. *)
+
+From Stdlib Require Import Nat.
+
+Module EnumSwitchQualified.
+
+Module Outer.
+  Inductive color : Type := Red | Blue.
+
+  Definition flip (c : color) : color :=
+    match c with
+    | Red => Blue
+    | Blue => Red
+    end.
+
+  Definition code (c : color) : nat :=
+    match c with
+    | Red => 1
+    | Blue => 2
+    end.
+End Outer.
+
+Definition t : nat := Outer.code (Outer.flip Outer.Red).
+
+End EnumSwitchQualified.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "enum_switch_qualified" EnumSwitchQualified.

--- a/tests/wip/enum_switch_qualified/enum_switch_qualified.cpp
+++ b/tests/wip/enum_switch_qualified/enum_switch_qualified.cpp
@@ -1,0 +1,37 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <enum_switch_qualified.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+color EnumSwitchQualified::Outer::flip(const color c) {
+  return [&](void) {
+    switch (c) {
+    case color::Red: {
+      return color::Blue;
+    }
+    case color::Blue: {
+      return color::Red;
+    }
+    }
+  }();
+}
+
+unsigned int EnumSwitchQualified::Outer::code(const color c) {
+  return [&](void) {
+    switch (c) {
+    case color::Red: {
+      return (0 + 1);
+    }
+    case color::Blue: {
+      return ((0 + 1) + 1);
+    }
+    }
+  }();
+}

--- a/tests/wip/enum_switch_qualified/enum_switch_qualified.h
+++ b/tests/wip/enum_switch_qualified/enum_switch_qualified.h
@@ -1,0 +1,59 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct EnumSwitchQualified {
+  struct Outer {
+    enum class color { Red, Blue };
+
+    template <typename T1>
+    static T1 color_rect(const T1 f, const T1 f0, const color c) {
+      return [&](void) {
+        switch (c) {
+        case color::Red: {
+          return f;
+        }
+        case color::Blue: {
+          return f0;
+        }
+        }
+      }();
+    }
+
+    template <typename T1>
+    static T1 color_rec(const T1 f, const T1 f0, const color c) {
+      return [&](void) {
+        switch (c) {
+        case color::Red: {
+          return f;
+        }
+        case color::Blue: {
+          return f0;
+        }
+        }
+      }();
+    }
+
+    static color flip(const color c);
+
+    static unsigned int code(const color c);
+  };
+
+  static inline const unsigned int t =
+      Outer::code(Outer::flip(Outer::color::Red));
+};

--- a/tests/wip/enum_switch_qualified/enum_switch_qualified.t.cpp
+++ b/tests/wip/enum_switch_qualified/enum_switch_qualified.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <enum_switch_qualified.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(EnumSwitchQualified::t == 2u);
+    return testStatus;
+}

--- a/tests/wip/identifier_escape_param/IdentifierEscapeParam.v
+++ b/tests/wip/identifier_escape_param/IdentifierEscapeParam.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 7: escaping of parameter/member identifiers colliding in generated C++. *)
+
+From Stdlib Require Import Nat.
+
+Module IdentifierEscapeParam.
+
+Definition id_from_param (double : nat) : nat := double.
+Definition add_one_from_param (double : nat) : nat := S (id_from_param double).
+Definition t : nat := add_one_from_param 6.
+
+End IdentifierEscapeParam.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "identifier_escape_param" IdentifierEscapeParam.

--- a/tests/wip/identifier_escape_param/identifier_escape_param.cpp
+++ b/tests/wip/identifier_escape_param/identifier_escape_param.cpp
@@ -1,0 +1,20 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <identifier_escape_param.h>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int IdentifierEscapeParam::id_from_param(const unsigned int double) {
+  return std::move(double);
+}
+
+unsigned int
+IdentifierEscapeParam::add_one_from_param(const unsigned int double) {
+  return (id_from_param(std::move(double)) + 1);
+}

--- a/tests/wip/identifier_escape_param/identifier_escape_param.h
+++ b/tests/wip/identifier_escape_param/identifier_escape_param.h
@@ -1,0 +1,27 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct IdentifierEscapeParam {
+  static unsigned int id_from_param(const unsigned int double);
+
+  static unsigned int add_one_from_param(const unsigned int double);
+
+  static inline const unsigned int t =
+      add_one_from_param(((((((0 + 1) + 1) + 1) + 1) + 1) + 1));
+};

--- a/tests/wip/identifier_escape_param/identifier_escape_param.t.cpp
+++ b/tests/wip/identifier_escape_param/identifier_escape_param.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <identifier_escape_param.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(IdentifierEscapeParam::t == 7u);
+    return testStatus;
+}

--- a/tests/wip/keyword_double_global/KeywordDoubleGlobal.v
+++ b/tests/wip/keyword_double_global/KeywordDoubleGlobal.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 8: keyword-safe emission for global symbol named double. *)
+
+From Stdlib Require Import Nat.
+
+Module KeywordDoubleGlobal.
+
+Definition double (n : nat) : nat := n + n.
+Definition t : nat := double 3.
+
+End KeywordDoubleGlobal.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "keyword_double_global" KeywordDoubleGlobal.

--- a/tests/wip/keyword_double_global/keyword_double_global.cpp
+++ b/tests/wip/keyword_double_global/keyword_double_global.cpp
@@ -1,0 +1,15 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <keyword_double_global.h>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int KeywordDoubleGlobal::double(const unsigned int n) {
+  return (n + n);
+}

--- a/tests/wip/keyword_double_global/keyword_double_global.h
+++ b/tests/wip/keyword_double_global/keyword_double_global.h
@@ -1,0 +1,24 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct KeywordDoubleGlobal {
+  static unsigned int double(const unsigned int n);
+
+  static inline const unsigned int t = double((((0 + 1) + 1) + 1));
+};

--- a/tests/wip/keyword_double_global/keyword_double_global.t.cpp
+++ b/tests/wip/keyword_double_global/keyword_double_global.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <keyword_double_global.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(KeywordDoubleGlobal::t == 6u);
+    return testStatus;
+}

--- a/tests/wip/qualified_shadow_ascii/QualifiedShadowAscii.v
+++ b/tests/wip/qualified_shadow_ascii/QualifiedShadowAscii.v
@@ -1,0 +1,19 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Bug 5: qualified type names must be rendered in absolute form under shadowing. *)
+
+Module QualifiedShadowAscii.
+
+Module Shadow.
+  Inductive shadow : Type :=
+  | Mk.
+End Shadow.
+
+Definition id_shadow (x : Shadow.shadow) : Shadow.shadow := x.
+Definition t : Shadow.shadow := id_shadow Shadow.Mk.
+
+End QualifiedShadowAscii.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std.
+Crane Extraction "qualified_shadow_ascii" QualifiedShadowAscii.

--- a/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.cpp
+++ b/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.cpp
@@ -1,0 +1,15 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <qualified_shadow_ascii.h>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+Shadow::shadow QualifiedShadowAscii::id_shadow(const Shadow::shadow x) {
+  return x;
+}

--- a/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.h
+++ b/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.h
@@ -1,0 +1,28 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct QualifiedShadowAscii {
+  struct Shadow {
+    enum class shadow { Mk };
+  };
+
+  static Shadow::shadow id_shadow(const Shadow::shadow x);
+
+  static inline const Shadow::shadow t = id_shadow(Shadow::shadow::Mk);
+};

--- a/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.t.cpp
+++ b/tests/wip/qualified_shadow_ascii/qualified_shadow_ascii.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <qualified_shadow_ascii.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    (void)QualifiedShadowAscii::t;
+    return testStatus;
+}


### PR DESCRIPTION
## Summary
This PR adds 12 focused repro tests for recently identified Crane codegen issues.

## Test Cases
- wrapper_collision_pos
- wrapper_decl_merge
- func_only_submodule
- forward_spec_ascii
- qualified_shadow_ascii
- enum_switch_qualified
- identifier_escape_param
- keyword_double_global
- signature_parity_fix
- bool_dec_std
- bool_dec_bde
- move_capture_reuse

## Layout
- Added passing cases under tests/regression:
  - wrapper_collision_pos
  - wrapper_decl_merge
  - func_only_submodule
  - forward_spec_ascii
  - signature_parity_fix
  - bool_dec_std
  - bool_dec_bde
  - move_capture_reuse
- Added active repro cases under tests/wip:
  - qualified_shadow_ascii
  - enum_switch_qualified
  - identifier_escape_param
  - keyword_double_global

## Build Rules
- Updated tests/regression/dune
- Updated tests/wip/dune

## Verification
- Built all new .vo targets.
- Confirmed compile success for new regression cases.
- Confirmed expected compile failures for new wip repro cases.