### PR TITLE
tests: add more TODO-backed wips

### DIFF
--- a/tests/wip/dune
+++ b/tests/wip/dune
@@ -1792,3 +1792,58 @@
   (alias runtest)
   (deps todo_dependent_field_alias.t.exe)
   (action (run ./todo_dependent_field_alias.t.exe))))
+
+(subdir todo_type_app_instance_alias
+ (rule
+  (targets todo_type_app_instance_alias.t.exe)
+  (deps TodoTypeAppInstanceAlias.vo todo_type_app_instance_alias.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} todo_type_app_instance_alias.t.exe todo_type_app_instance_alias.cpp todo_type_app_instance_alias.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps todo_type_app_instance_alias.t.exe)
+  (action (run ./todo_type_app_instance_alias.t.exe))))
+
+(subdir todo_inline_custom_symbol
+ (rule
+  (targets todo_inline_custom_symbol.t.exe)
+  (deps TodoInlineCustomSymbol.vo todo_inline_custom_symbol.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} todo_inline_custom_symbol.t.exe todo_inline_custom_symbol.cpp todo_inline_custom_symbol.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps todo_inline_custom_symbol.t.exe)
+  (action (run ./todo_inline_custom_symbol.t.exe))))
+
+(subdir todo_type_subst_pack_alias
+ (rule
+  (targets todo_type_subst_pack_alias.t.exe)
+  (deps TodoTypeSubstPackAlias.vo todo_type_subst_pack_alias.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} todo_type_subst_pack_alias.t.exe todo_type_subst_pack_alias.cpp todo_type_subst_pack_alias.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps todo_type_subst_pack_alias.t.exe)
+  (action (run ./todo_type_subst_pack_alias.t.exe))))
+
+(subdir todo_inline_custom_poly_id
+ (rule
+  (targets todo_inline_custom_poly_id.t.exe)
+  (deps TodoInlineCustomPolyId.vo todo_inline_custom_poly_id.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} todo_inline_custom_poly_id.t.exe todo_inline_custom_poly_id.cpp todo_inline_custom_poly_id.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps todo_inline_custom_poly_id.t.exe)
+  (action (run ./todo_inline_custom_poly_id.t.exe))))
+
+(subdir todo_erased_instance_param
+ (rule
+  (targets todo_erased_instance_param.t.exe)
+  (deps TodoErasedInstanceParam.vo todo_erased_instance_param.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} todo_erased_instance_param.t.exe todo_erased_instance_param.cpp todo_erased_instance_param.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps todo_erased_instance_param.t.exe)
+  (action (run ./todo_erased_instance_param.t.exe))))

--- a/tests/wip/todo_erased_instance_param/TodoErasedInstanceParam.v
+++ b/tests/wip/todo_erased_instance_param/TodoErasedInstanceParam.v
@@ -1,0 +1,28 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: erased proof parameters combined with instances should preserve arity. *)
+
+From Stdlib Require Import Nat.
+
+Module TodoErasedInstanceParam.
+
+Class Default (A : Type) := {
+  def : A
+}.
+
+#[global] Instance natDefault : Default nat := {
+  def := 4
+}.
+
+Definition pick {A : Type} `{Default A} (_ : True) : A :=
+  def.
+
+Definition test_value : nat :=
+  @pick nat natDefault I + @pick nat natDefault I.
+
+End TodoErasedInstanceParam.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+
+Crane Extraction "todo_erased_instance_param" TodoErasedInstanceParam.

--- a/tests/wip/todo_erased_instance_param/todo_erased_instance_param.cpp
+++ b/tests/wip/todo_erased_instance_param/todo_erased_instance_param.cpp
@@ -1,0 +1,11 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_erased_instance_param.h>
+#include <variant>

--- a/tests/wip/todo_erased_instance_param/todo_erased_instance_param.h
+++ b/tests/wip/todo_erased_instance_param/todo_erased_instance_param.h
@@ -1,0 +1,37 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+template <typename I, typename A>
+concept Default = requires {
+  { I::def() } -> std::convertible_to<A>;
+};
+
+struct TodoErasedInstanceParam {
+  struct natDefault {
+    static unsigned int def() { return 4u; }
+  };
+  static_assert(Default<natDefault, unsigned int>);
+
+  template <typename _tcI0, typename T1> static T1 pick() {
+    return _tcI0::def();
+  }
+
+  static inline const unsigned int test_value =
+      (pick<natDefault>() + pick<natDefault>());
+};

--- a/tests/wip/todo_erased_instance_param/todo_erased_instance_param.t.cpp
+++ b/tests/wip/todo_erased_instance_param/todo_erased_instance_param.t.cpp
@@ -1,0 +1,8 @@
+#include <cassert>
+
+#include "todo_erased_instance_param.h"
+
+int main() {
+    assert(TodoErasedInstanceParam::test_value == 8u);
+    return 0;
+}

--- a/tests/wip/todo_inline_custom_poly_id/TodoInlineCustomPolyId.v
+++ b/tests/wip/todo_inline_custom_poly_id/TodoInlineCustomPolyId.v
@@ -1,0 +1,23 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: inlined polymorphic function symbols should not mis-handle eta expansion. *)
+
+From Stdlib Require Import Nat Bool.
+
+Module TodoInlineCustomPolyId.
+
+Parameter foreign_id : forall {A : Type}, A -> A.
+
+Definition test_value : nat :=
+  let alias := @foreign_id in
+  let kept_nat := alias nat 4 in
+  let kept_bool := alias bool true in
+  if kept_bool then S kept_nat else 0.
+
+End TodoInlineCustomPolyId.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+
+Crane Extract Inlined Constant TodoInlineCustomPolyId.foreign_id => "inline_id_impl" From "todo_inline_custom_poly_id_support.h".
+Crane Extraction "todo_inline_custom_poly_id" TodoInlineCustomPolyId.

--- a/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.cpp
+++ b/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_inline_custom_poly_id.h>
+#include <todo_inline_custom_poly_id_support.h>
+#include <variant>

--- a/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.h
+++ b/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.h
@@ -1,0 +1,34 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_inline_custom_poly_id_support.h>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct TodoInlineCustomPolyId {
+  static inline const unsigned int test_value = [](void) {
+    unsigned int kept_nat = _anon_alias(4u);
+    bool kept_bool = _anon_alias(true);
+    if (kept_bool) {
+      return (std::move(kept_nat) + 1);
+    } else {
+      return 0u;
+    }
+  }();
+};
+template <typename T1> T1 _anon_alias() {
+  return [](const T1 _x0) { return inline_id_impl; };
+}

--- a/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.t.cpp
+++ b/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id.t.cpp
@@ -1,0 +1,8 @@
+#include <cassert>
+
+#include "todo_inline_custom_poly_id.h"
+
+int main() {
+    assert(TodoInlineCustomPolyId::test_value == 5u);
+    return 0;
+}

--- a/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id_support.h
+++ b/tests/wip/todo_inline_custom_poly_id/todo_inline_custom_poly_id_support.h
@@ -1,0 +1,8 @@
+#ifndef TODO_INLINE_CUSTOM_POLY_ID_SUPPORT_H
+#define TODO_INLINE_CUSTOM_POLY_ID_SUPPORT_H
+
+template <typename T> inline T inline_id_impl(const T x) {
+    return x;
+}
+
+#endif

--- a/tests/wip/todo_inline_custom_symbol/TodoInlineCustomSymbol.v
+++ b/tests/wip/todo_inline_custom_symbol/TodoInlineCustomSymbol.v
@@ -1,0 +1,26 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: direct inlined function symbols should not need spurious eta wrapping. *)
+
+From Stdlib Require Import Nat.
+
+Module TodoInlineCustomSymbol.
+
+Parameter foreign_inc : nat -> nat.
+
+Definition alias : nat -> nat :=
+  foreign_inc.
+
+Definition twice (n : nat) : nat :=
+  alias (alias n).
+
+Definition test_value : nat :=
+  twice 3.
+
+End TodoInlineCustomSymbol.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+
+Crane Extract Inlined Constant TodoInlineCustomSymbol.foreign_inc => "inline_inc_impl" From "todo_inline_custom_symbol_support.h".
+Crane Extraction "todo_inline_custom_symbol" TodoInlineCustomSymbol.

--- a/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.cpp
+++ b/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.cpp
@@ -1,0 +1,20 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_inline_custom_symbol.h>
+#include <todo_inline_custom_symbol_support.h>
+#include <variant>
+
+unsigned int TodoInlineCustomSymbol::alias(const unsigned int _x0) {
+  return inline_inc_impl;
+}
+
+unsigned int TodoInlineCustomSymbol::twice(const unsigned int n) {
+  return alias(alias(n));
+}

--- a/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.h
+++ b/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.h
@@ -1,0 +1,27 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_inline_custom_symbol_support.h>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+struct TodoInlineCustomSymbol {
+  static unsigned int alias(const unsigned int);
+
+  static unsigned int twice(const unsigned int n);
+
+  static inline const unsigned int test_value = twice(3u);
+};

--- a/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.t.cpp
+++ b/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol.t.cpp
@@ -1,0 +1,8 @@
+#include <cassert>
+
+#include "todo_inline_custom_symbol.h"
+
+int main() {
+    assert(TodoInlineCustomSymbol::test_value == 5u);
+    return 0;
+}

--- a/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol_support.h
+++ b/tests/wip/todo_inline_custom_symbol/todo_inline_custom_symbol_support.h
@@ -1,0 +1,8 @@
+#ifndef TODO_INLINE_CUSTOM_SYMBOL_SUPPORT_H
+#define TODO_INLINE_CUSTOM_SYMBOL_SUPPORT_H
+
+inline unsigned int inline_inc_impl(const unsigned int x) {
+    return x + 1u;
+}
+
+#endif

--- a/tests/wip/todo_type_app_instance_alias/TodoTypeAppInstanceAlias.v
+++ b/tests/wip/todo_type_app_instance_alias/TodoTypeAppInstanceAlias.v
@@ -1,0 +1,29 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: explicit type applications with instance arguments should reduce cleanly. *)
+
+From Stdlib Require Import Nat.
+
+Module TodoTypeAppInstanceAlias.
+
+Class Boxed (A : Type) := {
+  boxed_default : A
+}.
+
+#[global] Instance natBoxed : Boxed nat := {
+  boxed_default := 7
+}.
+
+Definition pick {A : Type} `{Boxed A} : A :=
+  boxed_default.
+
+Definition test_value : nat :=
+  let alias := @pick in
+  alias nat natBoxed + alias nat natBoxed.
+
+End TodoTypeAppInstanceAlias.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+
+Crane Extraction "todo_type_app_instance_alias" TodoTypeAppInstanceAlias.

--- a/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.cpp
+++ b/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.cpp
@@ -1,0 +1,11 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_type_app_instance_alias.h>
+#include <variant>

--- a/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.h
+++ b/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.h
@@ -1,0 +1,41 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+template <typename I, typename A>
+concept Boxed = requires {
+  { I::boxed_default() } -> std::convertible_to<A>;
+};
+
+struct TodoTypeAppInstanceAlias {
+  struct natBoxed {
+    static unsigned int boxed_default() { return 7u; }
+  };
+  static_assert(Boxed<natBoxed, unsigned int>);
+
+  template <typename _tcI0, typename T1> static T1 pick() {
+    return _tcI0::boxed_default();
+  }
+
+  static inline const unsigned int test_value = [](void) {
+    return (_anon_alias(natBoxed) + _anon_alias(natBoxed));
+  }();
+};
+template <typename T1> T1 _anon_alias() {
+  return TodoTypeAppInstanceAlias::pick;
+}

--- a/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.t.cpp
+++ b/tests/wip/todo_type_app_instance_alias/todo_type_app_instance_alias.t.cpp
@@ -1,0 +1,8 @@
+#include <cassert>
+
+#include "todo_type_app_instance_alias.h"
+
+int main() {
+    assert(TodoTypeAppInstanceAlias::test_value == 14u);
+    return 0;
+}

--- a/tests/wip/todo_type_subst_pack_alias/TodoTypeSubstPackAlias.v
+++ b/tests/wip/todo_type_subst_pack_alias/TodoTypeSubstPackAlias.v
@@ -1,0 +1,33 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(* WIP: dependent aliases should preserve substituted carrier types. *)
+
+From Stdlib Require Import Nat.
+
+Module TodoTypeSubstPackAlias.
+
+Record Pack := mkPack {
+  carrier : Type;
+  seed : carrier;
+  step : carrier -> carrier
+}.
+
+Definition step_of (p : Pack) : carrier p -> carrier p :=
+  step p.
+
+Definition run_twice (p : Pack) : carrier p :=
+  let alias := step_of p in
+  alias (alias (seed p)).
+
+Definition nat_pack : Pack :=
+  mkPack nat 3 S.
+
+Definition test_value : nat :=
+  run_twice nat_pack.
+
+End TodoTypeSubstPackAlias.
+
+Require Crane.Extraction.
+From Crane Require Mapping.Std Mapping.NatIntStd.
+
+Crane Extraction "todo_type_subst_pack_alias" TodoTypeSubstPackAlias.

--- a/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.cpp
+++ b/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.cpp
@@ -1,0 +1,11 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <todo_type_subst_pack_alias.h>
+#include <variant>

--- a/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.h
+++ b/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.h
@@ -1,0 +1,53 @@
+#include <algorithm>
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+template <typename F, typename R, typename... Args>
+concept MapsTo = std::is_invocable_r_v<R, F &, Args &...>;
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+template <typename I>
+concept Pack = (requires (typename I::carrier a0) {
+  typename I::carrier;
+  { I::step(a0) } -> std::convertible_to<typename I::carrier>;
+} && (requires {
+  { I::seed() } -> std::convertible_to<typename I::carrier>;
+} || requires {
+  { I::seed } -> std::convertible_to<typename I::carrier>;
+}));
+
+struct TodoTypeSubstPackAlias {
+  using carrier = std::any;
+
+  template <typename _tcI0, typename carrier>
+  static carrier step_of(const carrier _x0) {
+    return _tcI0::step(_x0);
+  }
+
+  template <typename _tcI0, typename carrier> static carrier run_twice() {
+    std::function<carrier(carrier)> alias = [](const carrier _x0) {
+      return step_of<_tcI0>(_x0);
+    };
+    return alias(alias(_tcI0::seed()));
+  }
+
+  struct nat_pack {
+    using carrier = unsigned int;
+    static unsigned int seed() { return 3u; }
+    static unsigned int step(unsigned int x) { return (x + 1); }
+  };
+  static_assert(Pack<nat_pack>);
+
+  static inline const unsigned int test_value = run_twice<nat_pack>();
+};

--- a/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.t.cpp
+++ b/tests/wip/todo_type_subst_pack_alias/todo_type_subst_pack_alias.t.cpp
@@ -1,0 +1,8 @@
+#include <cassert>
+
+#include "todo_type_subst_pack_alias.h"
+
+int main() {
+    assert(TodoTypeSubstPackAlias::test_value == 5u);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add five expected-failing WIP tests for additional TODO-backed extraction and translation seams
- wire the new cases into \\	ests/wip/dune\\

## Batch Size
- wip: +5

## New WIP Tests (5)
- todo_type_app_instance_alias
- todo_type_subst_pack_alias
- todo_inline_custom_symbol
- todo_inline_custom_poly_id
- todo_erased_instance_param

## Validation
- 5 WIP aliases failed as expected in a fresh ext4 WSL worktree
- failure modes remain compile-time C++ generation issues, not harness-only smoke failures