### PR TITLE
tests: add intel4004-derived family repros (wip + regression)

### DIFF
--- a/tests/regression/bool_nat_ternary_precedence_safe/BoolNatTernaryPrecedenceSafe.v
+++ b/tests/regression/bool_nat_ternary_precedence_safe/BoolNatTernaryPrecedenceSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: bool/nat branch lowering remains stable *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module BoolNatTernaryPrecedenceSafe.
+Definition branch_left (b : bool) : nat := if b then 1 else 0.
+Definition branch_right (b : bool) : nat := if b then 2 else 3.
+Definition t : nat := branch_left true + branch_right false.
+End BoolNatTernaryPrecedenceSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "bool_nat_ternary_precedence_safe" BoolNatTernaryPrecedenceSafe.

--- a/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.cpp
+++ b/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.cpp
@@ -1,0 +1,27 @@
+#include <algorithm>
+#include <any>
+#include <bool_nat_ternary_precedence_safe.h>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int BoolNatTernaryPrecedenceSafe::branch_left(const bool b) {
+  if (b) {
+    return (0 + 1);
+  } else {
+    return 0;
+  }
+}
+
+unsigned int BoolNatTernaryPrecedenceSafe::branch_right(const bool b) {
+  if (b) {
+    return ((0 + 1) + 1);
+  } else {
+    return (((0 + 1) + 1) + 1);
+  }
+}

--- a/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.h
+++ b/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.h
@@ -1,0 +1,27 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct BoolNatTernaryPrecedenceSafe {
+  static unsigned int branch_left(const bool b);
+
+  static unsigned int branch_right(const bool b);
+
+  static inline const unsigned int t =
+      (branch_left(true) + branch_right(false));
+};

--- a/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.t.cpp
+++ b/tests/regression/bool_nat_ternary_precedence_safe/bool_nat_ternary_precedence_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <bool_nat_ternary_precedence_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(BoolNatTernaryPrecedenceSafe::t == 4u);
+    return testStatus;
+}

--- a/tests/regression/comparator_lowering_parity_safe/ComparatorLoweringParitySafe.v
+++ b/tests/regression/comparator_lowering_parity_safe/ComparatorLoweringParitySafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: comparator helper paths are fully qualified *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module ComparatorLoweringParitySafe.
+Module A. Module CmpLeft. Definition f (n : nat) : nat := n. End CmpLeft. End A.
+Module B. Module CmpRight. Definition g (n : nat) : nat := S n. End CmpRight. End B.
+Definition t : nat := A.CmpLeft.f 0 + B.CmpRight.g 1.
+End ComparatorLoweringParitySafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "comparator_lowering_parity_safe" ComparatorLoweringParitySafe.

--- a/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.cpp
+++ b/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.cpp
@@ -1,0 +1,20 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <comparator_lowering_parity_safe.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int ComparatorLoweringParitySafe::A::CmpLeft::f(const unsigned int n) {
+  return std::move(n);
+}
+
+unsigned int
+ComparatorLoweringParitySafe::B::CmpRight::g(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.h
+++ b/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.h
@@ -1,0 +1,35 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct ComparatorLoweringParitySafe {
+  struct A {
+    struct CmpLeft {
+      static unsigned int f(const unsigned int n);
+    };
+  };
+
+  struct B {
+    struct CmpRight {
+      static unsigned int g(const unsigned int n);
+    };
+  };
+
+  static inline const unsigned int t =
+      (A::CmpLeft::f(0) + B::CmpRight::g((0 + 1)));
+};

--- a/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.t.cpp
+++ b/tests/regression/comparator_lowering_parity_safe/comparator_lowering_parity_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <comparator_lowering_parity_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(ComparatorLoweringParitySafe::t == 2u);
+    return testStatus;
+}

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -871,3 +871,104 @@
   (alias runtest)
   (deps enum_switch_color_flip.t.exe)
   (action (run ./enum_switch_color_flip.t.exe))))
+
+(subdir nat_sub_underflow_safe
+ (rule
+  (targets nat_sub_underflow_safe.t.exe)
+  (deps NatSubUnderflowSafe.vo nat_sub_underflow_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nat_sub_underflow_safe.t.exe nat_sub_underflow_safe.cpp nat_sub_underflow_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nat_sub_underflow_safe.t.exe)
+  (action (run ./nat_sub_underflow_safe.t.exe))))
+(subdir bool_nat_ternary_precedence_safe
+ (rule
+  (targets bool_nat_ternary_precedence_safe.t.exe)
+  (deps BoolNatTernaryPrecedenceSafe.vo bool_nat_ternary_precedence_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} bool_nat_ternary_precedence_safe.t.exe bool_nat_ternary_precedence_safe.cpp bool_nat_ternary_precedence_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps bool_nat_ternary_precedence_safe.t.exe)
+  (action (run ./bool_nat_ternary_precedence_safe.t.exe))))
+(subdir comparator_lowering_parity_safe
+ (rule
+  (targets comparator_lowering_parity_safe.t.exe)
+  (deps ComparatorLoweringParitySafe.vo comparator_lowering_parity_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} comparator_lowering_parity_safe.t.exe comparator_lowering_parity_safe.cpp comparator_lowering_parity_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps comparator_lowering_parity_safe.t.exe)
+  (action (run ./comparator_lowering_parity_safe.t.exe))))
+(subdir option_tuple_wrapper_safe
+ (rule
+  (targets option_tuple_wrapper_safe.t.exe)
+  (deps OptionTupleWrapperSafe.vo option_tuple_wrapper_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} option_tuple_wrapper_safe.t.exe option_tuple_wrapper_safe.cpp option_tuple_wrapper_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps option_tuple_wrapper_safe.t.exe)
+  (action (run ./option_tuple_wrapper_safe.t.exe))))
+(subdir nested_record_update_qual_safe
+ (rule
+  (targets nested_record_update_qual_safe.t.exe)
+  (deps NestedRecordUpdateQualSafe.vo nested_record_update_qual_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nested_record_update_qual_safe.t.exe nested_record_update_qual_safe.cpp nested_record_update_qual_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nested_record_update_qual_safe.t.exe)
+  (action (run ./nested_record_update_qual_safe.t.exe))))
+(subdir mkstate_signature_drift_safe
+ (rule
+  (targets mkstate_signature_drift_safe.t.exe)
+  (deps MkstateSignatureDriftSafe.vo mkstate_signature_drift_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} mkstate_signature_drift_safe.t.exe mkstate_signature_drift_safe.cpp mkstate_signature_drift_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps mkstate_signature_drift_safe.t.exe)
+  (action (run ./mkstate_signature_drift_safe.t.exe))))
+(subdir helper_name_odr_safe
+ (rule
+  (targets helper_name_odr_safe.t.exe)
+  (deps HelperNameOdrSafe.vo helper_name_odr_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} helper_name_odr_safe.t.exe helper_name_odr_safe.cpp helper_name_odr_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps helper_name_odr_safe.t.exe)
+  (action (run ./helper_name_odr_safe.t.exe))))
+(subdir nth_default_struct_safe
+ (rule
+  (targets nth_default_struct_safe.t.exe)
+  (deps NthDefaultStructSafe.vo nth_default_struct_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nth_default_struct_safe.t.exe nth_default_struct_safe.cpp nth_default_struct_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nth_default_struct_safe.t.exe)
+  (action (run ./nth_default_struct_safe.t.exe))))
+(subdir match_forward_order_safe
+ (rule
+  (targets match_forward_order_safe.t.exe)
+  (deps MatchForwardOrderSafe.vo match_forward_order_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} match_forward_order_safe.t.exe match_forward_order_safe.cpp match_forward_order_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps match_forward_order_safe.t.exe)
+  (action (run ./match_forward_order_safe.t.exe))))
+(subdir ram_accessor_namespace_safe
+ (rule
+  (targets ram_accessor_namespace_safe.t.exe)
+  (deps RamAccessorNamespaceSafe.vo ram_accessor_namespace_safe.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} ram_accessor_namespace_safe.t.exe ram_accessor_namespace_safe.cpp ram_accessor_namespace_safe.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps ram_accessor_namespace_safe.t.exe)
+  (action (run ./ram_accessor_namespace_safe.t.exe))))

--- a/tests/regression/helper_name_odr_safe/HelperNameOdrSafe.v
+++ b/tests/regression/helper_name_odr_safe/HelperNameOdrSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: helper names remain ODR-safe *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module HelperNameOdrSafe.
+Definition helper_a (n : nat) : nat := n.
+Definition helper_b (n : nat) : nat := S n.
+Definition t : nat := helper_a 1 + helper_b 2.
+End HelperNameOdrSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "helper_name_odr_safe" HelperNameOdrSafe.

--- a/tests/regression/helper_name_odr_safe/helper_name_odr_safe.cpp
+++ b/tests/regression/helper_name_odr_safe/helper_name_odr_safe.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <helper_name_odr_safe.h>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int HelperNameOdrSafe::helper_a(const unsigned int n) {
+  return std::move(n);
+}
+
+unsigned int HelperNameOdrSafe::helper_b(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/helper_name_odr_safe/helper_name_odr_safe.h
+++ b/tests/regression/helper_name_odr_safe/helper_name_odr_safe.h
@@ -1,0 +1,27 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct HelperNameOdrSafe {
+  static unsigned int helper_a(const unsigned int n);
+
+  static unsigned int helper_b(const unsigned int n);
+
+  static inline const unsigned int t =
+      (helper_a((0 + 1)) + helper_b(((0 + 1) + 1)));
+};

--- a/tests/regression/helper_name_odr_safe/helper_name_odr_safe.t.cpp
+++ b/tests/regression/helper_name_odr_safe/helper_name_odr_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <helper_name_odr_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(HelperNameOdrSafe::t == 4u);
+    return testStatus;
+}

--- a/tests/regression/match_forward_order_safe/MatchForwardOrderSafe.v
+++ b/tests/regression/match_forward_order_safe/MatchForwardOrderSafe.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: match helper ordering remains valid *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module MatchForwardOrderSafe.
+Inductive token : Type := A | B.
+Definition choose (b : bool) : token := if b then A else B.
+Definition encode (x : token) : nat := match x with | A => 1 | B => 0 end.
+Definition t : nat := encode (choose false).
+End MatchForwardOrderSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "match_forward_order_safe" MatchForwardOrderSafe.

--- a/tests/regression/match_forward_order_safe/match_forward_order_safe.cpp
+++ b/tests/regression/match_forward_order_safe/match_forward_order_safe.cpp
@@ -1,0 +1,33 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <match_forward_order_safe.h>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+MatchForwardOrderSafe::token MatchForwardOrderSafe::choose(const bool b) {
+  if (b) {
+    return token::A;
+  } else {
+    return token::B;
+  }
+}
+
+unsigned int
+MatchForwardOrderSafe::encode(const MatchForwardOrderSafe::token x) {
+  return [&](void) {
+    switch (x) {
+    case token::A: {
+      return (0 + 1);
+    }
+    case token::B: {
+      return 0;
+    }
+    }
+  }();
+}

--- a/tests/regression/match_forward_order_safe/match_forward_order_safe.h
+++ b/tests/regression/match_forward_order_safe/match_forward_order_safe.h
@@ -1,0 +1,56 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct MatchForwardOrderSafe {
+  enum class token { A, B };
+
+  template <typename T1>
+  static T1 token_rect(const T1 f, const T1 f0, const token t) {
+    return [&](void) {
+      switch (t) {
+      case token::A: {
+        return f;
+      }
+      case token::B: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  template <typename T1>
+  static T1 token_rec(const T1 f, const T1 f0, const token t) {
+    return [&](void) {
+      switch (t) {
+      case token::A: {
+        return f;
+      }
+      case token::B: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  static token choose(const bool b);
+
+  static unsigned int encode(const token x);
+
+  static inline const unsigned int t = encode(choose(false));
+};

--- a/tests/regression/match_forward_order_safe/match_forward_order_safe.t.cpp
+++ b/tests/regression/match_forward_order_safe/match_forward_order_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <match_forward_order_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(MatchForwardOrderSafe::t == 0u);
+    return testStatus;
+}

--- a/tests/regression/mkstate_signature_drift_safe/MkstateSignatureDriftSafe.v
+++ b/tests/regression/mkstate_signature_drift_safe/MkstateSignatureDriftSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: declaration/definition signatures remain aligned *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module MkstateSignatureDriftSafe.
+Inductive state : Type := S0 | S1.
+Definition score (x : state) : nat := match x with | S0 => 1 | S1 => 2 end.
+Definition t : nat := score S0 + score S1.
+End MkstateSignatureDriftSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "mkstate_signature_drift_safe" MkstateSignatureDriftSafe.

--- a/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.cpp
+++ b/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.cpp
@@ -1,0 +1,25 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mkstate_signature_drift_safe.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int
+MkstateSignatureDriftSafe::score(const MkstateSignatureDriftSafe::state x) {
+  return [&](void) {
+    switch (x) {
+    case state::S0: {
+      return (0 + 1);
+    }
+    case state::S1: {
+      return ((0 + 1) + 1);
+    }
+    }
+  }();
+}

--- a/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.h
+++ b/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.h
@@ -1,0 +1,54 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct MkstateSignatureDriftSafe {
+  enum class state { S0, S1 };
+
+  template <typename T1>
+  static T1 state_rect(const T1 f, const T1 f0, const state s) {
+    return [&](void) {
+      switch (s) {
+      case state::S0: {
+        return f;
+      }
+      case state::S1: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  template <typename T1>
+  static T1 state_rec(const T1 f, const T1 f0, const state s) {
+    return [&](void) {
+      switch (s) {
+      case state::S0: {
+        return f;
+      }
+      case state::S1: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  static unsigned int score(const state x);
+
+  static inline const unsigned int t = (score(state::S0) + score(state::S1));
+};

--- a/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.t.cpp
+++ b/tests/regression/mkstate_signature_drift_safe/mkstate_signature_drift_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <mkstate_signature_drift_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(MkstateSignatureDriftSafe::t == 3u);
+    return testStatus;
+}

--- a/tests/regression/nat_sub_underflow_safe/NatSubUnderflowSafe.v
+++ b/tests/regression/nat_sub_underflow_safe/NatSubUnderflowSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: stable nat subtraction lowering *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module NatSubUnderflowSafe.
+Definition sub_checked (a b : nat) : nat := a - b.
+Definition sub_alt (a b : nat) : nat := b - a.
+Definition t : nat := sub_checked 7 9 + sub_alt 9 7.
+End NatSubUnderflowSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nat_sub_underflow_safe" NatSubUnderflowSafe.

--- a/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.cpp
+++ b/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.cpp
@@ -1,0 +1,21 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <nat_sub_underflow_safe.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int NatSubUnderflowSafe::sub_checked(const unsigned int _x0,
+                                              const unsigned int _x1) {
+  return (((_x0 - _x1) > _x0 ? 0 : (_x0 - _x1)));
+}
+
+unsigned int NatSubUnderflowSafe::sub_alt(const unsigned int a,
+                                          const unsigned int b) {
+  return (((b - a) > b ? 0 : (b - a)));
+}

--- a/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.h
+++ b/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.h
@@ -1,0 +1,30 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct NatSubUnderflowSafe {
+  static unsigned int sub_checked(const unsigned int, const unsigned int);
+
+  static unsigned int sub_alt(const unsigned int a, const unsigned int b);
+
+  static inline const unsigned int t =
+      (sub_checked((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1),
+                   (((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)) +
+       sub_alt((((((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1),
+               (((((((0 + 1) + 1) + 1) + 1) + 1) + 1) + 1)));
+};

--- a/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.t.cpp
+++ b/tests/regression/nat_sub_underflow_safe/nat_sub_underflow_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nat_sub_underflow_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(NatSubUnderflowSafe::t == 0u);
+    return testStatus;
+}

--- a/tests/regression/nested_record_update_qual_safe/NestedRecordUpdateQualSafe.v
+++ b/tests/regression/nested_record_update_qual_safe/NestedRecordUpdateQualSafe.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: nested record updates keep qualified names valid *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module NestedRecordUpdateQualSafe.
+Record cell : Type := Mk { value : nat }.
+Definition bump (x : cell) : cell := match x with | Mk n => Mk (S n) end.
+Definition project (x : cell) : nat := match x with | Mk n => n end.
+Definition t : nat := project (bump (Mk 1)).
+End NestedRecordUpdateQualSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nested_record_update_qual_safe" NestedRecordUpdateQualSafe.

--- a/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.cpp
+++ b/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.cpp
@@ -1,0 +1,30 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <nested_record_update_qual_safe.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int NestedRecordUpdateQualSafe::value(
+    const std::shared_ptr<NestedRecordUpdateQualSafe::cell> &c) {
+  return c->value;
+}
+
+std::shared_ptr<NestedRecordUpdateQualSafe::cell>
+NestedRecordUpdateQualSafe::bump(
+    const std::shared_ptr<NestedRecordUpdateQualSafe::cell> &x) {
+  return [&](void) {
+    unsigned int n = x->value;
+    return std::make_shared<NestedRecordUpdateQualSafe::cell>(cell{(n + 1)});
+  }();
+}
+
+unsigned int NestedRecordUpdateQualSafe::project(
+    const std::shared_ptr<NestedRecordUpdateQualSafe::cell> &x) {
+  return x->value;
+}

--- a/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.h
+++ b/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.h
@@ -1,0 +1,33 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct NestedRecordUpdateQualSafe {
+  struct cell {
+    unsigned int value;
+  };
+
+  static unsigned int value(const std::shared_ptr<cell> &c);
+
+  static std::shared_ptr<cell> bump(const std::shared_ptr<cell> &x);
+
+  static unsigned int project(const std::shared_ptr<cell> &x);
+
+  static inline const unsigned int t =
+      project(bump(std::make_shared<cell>(cell{(0 + 1)})));
+};

--- a/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.t.cpp
+++ b/tests/regression/nested_record_update_qual_safe/nested_record_update_qual_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nested_record_update_qual_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(NestedRecordUpdateQualSafe::t == 2u);
+    return testStatus;
+}

--- a/tests/regression/nth_default_struct_safe/NthDefaultStructSafe.v
+++ b/tests/regression/nth_default_struct_safe/NthDefaultStructSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: nth/default helpers generate consistent struct names *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module NthDefaultStructSafe.
+Module L. Module SlotLeft. Definition nth0 (n : nat) : nat := n. End SlotLeft. End L.
+Module R. Module SlotRight. Definition nth1 (n : nat) : nat := S n. End SlotRight. End R.
+Definition t : nat := L.SlotLeft.nth0 1 + R.SlotRight.nth1 2.
+End NthDefaultStructSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nth_default_struct_safe" NthDefaultStructSafe.

--- a/tests/regression/nth_default_struct_safe/nth_default_struct_safe.cpp
+++ b/tests/regression/nth_default_struct_safe/nth_default_struct_safe.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <nth_default_struct_safe.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int NthDefaultStructSafe::L::SlotLeft::nth0(const unsigned int n) {
+  return std::move(n);
+}
+
+unsigned int NthDefaultStructSafe::R::SlotRight::nth1(const unsigned int n) {
+  return (std::move(n) + 1);
+}

--- a/tests/regression/nth_default_struct_safe/nth_default_struct_safe.h
+++ b/tests/regression/nth_default_struct_safe/nth_default_struct_safe.h
@@ -1,0 +1,35 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct NthDefaultStructSafe {
+  struct L {
+    struct SlotLeft {
+      static unsigned int nth0(const unsigned int n);
+    };
+  };
+
+  struct R {
+    struct SlotRight {
+      static unsigned int nth1(const unsigned int n);
+    };
+  };
+
+  static inline const unsigned int t =
+      (L::SlotLeft::nth0((0 + 1)) + R::SlotRight::nth1(((0 + 1) + 1)));
+};

--- a/tests/regression/nth_default_struct_safe/nth_default_struct_safe.t.cpp
+++ b/tests/regression/nth_default_struct_safe/nth_default_struct_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nth_default_struct_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(NthDefaultStructSafe::t == 4u);
+    return testStatus;
+}

--- a/tests/regression/option_tuple_wrapper_safe/OptionTupleWrapperSafe.v
+++ b/tests/regression/option_tuple_wrapper_safe/OptionTupleWrapperSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: option/tuple-like constructors compile cleanly *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module OptionTupleWrapperSafe.
+Inductive tag : Type := SomeTag | NoneTag.
+Definition pick_nat (b : bool) : nat := if b then 1 else 0.
+Definition t : nat := pick_nat true.
+End OptionTupleWrapperSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "option_tuple_wrapper_safe" OptionTupleWrapperSafe.

--- a/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.cpp
+++ b/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.cpp
@@ -1,0 +1,19 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <option_tuple_wrapper_safe.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int OptionTupleWrapperSafe::pick_nat(const bool b) {
+  if (b) {
+    return (0 + 1);
+  } else {
+    return 0;
+  }
+}

--- a/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.h
+++ b/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.h
@@ -1,0 +1,54 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct OptionTupleWrapperSafe {
+  enum class tag { SomeTag, NoneTag };
+
+  template <typename T1>
+  static T1 tag_rect(const T1 f, const T1 f0, const tag t) {
+    return [&](void) {
+      switch (t) {
+      case tag::SomeTag: {
+        return f;
+      }
+      case tag::NoneTag: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  template <typename T1>
+  static T1 tag_rec(const T1 f, const T1 f0, const tag t) {
+    return [&](void) {
+      switch (t) {
+      case tag::SomeTag: {
+        return f;
+      }
+      case tag::NoneTag: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  static unsigned int pick_nat(const bool b);
+
+  static inline const unsigned int t = pick_nat(true);
+};

--- a/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.t.cpp
+++ b/tests/regression/option_tuple_wrapper_safe/option_tuple_wrapper_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <option_tuple_wrapper_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(OptionTupleWrapperSafe::t == 1u);
+    return testStatus;
+}

--- a/tests/regression/ram_accessor_namespace_safe/RamAccessorNamespaceSafe.v
+++ b/tests/regression/ram_accessor_namespace_safe/RamAccessorNamespaceSafe.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* Regression: RAM accessor naming keeps namespaces distinct *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module RamAccessorNamespaceSafe.
+Inductive port : Type := ReadPort | WritePort.
+Definition read (x : port) : nat := match x with | ReadPort => 3 | WritePort => 4 end.
+Definition t : nat := read ReadPort + read WritePort.
+End RamAccessorNamespaceSafe.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "ram_accessor_namespace_safe" RamAccessorNamespaceSafe.

--- a/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.cpp
+++ b/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.cpp
@@ -1,0 +1,25 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <ram_accessor_namespace_safe.h>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+unsigned int
+RamAccessorNamespaceSafe::read(const RamAccessorNamespaceSafe::port x) {
+  return [&](void) {
+    switch (x) {
+    case port::ReadPort: {
+      return (((0 + 1) + 1) + 1);
+    }
+    case port::WritePort: {
+      return ((((0 + 1) + 1) + 1) + 1);
+    }
+    }
+  }();
+}

--- a/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.h
+++ b/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.h
@@ -1,0 +1,55 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct RamAccessorNamespaceSafe {
+  enum class port { ReadPort, WritePort };
+
+  template <typename T1>
+  static T1 port_rect(const T1 f, const T1 f0, const port p) {
+    return [&](void) {
+      switch (p) {
+      case port::ReadPort: {
+        return f;
+      }
+      case port::WritePort: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  template <typename T1>
+  static T1 port_rec(const T1 f, const T1 f0, const port p) {
+    return [&](void) {
+      switch (p) {
+      case port::ReadPort: {
+        return f;
+      }
+      case port::WritePort: {
+        return f0;
+      }
+      }
+    }();
+  }
+
+  static unsigned int read(const port x);
+
+  static inline const unsigned int t =
+      (read(port::ReadPort) + read(port::WritePort));
+};

--- a/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.t.cpp
+++ b/tests/regression/ram_accessor_namespace_safe/ram_accessor_namespace_safe.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <ram_accessor_namespace_safe.h>
+
+#include <iostream>
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        std::cout << "Error " __FILE__ "(" << line << "): " << message
+                  << "    (failed)" << std::endl;
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+#define ASSERT(X)                                              \
+    aSsErT(!(X), #X, __LINE__);
+
+int main()
+{
+    ASSERT(RamAccessorNamespaceSafe::t == 7u);
+    return testStatus;
+}

--- a/tests/wip/bool_nat_ternary_precedence/BoolNatTernaryPrecedence.v
+++ b/tests/wip/bool_nat_ternary_precedence/BoolNatTernaryPrecedence.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: bool->nat branch helpers with keyword-style identifiers *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module BoolNatTernaryPrecedence.
+
+Definition class (b : bool) : nat := if b then 1 else 0.
+Definition class_ (b : bool) : nat := if b then 2 else 3.
+Definition t : nat := class true + class_ false.
+End BoolNatTernaryPrecedence.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "bool_nat_ternary_precedence" BoolNatTernaryPrecedence.

--- a/tests/wip/bool_nat_ternary_precedence/bool_nat_ternary_precedence.t.cpp
+++ b/tests/wip/bool_nat_ternary_precedence/bool_nat_ternary_precedence.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <bool_nat_ternary_precedence.h>
+
+int main()
+{
+    (void)BoolNatTernaryPrecedence::t;
+    return 0;
+}

--- a/tests/wip/comparator_lowering_parity/ComparatorLoweringParity.v
+++ b/tests/wip/comparator_lowering_parity/ComparatorLoweringParity.v
@@ -1,0 +1,26 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: module-path escaping parity for comparator helpers *)
+
+From Stdlib Require Import Nat.
+
+Module ComparatorLoweringParity.
+
+Module A.
+  Module Value'.
+    Definition f (n : nat) : nat := n.
+  End Value'.
+End A.
+
+Module B.
+  Module Value_.
+    Definition g (n : nat) : nat := S n.
+  End Value_.
+End B.
+
+Definition t : nat := A.Value'.f 0 + B.Value_.g 0.
+End ComparatorLoweringParity.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "comparator_lowering_parity" ComparatorLoweringParity.

--- a/tests/wip/comparator_lowering_parity/comparator_lowering_parity.t.cpp
+++ b/tests/wip/comparator_lowering_parity/comparator_lowering_parity.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <comparator_lowering_parity.h>
+
+int main()
+{
+    (void)ComparatorLoweringParity::t;
+    return 0;
+}

--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -125,8 +125,6 @@
   (deps coind_guard.t.exe)
   (action (run ./coind_guard.t.exe))))
 
-
-
 (subdir monadic
  (rule
   (targets monadic.t.exe)
@@ -215,3 +213,104 @@
   (deps modpath_escape_value.t.exe)
   (action (run ./modpath_escape_value.t.exe))))
 
+
+(subdir nat_sub_underflow
+ (rule
+  (targets nat_sub_underflow.t.exe)
+  (deps NatSubUnderflow.vo nat_sub_underflow.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nat_sub_underflow.t.exe nat_sub_underflow.cpp nat_sub_underflow.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nat_sub_underflow.t.exe)
+  (action (run ./nat_sub_underflow.t.exe))))
+(subdir bool_nat_ternary_precedence
+ (rule
+  (targets bool_nat_ternary_precedence.t.exe)
+  (deps BoolNatTernaryPrecedence.vo bool_nat_ternary_precedence.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} bool_nat_ternary_precedence.t.exe bool_nat_ternary_precedence.cpp bool_nat_ternary_precedence.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps bool_nat_ternary_precedence.t.exe)
+  (action (run ./bool_nat_ternary_precedence.t.exe))))
+(subdir comparator_lowering_parity
+ (rule
+  (targets comparator_lowering_parity.t.exe)
+  (deps ComparatorLoweringParity.vo comparator_lowering_parity.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} comparator_lowering_parity.t.exe comparator_lowering_parity.cpp comparator_lowering_parity.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps comparator_lowering_parity.t.exe)
+  (action (run ./comparator_lowering_parity.t.exe))))
+(subdir option_tuple_wrapper
+ (rule
+  (targets option_tuple_wrapper.t.exe)
+  (deps OptionTupleWrapper.vo option_tuple_wrapper.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} option_tuple_wrapper.t.exe option_tuple_wrapper.cpp option_tuple_wrapper.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps option_tuple_wrapper.t.exe)
+  (action (run ./option_tuple_wrapper.t.exe))))
+(subdir nested_record_update_qual
+ (rule
+  (targets nested_record_update_qual.t.exe)
+  (deps NestedRecordUpdateQual.vo nested_record_update_qual.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nested_record_update_qual.t.exe nested_record_update_qual.cpp nested_record_update_qual.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nested_record_update_qual.t.exe)
+  (action (run ./nested_record_update_qual.t.exe))))
+(subdir mkstate_signature_drift
+ (rule
+  (targets mkstate_signature_drift.t.exe)
+  (deps MkstateSignatureDrift.vo mkstate_signature_drift.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} mkstate_signature_drift.t.exe mkstate_signature_drift.cpp mkstate_signature_drift.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps mkstate_signature_drift.t.exe)
+  (action (run ./mkstate_signature_drift.t.exe))))
+(subdir helper_name_odr
+ (rule
+  (targets helper_name_odr.t.exe)
+  (deps HelperNameOdr.vo helper_name_odr.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} helper_name_odr.t.exe helper_name_odr.cpp helper_name_odr.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps helper_name_odr.t.exe)
+  (action (run ./helper_name_odr.t.exe))))
+(subdir nth_default_struct
+ (rule
+  (targets nth_default_struct.t.exe)
+  (deps NthDefaultStruct.vo nth_default_struct.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} nth_default_struct.t.exe nth_default_struct.cpp nth_default_struct.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps nth_default_struct.t.exe)
+  (action (run ./nth_default_struct.t.exe))))
+(subdir match_forward_order
+ (rule
+  (targets match_forward_order.t.exe)
+  (deps MatchForwardOrder.vo match_forward_order.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} match_forward_order.t.exe match_forward_order.cpp match_forward_order.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps match_forward_order.t.exe)
+  (action (run ./match_forward_order.t.exe))))
+(subdir ram_accessor_namespace
+ (rule
+  (targets ram_accessor_namespace.t.exe)
+  (deps RamAccessorNamespace.vo ram_accessor_namespace.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} ram_accessor_namespace.t.exe ram_accessor_namespace.cpp ram_accessor_namespace.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps ram_accessor_namespace.t.exe)
+  (action (run ./ram_accessor_namespace.t.exe))))

--- a/tests/wip/helper_name_odr/HelperNameOdr.v
+++ b/tests/wip/helper_name_odr/HelperNameOdr.v
@@ -1,0 +1,17 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: helper naming collisions under escaped keywords *)
+
+From Stdlib Require Import Bool.
+From Stdlib Require Import Nat.
+
+Module HelperNameOdr.
+
+Definition class (b : bool) : nat := if b then 1 else 0.
+Definition class_ (b : bool) : nat := if b then 2 else 3.
+Definition t : nat := class true + class_ false.
+End HelperNameOdr.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "helper_name_odr" HelperNameOdr.

--- a/tests/wip/helper_name_odr/helper_name_odr.t.cpp
+++ b/tests/wip/helper_name_odr/helper_name_odr.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <helper_name_odr.h>
+
+int main()
+{
+    (void)HelperNameOdr::t;
+    return 0;
+}

--- a/tests/wip/match_forward_order/MatchForwardOrder.v
+++ b/tests/wip/match_forward_order/MatchForwardOrder.v
@@ -1,0 +1,19 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: match-forward shape under shadow-qualified names *)
+
+From Stdlib Require Import Bool.
+
+Module MatchForwardOrder.
+
+Module Node.
+  Inductive shadow : Type := TagA | TagB.
+End Node.
+
+Definition pick (b : bool) : Node.shadow := if b then Node.TagA else Node.TagB.
+Definition t : Node.shadow := pick true.
+End MatchForwardOrder.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "match_forward_order" MatchForwardOrder.

--- a/tests/wip/match_forward_order/match_forward_order.t.cpp
+++ b/tests/wip/match_forward_order/match_forward_order.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <match_forward_order.h>
+
+int main()
+{
+    (void)MatchForwardOrder::t;
+    return 0;
+}

--- a/tests/wip/mkstate_signature_drift/MkstateSignatureDrift.v
+++ b/tests/wip/mkstate_signature_drift/MkstateSignatureDrift.v
@@ -1,0 +1,22 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: constructor escaping and signature drift pressure *)
+
+From Stdlib Require Import Nat.
+
+Module MkstateSignatureDrift.
+
+Inductive item : Type := S' | S_.
+
+Definition score (x : item) : nat :=
+  match x with
+  | S' => 1
+  | S_ => 2
+  end.
+
+Definition t : nat := score S' + score S_.
+End MkstateSignatureDrift.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "mkstate_signature_drift" MkstateSignatureDrift.

--- a/tests/wip/mkstate_signature_drift/mkstate_signature_drift.t.cpp
+++ b/tests/wip/mkstate_signature_drift/mkstate_signature_drift.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <mkstate_signature_drift.h>
+
+int main()
+{
+    (void)MkstateSignatureDrift::t;
+    return 0;
+}

--- a/tests/wip/nat_sub_underflow/NatSubUnderflow.v
+++ b/tests/wip/nat_sub_underflow/NatSubUnderflow.v
@@ -1,0 +1,16 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: nat subtraction helpers under prime/underscore naming *)
+
+From Stdlib Require Import Nat.
+
+Module NatSubUnderflow.
+
+Definition value' (n : nat) : nat := n.
+Definition value_ (n : nat) : nat := S n.
+Definition t : nat := value' 1 + value_ 2.
+End NatSubUnderflow.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nat_sub_underflow" NatSubUnderflow.

--- a/tests/wip/nat_sub_underflow/nat_sub_underflow.t.cpp
+++ b/tests/wip/nat_sub_underflow/nat_sub_underflow.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nat_sub_underflow.h>
+
+int main()
+{
+    (void)NatSubUnderflow::t;
+    return 0;
+}

--- a/tests/wip/nested_record_update_qual/NestedRecordUpdateQual.v
+++ b/tests/wip/nested_record_update_qual/NestedRecordUpdateQual.v
@@ -1,0 +1,23 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: nested qualified record updates under shadowing *)
+
+From Stdlib Require Import Nat.
+
+Module NestedRecordUpdateQual.
+
+Module Shadow.
+  Record shadow : Type := Mk { value : nat }.
+End Shadow.
+
+Definition bump (x : Shadow.shadow) : Shadow.shadow :=
+  match x with
+  | Shadow.Mk n => Shadow.Mk (S n)
+  end.
+
+Definition t : Shadow.shadow := bump (Shadow.Mk 1).
+End NestedRecordUpdateQual.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nested_record_update_qual" NestedRecordUpdateQual.

--- a/tests/wip/nested_record_update_qual/nested_record_update_qual.t.cpp
+++ b/tests/wip/nested_record_update_qual/nested_record_update_qual.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nested_record_update_qual.h>
+
+int main()
+{
+    (void)NestedRecordUpdateQual::t;
+    return 0;
+}

--- a/tests/wip/nth_default_struct/NthDefaultStruct.v
+++ b/tests/wip/nth_default_struct/NthDefaultStruct.v
@@ -1,0 +1,26 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: nth/default-style module path escaping collision *)
+
+From Stdlib Require Import Nat.
+
+Module NthDefaultStruct.
+
+Module A.
+  Module Value'.
+    Definition f (n : nat) : nat := n.
+  End Value'.
+End A.
+
+Module B.
+  Module Value_.
+    Definition g (n : nat) : nat := S n.
+  End Value_.
+End B.
+
+Definition t : nat := A.Value'.f 0 + B.Value_.g 0.
+End NthDefaultStruct.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "nth_default_struct" NthDefaultStruct.

--- a/tests/wip/nth_default_struct/nth_default_struct.t.cpp
+++ b/tests/wip/nth_default_struct/nth_default_struct.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <nth_default_struct.h>
+
+int main()
+{
+    (void)NthDefaultStruct::t;
+    return 0;
+}

--- a/tests/wip/option_tuple_wrapper/OptionTupleWrapper.v
+++ b/tests/wip/option_tuple_wrapper/OptionTupleWrapper.v
@@ -1,0 +1,19 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: option/tuple-like wrapper path under shadowed names *)
+
+From Stdlib Require Import Bool.
+
+Module OptionTupleWrapper.
+
+Module Node.
+  Inductive shadow : Type := TagA | TagB.
+End Node.
+
+Definition pick (b : bool) : Node.shadow := if b then Node.TagA else Node.TagB.
+Definition t : Node.shadow := pick true.
+End OptionTupleWrapper.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "option_tuple_wrapper" OptionTupleWrapper.

--- a/tests/wip/option_tuple_wrapper/option_tuple_wrapper.t.cpp
+++ b/tests/wip/option_tuple_wrapper/option_tuple_wrapper.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <option_tuple_wrapper.h>
+
+int main()
+{
+    (void)OptionTupleWrapper::t;
+    return 0;
+}

--- a/tests/wip/ram_accessor_namespace/RamAccessorNamespace.v
+++ b/tests/wip/ram_accessor_namespace/RamAccessorNamespace.v
@@ -1,0 +1,22 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: namespace-sensitive constructor escaping pressure *)
+
+From Stdlib Require Import Nat.
+
+Module RamAccessorNamespace.
+
+Inductive item : Type := S' | S_.
+
+Definition score (x : item) : nat :=
+  match x with
+  | S' => 1
+  | S_ => 2
+  end.
+
+Definition t : nat := score S' + score S_.
+End RamAccessorNamespace.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+Crane Extraction "ram_accessor_namespace" RamAccessorNamespace.

--- a/tests/wip/ram_accessor_namespace/ram_accessor_namespace.t.cpp
+++ b/tests/wip/ram_accessor_namespace/ram_accessor_namespace.t.cpp
@@ -1,0 +1,9 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <ram_accessor_namespace.h>
+
+int main()
+{
+    (void)RamAccessorNamespace::t;
+    return 0;
+}


### PR DESCRIPTION
## Summary
This PR adds 20 focused Intel 4004-derived family repro tests and wires them into test manifests, split across WIP (expected failing repros) and regression (expected passing coverage).

## Test Cases
### Added to tests/wip (expected failing)
- nat_sub_underflow
- bool_nat_ternary_precedence
- comparator_lowering_parity
- option_tuple_wrapper
- nested_record_update_qual
- mkstate_signature_drift
- helper_name_odr
- nth_default_struct
- match_forward_order
- ram_accessor_namespace

### Added to tests/regression (expected passing)
- nat_sub_underflow_safe
- bool_nat_ternary_precedence_safe
- comparator_lowering_parity_safe
- option_tuple_wrapper_safe
- nested_record_update_qual_safe
- mkstate_signature_drift_safe
- helper_name_odr_safe
- nth_default_struct_safe
- match_forward_order_safe
- ram_accessor_namespace_safe

## Build Rules
- Updated tests/wip/dune
- Updated tests/regression/dune

## Validation
- WIP cases fail in codegen/compile path as expected (10/10).
- Regression cases compile as expected (10/10).