### PR TITLE
Fix Rocq dependency version

### DIFF
--- a/rocq-crane.opam
+++ b/rocq-crane.opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1"
 bug-reports: "https://github.com/bloomberg/crane/issues"
 depends: [
   "ocaml"
-  "coq" {>= "9.0.0"}
+  "coq" {>= "9.0.0" & < "9.1"}
   "rocq-runtime"
   "conf-clang"
   "conf-clang-format"


### PR DESCRIPTION
The Rocq version is currently listed as `>= 9.0.0`, however versions `>= 9.1.0` do not compile.