### PR TITLE
Fixes type argument extraction bug with custom map

### DIFF
--- a/src/translation.ml
+++ b/src/translation.ml
@@ -2044,11 +2044,11 @@ let is_cpp_dummy_prop = function
 
     @param tys List of C++ types (template arguments)
     @return Filtered list: either all concrete types or empty list *)
-let filter_erased_type_args tys =
-  (* Phase 1: Strip proof-erasure markers *)
+let filter_erased_type_args ?(preserve_positions = false) tys =
   let tys = List.filter (fun t -> not (is_cpp_dummy_prop t)) tys in
-  (* Phase 2: Apply all-or-nothing rule for erased types *)
-  if List.exists is_erased_type tys then [] else tys
+  if preserve_positions then
+    List.map (fun t -> if is_erased_type t then Minicpp.Tany else t) tys
+  else if List.exists is_erased_type tys then [] else tys
 
 (** Recursively check whether a C++ type tree contains erased HKT markers (Tany
     or dummy_type globs). These markers arise when a higher-kinded type
@@ -5822,7 +5822,11 @@ and eta_fun env f args =
        This is needed because C++ cannot deduce template type params from lambda
        arguments — lambdas don't participate in template argument deduction. *)
     let regular_type_args =
-      let filtered = filter_erased_type_args regular_type_args in
+      let filtered =
+        filter_erased_type_args
+          ~preserve_positions:(Table.is_inline_custom id)
+          regular_type_args
+      in
       (* Check if the callee's return type is a Tvar pointing to an erased
          (Tdummy Ktype) domain position, and if so, return the position index,
          the concrete C++ type to use, and the full ML domain. *)

--- a/tests/basics/topological_sort_bde/topological_sort_bde.cpp
+++ b/tests/basics/topological_sort_bde/topological_sort_bde.cpp
@@ -5,20 +5,20 @@
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
+#include <bsl_optional.h>
+#include <bsl_utility.h>
+#include <bsl_string.h>
+#include <bsl_memory.h>
 
-namespace BloombergLP {}
-List<unsigned int> ListDef::seq(unsigned int start, unsigned int len) {
-  if (len <= 0) {
-    return List<unsigned int>::nil();
-  } else {
-    unsigned int len0 = len - 1;
-    return List<unsigned int>::cons(start, ListDef::seq((start + 1), len0));
-  }
+
+namespace BloombergLP {
+
 }
+List<unsigned int> ListDef::seq(unsigned int start,
+unsigned int len){if (len <= 0) { return List<unsigned int>::nil(); } else { unsigned int len0 = len - 1; return List<unsigned int>::cons(start, ListDef::seq((start + 1),
+len0)); }}

--- a/tests/basics/topological_sort_bde/topological_sort_bde.h
+++ b/tests/basics/topological_sort_bde/topological_sort_bde.h
@@ -1,20 +1,23 @@
 #ifndef INCLUDED_TOPOLOGICAL_SORT_BDE
 #define INCLUDED_TOPOLOGICAL_SORT_BDE
 
-#include <any>
 #include <bdlf_overloaded.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
+#include <any>
 #include <utility>
+#include <bsl_optional.h>
+#include <bsl_utility.h>
+#include <bsl_string.h>
+#include <bsl_memory.h>
+
 
 using namespace BloombergLP;
 using namespace bsl::string_literals;
@@ -25,485 +28,349 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-template <typename t_A> struct List {
-  // TYPES
-  struct Nil {};
-  struct Cons {
-    t_A d_a;
-    bsl::shared_ptr<List<t_A>> d_l;
-  };
-  using variant_t = bsl::variant<Nil, Cons>;
 
+template <typename
+t_A>struct List {
+  // TYPES
+struct Nil {
+
+};
+struct Cons {
+t_A d_a;
+bsl::shared_ptr<List<t_A>> d_l;
+};
+using variant_t = bsl::variant<Nil,
+Cons>;
 private:
   // DATA
-  variant_t d_v_;
-
+variant_t d_v_;
 public:
   // CREATORS
-  List() {}
-  explicit List(Nil _v) : d_v_(_v) {}
-  explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
-  template <typename _U> explicit List(const List<_U> &_other) {
-    if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
-      this->d_v_ = Nil{};
-    } else {
-      const auto &[d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
-      this->d_v_ = Cons{
-          [&]() -> t_A {
-            if constexpr (std::is_same_v<_U, std::any>) {
-              if (d_a.type() == typeid(t_A))
-                return std::any_cast<t_A>(d_a);
-              if constexpr (requires {
-                              typename t_A::first_type;
-                              typename t_A::second_type;
-                            }) {
-                const auto &[_k, _v] =
-                    std::any_cast<std::pair<std::any, std::any>>(d_a);
-                return t_A{
-                    [&]() -> typename t_A::first_type {
-                      if constexpr (std::is_same_v<typename t_A::first_type,
-                                                   std::any>)
-                        return _k;
-                      else
-                        return std::any_cast<typename t_A::first_type>(_k);
-                    }(),
-                    [&]() -> typename t_A::second_type {
-                      if constexpr (std::is_same_v<typename t_A::second_type,
-                                                   std::any>)
-                        return _v;
-                      else
-                        return std::any_cast<typename t_A::second_type>(_v);
-                    }()};
-              }
-              return std::any_cast<t_A>(d_a);
-            } else
-              return t_A(d_a);
-          }(),
-          d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
-    }
-  }
-  static List<t_A> nil() { return List(Nil{}); }
-  static List<t_A> cons(t_A a, List<t_A> l) {
-    return List(Cons{bsl::move(a), bsl::make_shared<List<t_A>>(bsl::move(l))});
-  }
+List() {}
+explicit List(Nil _v) : d_v_(_v) {}
+explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
+template <typename
+_U>
+explicit List(const List<_U>& _other) {
+if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
+this->d_v_ = Nil{};
+} else {
+const auto& [d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
+this->d_v_ = Cons{[&]() -> t_A { if constexpr (std::is_same_v<_U, std::any>) { if (d_a.type() == typeid(t_A)) return std::any_cast<t_A>(d_a); if constexpr (requires { typename t_A::first_type; typename t_A::second_type; }) { const auto& [_k, _v] = std::any_cast<std::pair<std::any, std::any>>(d_a); return t_A{ [&]() -> typename t_A::first_type { if constexpr (std::is_same_v<typename t_A::first_type, std::any>) return _k; else return std::any_cast<typename t_A::first_type>(_k); }(), [&]() -> typename t_A::second_type { if constexpr (std::is_same_v<typename t_A::second_type, std::any>) return _v; else return std::any_cast<typename t_A::second_type>(_v); }() }; } return std::any_cast<t_A>(d_a); } else return t_A(d_a); }(),
+d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
+}}
+static List<t_A> nil(){
+return List(Nil{});}
+static List<t_A> cons(t_A a, List<t_A> l){
+return List(Cons{bsl::move(a),
+bsl::make_shared<List<t_A>>(bsl::move(l))});}
   // MANIPULATORS
-  ~List() {
-    bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
-    auto _drain = [&](variant_t &_v) {
-      if (auto *_alt = bsl::get_if<Cons>(&_v)) {
-        if (_alt->d_l) {
-          _stack.push_back(bsl::move(_alt->d_l));
-        }
-      }
-    };
-    _drain(v_mut());
-    while (!_stack.empty()) {
-      auto _cur = bsl::move(_stack.back());
-      _stack.pop_back();
-      if (_cur.use_count() == 1) {
-        _drain(_cur->v_mut());
-      }
-    }
-  }
-  inline variant_t &v_mut() { return d_v_; }
+~List() {
+bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
+auto _drain = [&](variant_t&
+_v) {
+if (auto* _alt = bsl::get_if<Cons>(&_v)) {
+if (_alt->d_l) {
+_stack.push_back(bsl::move(_alt->d_l));
+}
+}
+};
+_drain(v_mut());
+while (!_stack.empty()) {
+auto _cur = bsl::move(_stack.back());
+_stack.pop_back();
+if (_cur.use_count() == 1) {
+_drain(_cur->v_mut());
+}
+}
+}
+inline variant_t& v_mut() {
+return d_v_;}
   // ACCESSORS
-  const variant_t &v() const { return d_v_; }
-  template <typename T1>
-  List<bsl::pair<t_A, T1>> combine(const List<T1> &l_) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return List<bsl::pair<t_A, T1>>::nil();
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      if (bsl::holds_alternative<typename List<T1>::Nil>(l_.v())) {
-        return List<bsl::pair<t_A, T1>>::nil();
-      } else {
-        const auto &[d_a00, d_a10] = bsl::get<typename List<T1>::Cons>(l_.v());
-        return List<bsl::pair<t_A, T1>>::cons(
-            bsl::make_pair(d_a0, d_a00), d_a1->template combine<T1>(*d_a10));
-      }
-    }
-  }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
-  bsl::optional<t_A> find(F0 &&f) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return bsl::optional<t_A>();
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      if (f(d_a0)) {
-        return bsl::make_optional<t_A>(d_a0);
-      } else {
-        return d_a1->find(f);
-      }
-    }
-  }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
-  List<t_A> filter(F0 &&f) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return List<t_A>::nil();
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      if (f(d_a0)) {
-        return List<t_A>::cons(d_a0, d_a1->filter(f));
-      } else {
-        return d_a1->filter(f);
-      }
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<T1, F0 &, t_A &, T1 &>
-  T1 fold_right(F0 &&f, T1 a0) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return a0;
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      return f(d_a0, d_a1->template fold_right<T1>(f, a0));
-    }
-  }
-  template <typename T1> List<T1> concat() const {
-    if (bsl::holds_alternative<typename List<List<T1>>::Nil>(this->v())) {
-      return List<T1>::nil();
-    } else {
-      const auto &[d_a0, d_a1] =
-          bsl::get<typename List<List<T1>>::Cons>(this->v());
-      return d_a0.app(d_a1->template concat<T1>());
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<T1, F0 &, t_A &>
-  List<T1> map(F0 &&f) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return List<T1>::nil();
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      return List<T1>::cons(f(d_a0), d_a1->template map<T1>(f));
-    }
-  }
-  unsigned int length() const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return 0u;
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      return (d_a1->length() + 1);
-    }
-  }
-  List<t_A> app(List<t_A> m) const {
-    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-      return m;
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-      return List<t_A>::cons(d_a0, d_a1->app(bsl::move(m)));
-    }
-  }
+const variant_t& v() const {
+return d_v_;}
+template <typename
+T1>
+List<bsl::pair<t_A, T1>> combine(const List<T1>& l_) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return List<bsl::pair<t_A, T1>>::nil();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+if (bsl::holds_alternative<typename List<T1>::Nil>(l_.v())) {
+return List<bsl::pair<t_A, T1>>::nil();
+} else {
+const auto& [d_a00, d_a10] = bsl::get<typename List<T1>::Cons>(l_.v());
+return List<bsl::pair<t_A, T1>>::cons(bsl::make_pair(d_a0, d_a00), d_a1->template combine<T1>(*d_a10));
+}
+}}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
+bsl::optional<t_A> find(F0&& f) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return bsl::optional<t_A>();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+if (f(d_a0)) { return bsl::make_optional<t_A>(d_a0); } else { return d_a1->find(f); }
+}}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
+List<t_A> filter(F0&& f) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return List<t_A>::nil();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+if (f(d_a0)) { return List<t_A>::cons(d_a0, d_a1->filter(f)); } else { return d_a1->filter(f); }
+}}
+template <typename T1, typename
+F0>
+  requires bsl::is_invocable_r_v<T1, F0 &, t_A &, T1 &>
+T1 fold_right(F0&& f,
+T1 a0) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return a0;
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+return f(d_a0, d_a1->template fold_right<T1>(f, a0));
+}}
+template <typename
+T1>
+List<T1> concat() const {
+if (bsl::holds_alternative<typename List<List<T1>>::Nil>(this->v())) {
+return List<T1>::nil();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<List<T1>>::Cons>(this->v());
+return d_a0.app(d_a1->template concat<T1>());
+}}
+template <typename T1, typename
+F0>
+  requires bsl::is_invocable_r_v<T1, F0 &, t_A &>
+List<T1> map(F0&& f) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return List<T1>::nil();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+return List<T1>::cons(f(d_a0), d_a1->template map<T1>(f));
+}}
+unsigned int length() const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return 0u;
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+return (d_a1->length() + 1);
+}}
+List<t_A> app(List<t_A> m) const {
+if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+return m;
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+return List<t_A>::cons(d_a0, d_a1->app(bsl::move(m)));
+}}
+};struct ListDef {
+static List<unsigned int> seq(unsigned int start, unsigned int len);
+};struct ToString {
+template <typename T1, typename T2, typename F0, typename
+F1>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
+      && bsl::is_invocable_r_v<bsl::string, F1 &, T2 &>
+static bsl::string pair_to_string(F0&& p1, F1&& p2,
+const bsl::pair<T1, T2>& x){auto [a, b] = x; return "("_s + p1(a) + ", "_s + p2(b) + ")"_s;}
+template <typename T1, typename F0>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
+static bsl::string intersperse(F0&& p, bsl::string sep,
+const List<T1>& l){if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
+return "";
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
+auto&& _sv = *d_a1;
+if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
+return sep + p(d_a0);
+} else {
+return sep + p(d_a0) + intersperse<T1>(p, sep, *d_a1);
+}
+}}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
+static bsl::string list_to_string(F0&& p,
+const List<T1>& l){if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
+return "[]";
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
+auto&& _sv = *d_a1;
+if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
+return "["_s + p(d_a0) + "]"_s;
+} else {
+return "["_s + p(d_a0) + intersperse<T1>(p, "; ", *d_a1) + "]"_s;
+}
+}}
+};struct TopologicalSort {
+template <typename node> using entry = bsl::pair<node, List<node>>;
+template <typename node> using graph = List<entry<node>>;
+template <typename node> using order = List<List<node>>;template <typename
+T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<T1> get_elems(F0&& eqb_node,
+const List<bsl::pair<T1, T1>>& l){auto get_elems_aux_impl = [&](auto&
+_self_get_elems_aux, const List<bsl::pair<T1, T1>>& l0, List<T1>
+h) -> List<T1> {
+if (bsl::holds_alternative<typename List<bsl::pair<T1, T1>>::Nil>(l0.v())) {
+return h;
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T1>>::Cons>(l0.v());
+const List<bsl::pair<T1, T1>>& d_a1_value = *d_a1;
+auto [e1, e2] = d_a0; bsl::optional<T1> f1 = h.find([=](const T1&
+x) mutable {
+return eqb_node(e1, x);
+});
+bsl::optional<T1> f2 = h.find([=](const T1& x) mutable {
+return eqb_node(e2,
+x);
+});
+if (f1.has_value()) { T1 _x = *f1; if (f2.has_value()) { T1 _x0 = *f2; return _self_get_elems_aux(_self_get_elems_aux,
+d_a1_value,
+bsl::move(h)); } else { return _self_get_elems_aux(_self_get_elems_aux,
+d_a1_value,
+List<T1>::cons(e2, bsl::move(h))); } } else { if (f2.has_value()) { T1 _x = *f2; return _self_get_elems_aux(_self_get_elems_aux,
+d_a1_value, List<T1>::cons(e1, bsl::move(h))); } else { if (eqb_node(e1,
+e2)) { return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
+List<T1>::cons(e1, bsl::move(h))); } else { return _self_get_elems_aux(_self_get_elems_aux,
+d_a1_value,
+List<T1>::cons(e1, List<T1>::cons(e2, bsl::move(h)))); } } }
+}
 };
-struct ListDef {
-  static List<unsigned int> seq(unsigned int start, unsigned int len);
+auto get_elems_aux = [&](const List<bsl::pair<T1, T1>>& l0, List<T1>
+h) -> List<T1> {
+return get_elems_aux_impl(get_elems_aux_impl, l0,
+h);
 };
-struct ToString {
-  template <typename T1, typename T2, typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &> &&
-             bsl::is_invocable_r_v<bsl::string, F1 &, T2 &>
-  static bsl::string pair_to_string(F0 &&p1, F1 &&p2,
-                                    const bsl::pair<T1, T2> &x) {
-    auto [a, b] = x;
-    return "("_s + p1(a) + ", "_s + p2(b) + ")"_s;
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
-  static bsl::string intersperse(F0 &&p, bsl::string sep, const List<T1> &l) {
-    if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
-      return "";
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
-      auto &&_sv = *d_a1;
-      if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
-        return sep + p(d_a0);
-      } else {
-        return sep + p(d_a0) + intersperse<T1>(p, sep, *d_a1);
-      }
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
-  static bsl::string list_to_string(F0 &&p, const List<T1> &l) {
-    if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
-      return "[]";
-    } else {
-      const auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
-      auto &&_sv = *d_a1;
-      if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
-        return "["_s + p(d_a0) + "]"_s;
-      } else {
-        return "["_s + p(d_a0) + intersperse<T1>(p, "; ", *d_a1) + "]"_s;
-      }
-    }
-  }
-};
-struct TopologicalSort {
-  template <typename node> using entry = bsl::pair<node, List<node>>;
-  template <typename node> using graph = List<entry<node>>;
-  template <typename node> using order = List<List<node>>;
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<T1> get_elems(F0 &&eqb_node, const List<bsl::pair<T1, T1>> &l) {
-    auto get_elems_aux_impl = [&](auto &_self_get_elems_aux,
-                                  const List<bsl::pair<T1, T1>> &l0,
-                                  List<T1> h) -> List<T1> {
-      if (bsl::holds_alternative<typename List<bsl::pair<T1, T1>>::Nil>(
-              l0.v())) {
-        return h;
-      } else {
-        const auto &[d_a0, d_a1] =
-            bsl::get<typename List<bsl::pair<T1, T1>>::Cons>(l0.v());
-        const List<bsl::pair<T1, T1>> &d_a1_value = *d_a1;
-        auto [e1, e2] = d_a0;
-        bsl::optional<T1> f1 =
-            h.find([=](const T1 &x) mutable { return eqb_node(e1, x); });
-        bsl::optional<T1> f2 =
-            h.find([=](const T1 &x) mutable { return eqb_node(e2, x); });
-        if (f1.has_value()) {
-          T1 _x = *f1;
-          if (f2.has_value()) {
-            T1 _x0 = *f2;
-            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
-                                       bsl::move(h));
-          } else {
-            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
-                                       List<T1>::cons(e2, bsl::move(h)));
-          }
-        } else {
-          if (f2.has_value()) {
-            T1 _x = *f2;
-            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
-                                       List<T1>::cons(e1, bsl::move(h)));
-          } else {
-            if (eqb_node(e1, e2)) {
-              return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
-                                         List<T1>::cons(e1, bsl::move(h)));
-            } else {
-              return _self_get_elems_aux(
-                  _self_get_elems_aux, d_a1_value,
-                  List<T1>::cons(e1, List<T1>::cons(e2, bsl::move(h))));
-            }
-          }
-        }
-      }
-    };
-    auto get_elems_aux = [&](const List<bsl::pair<T1, T1>> &l0,
-                             List<T1> h) -> List<T1> {
-      return get_elems_aux_impl(get_elems_aux_impl, l0, h);
-    };
-    return get_elems_aux(l, List<T1>::nil());
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static entry<T1> make_entry(F0 &&eqb_node, const List<bsl::pair<T1, T1>> &l,
-                              T1 e) {
-    return bsl::make_pair(
-        e, l.template fold_right<List<T1>>(
-               [=](const bsl::pair<T1, T1> &x, List<T1> ret) mutable {
-                 if (eqb_node(e, x.first)) {
-                   return List<T1>::cons(x.second, ret);
-                 } else {
-                   return ret;
-                 }
-               },
-               List<T1>::nil()));
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static graph<T1> make_graph(F0 &&eqb_node, List<bsl::pair<T1, T1>> l) {
-    List<T1> elems = get_elems<T1>(eqb_node, l);
-    return bsl::move(elems).template fold_right<List<entry<T1>>>(
-        [=](const T1 &e, List<bsl::pair<T1, List<T1>>> ret) mutable {
-          return List<bsl::pair<T1, List<T1>>>::cons(
-              make_entry<T1>(eqb_node, l, e), ret);
-        },
-        List<bsl::pair<T1, List<T1>>>::nil());
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<T1> graph_lookup(F0 &&eqb_node, const T1 &elem,
-                               const List<bsl::pair<T1, List<T1>>> &graph0) {
-    auto _cs = graph0.find([=](const bsl::pair<T1, List<T1>> &entry0) mutable {
-      return eqb_node(elem, entry0.first);
-    });
-    if (_cs.has_value()) {
-      bsl::pair<T1, List<T1>> p = *_cs;
-      auto [_x, es] = p;
-      return es;
-    } else {
-      return List<T1>::nil();
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bool contains(F0 &&eqb_node, const T1 &elem, const List<T1> &es) {
-    auto _cs = es.find([=](const T1 &x) mutable { return eqb_node(elem, x); });
-    if (_cs.has_value()) {
-      T1 _x = *_cs;
-      return true;
-    } else {
-      return false;
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static T1 cycle_entry_aux(F0 &&eqb_node,
-                            const List<bsl::pair<T1, List<T1>>> &graph0,
-                            List<T1> seens, T1 elem, unsigned int counter) {
-    if (contains<T1>(eqb_node, elem, seens)) {
-      return elem;
-    } else {
-      if (counter <= 0) {
-        return elem;
-      } else {
-        unsigned int c = counter - 1;
-        List<T1> l = graph_lookup<T1>(eqb_node, elem, graph0);
-        if (bsl::holds_alternative<typename List<T1>::Nil>(l.v_mut())) {
-          return elem;
-        } else {
-          auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v_mut());
-          return cycle_entry_aux<T1>(eqb_node, graph0,
-                                     List<T1>::cons(elem, bsl::move(seens)),
-                                     bsl::move(d_a0), c);
-        }
-      }
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::optional<T1>
-  cycle_entry(F0 &&eqb_node, const List<bsl::pair<T1, List<T1>>> &graph0) {
-    if (bsl::holds_alternative<typename List<bsl::pair<T1, List<T1>>>::Nil>(
-            graph0.v())) {
-      return bsl::optional<T1>();
-    } else {
-      const auto &[d_a0, d_a1] =
-          bsl::get<typename List<bsl::pair<T1, List<T1>>>::Cons>(graph0.v());
-      auto [e, _x0] = d_a0;
-      return bsl::make_optional<T1>(cycle_entry_aux<T1>(
-          eqb_node, graph0, List<T1>::nil(), e, graph0.length()));
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<T1>
-  cycle_extract_aux(F0 &&eqb_node, const List<bsl::pair<T1, List<T1>>> &graph0,
-                    unsigned int counter, T1 elem, List<T1> cycl) {
-    if (counter <= 0) {
-      return cycl;
-    } else {
-      unsigned int c = counter - 1;
-      if (contains<T1>(eqb_node, elem, cycl)) {
-        return cycl;
-      } else {
-        return graph_lookup<T1>(eqb_node, elem, graph0)
-            .template fold_right<List<T1>>(
-                [=](T1 _x0, List<T1> _x1) mutable -> List<T1> {
-                  return cycle_extract_aux<T1>(eqb_node, graph0, c, _x0, _x1);
-                },
-                List<T1>::cons(elem, bsl::move(cycl)));
-      }
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<T1> cycle_extract(F0 &&eqb_node,
-                                const List<bsl::pair<T1, List<T1>>> &graph0) {
-    auto _cs = cycle_entry<T1>(eqb_node, graph0);
-    if (_cs.has_value()) {
-      T1 elem = *_cs;
-      return cycle_extract_aux<T1>(eqb_node, graph0, graph0.length(), elem,
-                                   List<T1>::nil());
-    } else {
-      return List<T1>::nil();
-    }
-  }
-  template <typename T1> static bool null(const List<T1> &xs) {
-    if (bsl::holds_alternative<typename List<T1>::Nil>(xs.v())) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static order<T1>
-  topological_sort_aux(F0 &&eqb_node,
-                       const List<bsl::pair<T1, List<T1>>> &graph0,
-                       unsigned int counter) {
-    if (counter <= 0) {
-      return List<List<T1>>::nil();
-    } else {
-      unsigned int c = counter - 1;
-      if (null<entry<T1>>(graph0)) {
-        return List<List<T1>>::nil();
-      } else {
-        List<T1> mins =
-            graph0
-                .filter([](const bsl::pair<T1, List<T1>> &p) {
-                  return null<T1>(p.second);
-                })
-                .template map<T1>([](bsl::pair<T1, List<T1>> _x0) -> T1 {
-                  return _x0.first;
-                });
-        List<T1> mins_;
-        if (null<T1>(mins)) {
-          mins_ = cycle_extract<T1>(eqb_node, graph0);
-        } else {
-          mins_ = mins;
-        }
-        List<bsl::pair<T1, List<T1>>> rest =
-            graph0.filter([=](const bsl::pair<T1, List<T1>> &entry0) mutable {
-              return !(contains<T1>(eqb_node, entry0.first, mins_));
-            });
-        List<bsl::pair<T1, List<T1>>> rest_ =
-            bsl::move(rest).template map<bsl::pair<T1, List<T1>>>(
-                [=](const bsl::pair<T1, List<T1>> &entry0) mutable {
-                  return bsl::make_pair(
-                      entry0.first,
-                      entry0.second.filter([=](const T1 &e) mutable {
-                        return !(contains<T1>(eqb_node, e, mins_));
-                      }));
-                });
-        return List<List<T1>>::cons(
-            bsl::move(mins_),
-            topological_sort_aux<T1>(eqb_node, bsl::move(rest_), c));
-      }
-    }
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<List<T1>> topological_sort(F0 &&eqb_node,
-                                         const List<bsl::pair<T1, T1>> &g) {
-    List<bsl::pair<T1, List<T1>>> g_ = make_graph<T1>(eqb_node, g);
-    return topological_sort_aux<T1>(eqb_node, g_, g_.length());
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static order<T1>
-  topological_sort_graph(F0 &&eqb_node,
-                         const List<bsl::pair<T1, List<T1>>> &graph0) {
-    return topological_sort_aux<T1>(eqb_node, graph0, graph0.length());
-  }
-  template <typename T1, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<bsl::pair<T1, unsigned int>>
-  topological_rank_list(F0 &&eqb_node,
-                        const List<bsl::pair<T1, List<T1>>> &graph0) {
-    List<List<T1>> lorder = topological_sort_graph<T1>(eqb_node, graph0);
-    return lorder
-        .template combine<unsigned int>(ListDef::seq(0u, lorder.length()))
-        .template map<List<bsl::pair<T1, unsigned int>>>(
-            [](bsl::pair<List<T1>, unsigned int> x) {
-              auto [fs, rk] = x;
-              return fs.template map<bsl::pair<T1, unsigned int>>(
-                  [=](T1 f) mutable { return bsl::make_pair(f, rk); });
-            })
-        .template concat<bsl::pair<T1, unsigned int>>();
-  }
+return get_elems_aux(l, List<T1>::nil());}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static entry<T1> make_entry(F0&& eqb_node, const List<bsl::pair<T1, T1>>& l,
+T1 e){return bsl::make_pair(e, l.template fold_right<List<T1>>([=](const bsl::pair<T1, T1>&
+x, List<T1> ret) mutable {
+if (eqb_node(e,
+x.first)) { return List<T1>::cons(x.second, ret); } else { return ret; }
+}, List<T1>::nil()));}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static graph<T1> make_graph(F0&& eqb_node,
+List<bsl::pair<T1, T1>> l){List<T1> elems = get_elems<T1>(eqb_node,
+l);
+return bsl::move(elems).template fold_right<List<entry<T1>>>([=](const T1& e,
+List<bsl::pair<T1, List<T1>>>
+ret) mutable {
+return List<bsl::pair<T1, List<T1>>>::cons(make_entry<T1>(eqb_node, l,
+e), ret);
+}, List<bsl::pair<T1, List<T1>>>::nil());}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<T1> graph_lookup(F0&& eqb_node, const T1& elem,
+const List<bsl::pair<T1, List<T1>>>& graph0){auto _cs = graph0.find([=](const bsl::pair<T1, List<T1>>&
+entry0) mutable {
+return eqb_node(elem,
+entry0.first);
+});
+if (_cs.has_value()) { bsl::pair<T1, List<T1>> p = *_cs; auto [_x, es] = p; return es; } else { return List<T1>::nil(); }}
+template <typename T1, typename F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bool contains(F0&& eqb_node, const T1& elem,
+const List<T1>& es){auto _cs = es.find([=](const T1&
+x) mutable {
+return eqb_node(elem,
+x);
+});
+if (_cs.has_value()) { T1 _x = *_cs; return true; } else { return false; }}
+template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static T1 cycle_entry_aux(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0, List<T1> seens, T1 elem,
+unsigned int counter){if (contains<T1>(eqb_node, elem,
+seens)) { return elem; } else { if (counter <= 0) { return elem; } else { unsigned int c = counter - 1; List<T1> l = graph_lookup<T1>(eqb_node,
+elem,
+graph0);
+if (bsl::holds_alternative<typename List<T1>::Nil>(l.v_mut())) {
+return elem;
+} else {
+auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v_mut());
+return cycle_entry_aux<T1>(eqb_node, graph0,
+List<T1>::cons(elem, bsl::move(seens)), bsl::move(d_a0), c);
+} } }}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::optional<T1> cycle_entry(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0){if (bsl::holds_alternative<typename List<bsl::pair<T1, List<T1>>>::Nil>(graph0.v())) {
+return bsl::optional<T1>();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, List<T1>>>::Cons>(graph0.v());
+auto [e, _x0] = d_a0; return bsl::make_optional<T1>(cycle_entry_aux<T1>(eqb_node,
+graph0, List<T1>::nil(), e, graph0.length()));
+}}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<T1> cycle_extract_aux(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0, unsigned int counter, T1 elem,
+List<T1> cycl){if (counter <= 0) { return cycl; } else { unsigned int c = counter - 1; if (contains<T1>(eqb_node,
+elem, cycl)) { return cycl; } else { return graph_lookup<T1>(eqb_node, elem,
+graph0).template fold_right<List<T1>>([=](T1 _x0, List<T1>
+_x1) mutable -> List<T1> {
+return cycle_extract_aux<T1>(eqb_node, graph0, c, _x0, _x1);
+}, List<T1>::cons(elem, bsl::move(cycl))); } }}template <typename T1,
+typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<T1> cycle_extract(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0){auto _cs = cycle_entry<T1>(eqb_node,
+graph0);
+if (_cs.has_value()) { T1 elem = *_cs; return cycle_extract_aux<T1>(eqb_node,
+graph0, graph0.length(), elem,
+List<T1>::nil()); } else { return List<T1>::nil(); }}template <typename
+T1>static bool null(const List<T1>& xs){if (bsl::holds_alternative<typename List<T1>::Nil>(xs.v())) {
+return true;
+} else {
+return false;
+}}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static order<T1> topological_sort_aux(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0,
+unsigned int counter){if (counter <= 0) { return List<List<T1>>::nil(); } else { unsigned int c = counter - 1; if (null<entry<T1>>(graph0)) { return List<List<T1>>::nil(); } else { List<T1> mins = graph0.filter([](const bsl::pair<T1, List<T1>>&
+p) {
+return null<T1>(p.second);
+}).template map<T1>([](bsl::pair<T1, List<T1>>
+_x0) -> T1 {
+return _x0.first;
+});
+List<T1> mins_;
+if (null<T1>(mins)) { mins_ = cycle_extract<T1>(eqb_node,
+graph0); } else { mins_ = mins; }
+List<bsl::pair<T1, List<T1>>> rest = graph0.filter([=](const bsl::pair<T1, List<T1>>&
+entry0) mutable {
+return !(contains<T1>(eqb_node, entry0.first,
+mins_));
+});
+List<bsl::pair<T1, List<T1>>> rest_ = bsl::move(rest).template map<bsl::pair<T1, List<T1>>>([=](const bsl::pair<T1, List<T1>>&
+entry0) mutable {
+return bsl::make_pair(entry0.first, entry0.second.filter([=](const T1&
+e) mutable {
+return !(contains<T1>(eqb_node, e,
+mins_));
+}));
+});
+return List<List<T1>>::cons(bsl::move(mins_), topological_sort_aux<T1>(eqb_node,
+bsl::move(rest_), c)); } }}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<List<T1>> topological_sort(F0&& eqb_node,
+const List<bsl::pair<T1, T1>>& g){List<bsl::pair<T1, List<T1>>> g_ = make_graph<T1>(eqb_node,
+g);
+return topological_sort_aux<T1>(eqb_node, g_, g_.length());}
+template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static order<T1> topological_sort_graph(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0){return topological_sort_aux<T1>(eqb_node,
+graph0, graph0.length());}template <typename T1, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<bsl::pair<T1, unsigned int>> topological_rank_list(F0&& eqb_node,
+const List<bsl::pair<T1, List<T1>>>& graph0){List<List<T1>> lorder = topological_sort_graph<T1>(eqb_node,
+graph0);
+return lorder.template combine<unsigned int>(ListDef::seq(0u,
+lorder.length())).template map<List<bsl::pair<T1, unsigned int>>>([](bsl::pair<List<T1>, unsigned int>
+x) {
+auto [fs, rk] = x; return fs.template map<bsl::pair<T1, unsigned int>>([=](T1
+f) mutable {
+return bsl::make_pair(f, rk);
+});
+}).template concat<bsl::pair<T1, unsigned int>>();}
 };
 
 #endif // INCLUDED_TOPOLOGICAL_SORT_BDE

--- a/tests/monadic/monadic/monadic.cpp
+++ b/tests/monadic/monadic/monadic.cpp
@@ -42,8 +42,7 @@ Monadic::fib_state(uint64_t n) {
                                 std::pair<uint64_t, uint64_t>, std::monostate>(
                   state_get<std::pair<uint64_t, uint64_t>>(),
                   [](std::pair<uint64_t, uint64_t> pat) {
-                    const uint64_t &a = pat.first;
-                    const uint64_t &b = pat.second;
+                    const auto &[a, b] = pat;
                     return state_put<std::pair<uint64_t, uint64_t>>(
                         std::make_pair(b, (a + b)));
                   });
@@ -57,11 +56,8 @@ uint64_t Monadic::fib(uint64_t n) {
   if (n <= UINT64_C(2)) {
     return n;
   } else {
-    auto _cs = fib_state(n)(std::make_pair(UINT64_C(0), UINT64_C(1)));
-    std::monostate _x = std::move(_cs.first);
-    std::pair<uint64_t, uint64_t> p = std::move(_cs.second);
-    uint64_t a = std::move(p.first);
-    uint64_t _x0 = std::move(p.second);
+    auto [_x, p] = fib_state(n)(std::make_pair(UINT64_C(0), UINT64_C(1)));
+    auto [a, _x0] = std::move(p);
     return a;
   }
 }

--- a/tests/monadic/skiplist_bde/skiplist_bde.cpp
+++ b/tests/monadic/skiplist_bde/skiplist_bde.cpp
@@ -1,21 +1,27 @@
 #include "skiplist_bde.h"
 
 #include <bdlf_overloaded.h>
-#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <fstream>
-#include <skipnode.h>
+#include <bsl_optional.h>
+#include <bsl_iostream.h>
+#include <bdls_filesystemutil.h>
 #include <stm_adapter.h>
+#include <bsl_utility.h>
+#include <bsl_memory.h>
+#include <skipnode.h>
 #include <variant>
+#include <fstream>
 
-namespace BloombergLP {}
+
+namespace BloombergLP {
+
+}
+

--- a/tests/monadic/skiplist_bde/skiplist_bde.h
+++ b/tests/monadic/skiplist_bde/skiplist_bde.h
@@ -2,23 +2,26 @@
 #define INCLUDED_SKIPLIST_BDE
 
 #include <bdlf_overloaded.h>
-#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <fstream>
-#include <skipnode.h>
-#include <stm_adapter.h>
 #include <utility>
+#include <bsl_optional.h>
+#include <bsl_iostream.h>
+#include <bdls_filesystemutil.h>
+#include <stm_adapter.h>
+#include <bsl_utility.h>
+#include <bsl_memory.h>
+#include <skipnode.h>
 #include <variant>
+#include <fstream>
+
 
 using namespace BloombergLP;
 template <class From, class To>
@@ -27,1047 +30,580 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-template <typename K, typename V> struct SkipList {
-  bsl::shared_ptr<SkipNode<K, V>> slHead;
-  unsigned int slMaxLevel;
-  stm::TVar<unsigned int> slLevel;
-  stm::TVar<unsigned int> slLength;
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-  SkipPath<K, V> findPath(F0 &&ltK, const K &target) const {
-    unsigned int lvl = stm::readTVar(this->slLevel);
-    SkipPath<K, V> path = SkipPath<K, V>{};
-    return SkipList<int, int>::template findPath_aux<K, V>(
-        ltK, this->slHead, target, lvl, bsl::move(path));
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::optional<V> lookup(F0 &&ltK, F1 &&eqK, const K &k) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, k)) {
-        V v = stm::readTVar<V>(node->value);
-        return bsl::make_optional<V>(v);
-      } else {
-        return bsl::optional<V>();
-      }
-    } else {
-      return bsl::optional<V>();
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  std::monostate insert(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
-                        unsigned int newLevel) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-                                                  (newLevel + 1), curLvl);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
-      if (eqK(existing->key, k)) {
-        stm::writeTVar<V>(existing->value, v);
-        return std::monostate{};
-      } else {
-        bsl::shared_ptr<SkipNode<K, V>> newN =
-            SkipNode<K, V>::create(k, v, newLevel);
-        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
-                                                    this->slHead, newN);
-        if (curLvl < newLevel) {
-          stm::writeTVar(this->slLevel, newLevel);
-          return std::monostate{};
-        } else {
-          return std::monostate{};
-        }
-      }
-    } else {
-      bsl::shared_ptr<SkipNode<K, V>> newN =
-          SkipNode<K, V>::create(k, v, newLevel);
-      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-                                                  newN);
-      if (curLvl < newLevel) {
-        stm::writeTVar(this->slLevel, newLevel);
-        return std::monostate{};
-      } else {
-        return std::monostate{};
-      }
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  std::monostate remove(F0 &&ltK, F1 &&eqK, const K &k) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, k)) {
-        unsigned int curLvl = stm::readTVar(this->slLevel);
-        SkipList<int, int>::template extendPath<K, V>(
-            path, this->slHead, (node->level + 1), curLvl);
-        SkipList<int, int>::template unlinkNode<K, V>(bsl::move(path), node);
-        return std::monostate{};
-      } else {
-        return std::monostate{};
-      }
-    } else {
-      return std::monostate{};
-    }
-  }
-  bsl::optional<bsl::pair<K, V>> minimum() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (firstOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
-      V v = stm::readTVar<V>(node->value);
-      return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v));
-    } else {
-      return bsl::optional<bsl::pair<K, V>>();
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool memberFast(F0 &&ltK, F1 &&eqK, const K &k) const {
-    unsigned int lvl = stm::readTVar(this->slLevel);
-    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
-                                                          this->slHead, k, lvl);
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool member(F0 &&ltK, F1 &&eqK, const K &k) const {
-    unsigned int lvl = stm::readTVar(this->slLevel);
-    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
-                                                          this->slHead, k, lvl);
-  }
-  bool isEmpty() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    return [=]() mutable -> bool {
-      if (firstOpt.has_value()) {
-        bsl::shared_ptr<SkipNode<K, V>> _x = *firstOpt;
-        return false;
-      } else {
-        return true;
-      }
-    }();
-  }
-  unsigned int length() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    return SkipList<int, int>::template length_aux<K, V>(
-        10000u, bsl::move(firstOpt), 0u);
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool exists_(F0 &&ltK, F1 &&eqK, const K &k) const {
-    unsigned int lvl = stm::readTVar(this->slLevel);
-    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
-                                                          this->slHead, k, lvl);
-  }
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> front() const {
-    return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-        this->slHead->forward[0u]));
-  }
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> back() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (firstOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt;
-      return SkipList<int, int>::template findLast_aux<K, V>(10000u, first);
-    } else {
-      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-    }
-  }
-  bsl::optional<bsl::pair<K, V>> popFront() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (firstOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
-      SkipList<int, int>::template unlinkFirstFromHead<K, V>(this->slHead, node,
-                                                             node->level);
-      V v = stm::readTVar<V>(node->value);
-      return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v));
-    } else {
-      return bsl::optional<bsl::pair<K, V>>();
-    }
-  }
-  unsigned int removeAll() const {
-    unsigned int count = SkipList<int, int>::template removeAll_aux<K, V>(
-        10000u, this->slHead, 0u);
-    stm::writeTVar(this->slLevel, 0u);
-    return count;
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  std::monostate add(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
-                     unsigned int newLevel) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-                                                  (newLevel + 1), curLvl);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
-      if (eqK(existing->key, k)) {
-        stm::writeTVar<V>(existing->value, v);
-        return std::monostate{};
-      } else {
-        bsl::shared_ptr<SkipNode<K, V>> newN =
-            SkipNode<K, V>::create(k, v, newLevel);
-        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
-                                                    this->slHead, newN);
-        if (curLvl < newLevel) {
-          stm::writeTVar(this->slLevel, newLevel);
-          return std::monostate{};
-        } else {
-          return std::monostate{};
-        }
-      }
-    } else {
-      bsl::shared_ptr<SkipNode<K, V>> newN =
-          SkipNode<K, V>::create(k, v, newLevel);
-      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-                                                  newN);
-      if (curLvl < newLevel) {
-        stm::writeTVar(this->slLevel, newLevel);
-        return std::monostate{};
-      } else {
-        return std::monostate{};
-      }
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool addUnique(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
-                 unsigned int newLevel) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-                                                  (newLevel + 1), curLvl);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
-      if (eqK(existing->key, k)) {
-        return false;
-      } else {
-        bsl::shared_ptr<SkipNode<K, V>> newN =
-            SkipNode<K, V>::create(k, v, newLevel);
-        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
-                                                    this->slHead, newN);
-        [&]() -> void {
-          if (curLvl < newLevel) {
-            stm::writeTVar(this->slLevel, newLevel);
-            return;
-          } else {
-            return;
-          }
-        }();
-        return true;
-      }
-    } else {
-      bsl::shared_ptr<SkipNode<K, V>> newN =
-          SkipNode<K, V>::create(k, v, newLevel);
-      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-                                                  newN);
-      [&]() -> void {
-        if (curLvl < newLevel) {
-          stm::writeTVar(this->slLevel, newLevel);
-          return;
-        } else {
-          return;
-        }
-      }();
-      return true;
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> find(F0 &&ltK, F1 &&eqK,
-                                                      const K &k) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, k)) {
-        return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
-      } else {
-        return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-      }
-    } else {
-      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-    }
-  }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
-  previous(F0 &&eqK, bsl::shared_ptr<SkipNode<K, V>> pair) const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (firstOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt;
-      if (eqK(first->key, pair->key)) {
-        return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-      } else {
-        return SkipList<int, int>::template findPrev_aux<K, V>(
-            eqK, 10000u, first, this->slHead, pair->key);
-      }
-    } else {
-      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-    }
-  }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
-  findLowerBound(F0 &&ltK, const K &k) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
-    } else {
-      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
-  findUpperBound(F0 &&ltK, F1 &&eqK, const K &k) const {
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, k)) {
-        return ptr_to_opt(
-            stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(node->forward[0u]));
-      } else {
-        return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
-      }
-    } else {
-      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool removePair(F0 &&ltK, F1 &&eqK,
-                  bsl::shared_ptr<SkipNode<K, V>> pair) const {
-    K k = pair->key;
-    SkipPath<K, V> path = this->findPath(ltK, k);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, k)) {
-        SkipList<int, int>::template extendPath<K, V>(
-            path, this->slHead, (node->level + 1), curLvl);
-        SkipList<int, int>::template unlinkNode<K, V>(path, node);
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::pair<bsl::shared_ptr<SkipNode<K, V>>, bool>
-  bde_add(F0 &&ltK, F1 &&eqK, const K &key0, const V &data0,
-          unsigned int level) const {
-    SkipPath<K, V> path = this->findPath(ltK, key0);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-                                                  (level + 1), curLvl);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    bool isNewFront;
-    if (curFront.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront;
-      isNewFront = ltK(key0, frontNode->key);
-    } else {
-      isNewFront = true;
-    }
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
-      if (eqK(existing->key, key0)) {
-        stm::writeTVar<V>(existing->value, data0);
-        return bsl::make_pair(existing, false);
-      } else {
-        bsl::shared_ptr<SkipNode<K, V>> newN =
-            SkipNode<K, V>::create(key0, data0, level);
-        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
-                                                    this->slHead, newN);
-        [&]() -> void {
-          if (curLvl < level) {
-            stm::writeTVar(this->slLevel, level);
-            return;
-          } else {
-            return;
-          }
-        }();
-        return bsl::make_pair(newN, isNewFront);
-      }
-    } else {
-      bsl::shared_ptr<SkipNode<K, V>> newN =
-          SkipNode<K, V>::create(key0, data0, level);
-      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-                                                  newN);
-      [&]() -> void {
-        if (curLvl < level) {
-          stm::writeTVar(this->slLevel, level);
-          return;
-        } else {
-          return;
-        }
-      }();
-      return bsl::make_pair(newN, isNewFront);
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::pair<
-      bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>,
-      bool>
-  bde_addUnique(F0 &&ltK, F1 &&eqK, const K &key0, const V &data0,
-                unsigned int level) const {
-    SkipPath<K, V> path = this->findPath(ltK, key0);
-    unsigned int curLvl = stm::readTVar(this->slLevel);
-    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-                                                  (level + 1), curLvl);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    bool isNewFront;
-    if (curFront.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront;
-      isNewFront = ltK(key0, frontNode->key);
-    } else {
-      isNewFront = true;
-    }
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
-      if (eqK(existing->key, key0)) {
-        return bsl::make_pair(
-            bsl::make_pair(SkipList<int, int>::e_DUPLICATE,
-                           bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()),
-            false);
-      } else {
-        bsl::shared_ptr<SkipNode<K, V>> newN =
-            SkipNode<K, V>::create(key0, data0, level);
-        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
-                                                    this->slHead, newN);
-        [&]() -> void {
-          if (curLvl < level) {
-            stm::writeTVar(this->slLevel, level);
-            return;
-          } else {
-            return;
-          }
-        }();
-        return bsl::make_pair(
-            bsl::make_pair(
-                SkipList<int, int>::e_SUCCESS,
-                bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)),
-            isNewFront);
-      }
-    } else {
-      bsl::shared_ptr<SkipNode<K, V>> newN =
-          SkipNode<K, V>::create(key0, data0, level);
-      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-                                                  newN);
-      [&]() -> void {
-        if (curLvl < level) {
-          stm::writeTVar(this->slLevel, level);
-          return;
-        } else {
-          return;
-        }
-      }();
-      return bsl::make_pair(
-          bsl::make_pair(
-              SkipList<int, int>::e_SUCCESS,
-              bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)),
-          isNewFront);
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_find(F0 &&ltK, F1 &&eqK, const K &key0) const {
-    SkipPath<K, V> path = this->findPath(ltK, key0);
-    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
-      if (eqK(node->key, key0)) {
-        return bsl::make_pair(
-            SkipList<int, int>::e_SUCCESS,
-            bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-      } else {
-        return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                              bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-      }
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_front() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> frontOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (frontOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *frontOpt;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_back() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> backOpt = this->back();
-    if (backOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *backOpt;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_popFront() const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
-            this->slHead->forward[0u]));
-    if (firstOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
-      SkipList<int, int>::template unlinkFirstFromHead<K, V>(this->slHead, node,
-                                                             node->level);
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  unsigned int bde_remove(F0 &&ltK, F1 &&eqK,
-                          bsl::shared_ptr<SkipNode<K, V>> pair) const {
-    bool result = this->removePair(ltK, eqK, pair);
-    if (result) {
-      return SkipList<int, int>::e_SUCCESS;
-    } else {
-      return SkipList<int, int>::e_NOT_FOUND;
-    }
-  }
-  unsigned int bde_removeAll() const { return this->removeAll(); }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bool bde_exists(F0 &&ltK, F1 &&eqK, const K &key0) const {
-    unsigned int lvl = stm::readTVar(this->slLevel);
-    return SkipList<int, int>::template findKey_aux<K, V>(
-        ltK, eqK, this->slHead, key0, lvl);
-  }
-  bool bde_isEmpty() const { return this->isEmpty(); }
-  unsigned int bde_length() const { return this->length(); }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_previous(F0 &&eqK, bsl::shared_ptr<SkipNode<K, V>> pair) const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> prevOpt =
-        this->previous(eqK, pair);
-    if (prevOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *prevOpt;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  template <typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_findLowerBound(F0 &&ltK, const K &key0) const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result =
-        this->findLowerBound(ltK, key0);
-    if (result.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *result;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  template <typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
-             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
-  bde_findUpperBound(F0 &&ltK, F1 &&eqK, const K &key0) const {
-    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result =
-        this->findUpperBound(ltK, eqK, key0);
-    if (result.has_value()) {
-      bsl::shared_ptr<SkipNode<K, V>> node = *result;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
-    }
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::shared_ptr<SkipNode<T1, T2>>
-  findPred_go(F0 &&ltK, unsigned int fuel,
-              bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1 &target,
-              unsigned int level) {
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-    unsigned int _loop_fuel = bsl::move(fuel);
-    while (true) {
-      if (_loop_fuel <= 0) {
-        return _loop_curr;
-      } else {
-        unsigned int fuel_ = _loop_fuel - 1;
-        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
-            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-                _loop_curr->forward[level]));
-        if (nextOpt.has_value()) {
-          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
-          if (ltK(next0->key, target)) {
-            _loop_curr = next0;
-            _loop_fuel = fuel_;
-          } else {
-            return _loop_curr;
-          }
-        } else {
-          return _loop_curr;
-        }
-      }
-    }
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::shared_ptr<SkipNode<T1, T2>>
-  findPred(F0 &&ltK, bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1 &target,
-           unsigned int level) {
-    return SkipList<int, int>::template findPred_go<T1, T2>(ltK, 10000u, curr,
-                                                            target, level);
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static SkipPath<T1, T2>
-  findPath_aux(F0 &&ltK, bsl::shared_ptr<SkipNode<T1, T2>> curr,
-               const T1 &target, unsigned int level, SkipPath<T1, T2> path) {
-    unsigned int _loop_level = bsl::move(level);
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-    while (true) {
-      bsl::shared_ptr<SkipNode<T1, T2>> pred =
-          SkipList<int, int>::template findPred<T1, T2>(ltK, _loop_curr, target,
-                                                        _loop_level);
-      path.set(_loop_level, pred);
-      if (_loop_level <= 0) {
-        return path;
-      } else {
-        unsigned int level_ = _loop_level - 1;
-        _loop_level = level_;
-        _loop_curr = bsl::move(pred);
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static void linkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
-                          bsl::shared_ptr<SkipNode<T1, T2>> newNode,
-                          unsigned int level) {
-    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> oldNext = ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level]));
-    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-        pred->forward[level],
-        opt_to_ptr(
-            bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(newNode)));
-    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-        bsl::move(newNode)->forward[level], opt_to_ptr(bsl::move(oldNext)));
-    return;
-  }
-  template <typename T1, typename T2>
-  static void
-  linkNode_aux(SkipPath<T1, T2> path, bsl::shared_ptr<SkipNode<T1, T2>>,
-               bsl::shared_ptr<SkipNode<T1, T2>> newNode, unsigned int level) {
-    unsigned int _loop_level = bsl::move(level);
-    while (true) {
-      bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
-      SkipList<int, int>::template linkAtLevel<T1, T2>(pred, newNode,
-                                                       _loop_level);
-      if (_loop_level <= 0) {
-        return;
-      } else {
-        unsigned int level_ = _loop_level - 1;
-        _loop_level = level_;
-      }
-    }
-    return;
-  }
-  template <typename T1, typename T2>
-  static void extendPath_aux(SkipPath<T1, T2> path,
-                             bsl::shared_ptr<SkipNode<T1, T2>> head,
-                             unsigned int level, unsigned int maxLevel) {
-    unsigned int _loop_level = bsl::move(level);
-    while (true) {
-      if (_loop_level <= 0) {
-        path.set(0u, head);
-        return;
-      } else {
-        unsigned int level_ = _loop_level - 1;
-        path.set(_loop_level, head);
-        if (maxLevel <= level_) {
-          _loop_level = level_;
-        } else {
-          return;
-        }
-      }
-    }
-    return;
-  }
-  template <typename T1, typename T2>
-  static void extendPath(SkipPath<T1, T2> path,
-                         bsl::shared_ptr<SkipNode<T1, T2>> head,
-                         unsigned int needed, unsigned int currentMax) {
-    if (needed <= (currentMax + 1)) {
-      return;
-    } else {
-      SkipList<int, int>::template extendPath_aux<T1, T2>(
-          path, head, (((needed - 1u) > needed ? 0 : (needed - 1u))),
-          (currentMax + 1u));
-      return;
-    }
-  }
-  template <typename T1, typename T2>
-  static void linkNode(SkipPath<T1, T2> path,
-                       bsl::shared_ptr<SkipNode<T1, T2>> head,
-                       bsl::shared_ptr<SkipNode<T1, T2>> newNode) {
-    unsigned int lvl = newNode->level;
-    SkipList<int, int>::template linkNode_aux<T1, T2>(path, head, newNode, lvl);
-    return;
-  }
-  template <typename T1, typename T2>
-  static void unlinkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
-                            bsl::shared_ptr<SkipNode<T1, T2>> target,
-                            unsigned int level) {
-    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> targetNext =
-        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-            target->forward[level]));
-    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-        pred->forward[level], opt_to_ptr(bsl::move(targetNext)));
-    return;
-  }
-  template <typename T1, typename T2>
-  static void unlinkNode_aux(SkipPath<T1, T2> path,
-                             bsl::shared_ptr<SkipNode<T1, T2>> target,
-                             unsigned int level) {
-    unsigned int _loop_level = bsl::move(level);
-    while (true) {
-      bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
-      SkipList<int, int>::template unlinkAtLevel<T1, T2>(pred, target,
-                                                         _loop_level);
-      if (_loop_level <= 0) {
-        return;
-      } else {
-        unsigned int level_ = _loop_level - 1;
-        _loop_level = level_;
-      }
-    }
-    return;
-  }
-  template <typename T1, typename T2>
-  static void unlinkNode(SkipPath<T1, T2> path,
-                         bsl::shared_ptr<SkipNode<T1, T2>> target) {
-    unsigned int lvl = target->level;
-    SkipList<int, int>::template unlinkNode_aux<T1, T2>(path, target, lvl);
-    return;
-  }
-  template <typename T1, typename T2, typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &> &&
-             bsl::is_invocable_r_v<bool, F1 &, T1 &, T1 &>
-  static bool findKey_aux(F0 &&ltK, F1 &&eqK,
-                          bsl::shared_ptr<SkipNode<T1, T2>> curr,
-                          const T1 &target, unsigned int level) {
-    unsigned int _loop_level = bsl::move(level);
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-    while (true) {
-      bsl::shared_ptr<SkipNode<T1, T2>> pred =
-          SkipList<int, int>::template findPred<T1, T2>(ltK, _loop_curr, target,
-                                                        _loop_level);
-      if (_loop_level <= 0) {
-        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
-            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-                bsl::move(pred)->forward[0u]));
-        if (nextOpt.has_value()) {
-          bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt;
-          return eqK(node->key, target);
-        } else {
-          return false;
-        }
-      } else {
-        unsigned int level_ = _loop_level - 1;
-        _loop_level = level_;
-        _loop_curr = bsl::move(pred);
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static unsigned int
-  length_aux(unsigned int fuel,
-             const bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> &node,
-             unsigned int acc) {
-    unsigned int _loop_acc = bsl::move(acc);
-    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> _loop_node = node;
-    unsigned int _loop_fuel = bsl::move(fuel);
-    while (true) {
-      if (_loop_fuel <= 0) {
-        return _loop_acc;
-      } else {
-        unsigned int fuel_ = _loop_fuel - 1;
-        if (_loop_node.has_value()) {
-          bsl::shared_ptr<SkipNode<T1, T2>> n = *_loop_node;
-          bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(
-              stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(n->forward[0u]));
-          _loop_acc = (_loop_acc + 1);
-          _loop_node = bsl::move(nextOpt);
-          _loop_fuel = fuel_;
-        } else {
-          return _loop_acc;
-        }
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
-  findLast_aux(unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr) {
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-    unsigned int _loop_fuel = bsl::move(fuel);
-    while (true) {
-      if (_loop_fuel <= 0) {
-        return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
-            _loop_curr);
-      } else {
-        unsigned int fuel_ = _loop_fuel - 1;
-        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
-            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-                _loop_curr->forward[0u]));
-        if (nextOpt.has_value()) {
-          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
-          _loop_curr = next0;
-          _loop_fuel = fuel_;
-        } else {
-          return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
-              bsl::move(_loop_curr));
-        }
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static void unlinkFirstFromHead(bsl::shared_ptr<SkipNode<T1, T2>> head,
-                                  bsl::shared_ptr<SkipNode<T1, T2>> node,
-                                  unsigned int lvl) {
-    unsigned int _loop_lvl = bsl::move(lvl);
-    while (true) {
-      bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext =
-          ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-              node->forward[_loop_lvl]));
-      stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-          head->forward[_loop_lvl], opt_to_ptr(nodeNext));
-      if (_loop_lvl <= 0) {
-        return;
-      } else {
-        unsigned int lvl_ = _loop_lvl - 1;
-        _loop_lvl = lvl_;
-      }
-    }
-    return;
-  }
-  template <typename T1, typename T2>
-  static void unlinkNodeAtAllLevels(bsl::shared_ptr<SkipNode<T1, T2>> head,
-                                    bsl::shared_ptr<SkipNode<T1, T2>> node,
-                                    unsigned int lvl) {
-    unsigned int _loop_lvl = bsl::move(lvl);
-    while (true) {
-      bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext =
-          ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-              node->forward[_loop_lvl]));
-      stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-          head->forward[_loop_lvl], opt_to_ptr(nodeNext));
-      if (_loop_lvl <= 0) {
-        return;
-      } else {
-        unsigned int lvl_ = _loop_lvl - 1;
-        _loop_lvl = lvl_;
-      }
-    }
-    return;
-  }
-  template <typename T1, typename T2>
-  static unsigned int removeAll_aux(unsigned int fuel,
-                                    bsl::shared_ptr<SkipNode<T1, T2>> head,
-                                    unsigned int acc) {
-    if (fuel <= 0) {
-      return acc;
-    } else {
-      unsigned int fuel_ = fuel - 1;
-      bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> firstOpt = ptr_to_opt(
-          stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[0u]));
-      if (firstOpt.has_value()) {
-        bsl::shared_ptr<SkipNode<T1, T2>> node = *firstOpt;
-        SkipList<int, int>::template unlinkNodeAtAllLevels<T1, T2>(head, node,
-                                                                   node->level);
-        return SkipList<int, int>::template removeAll_aux<T1, T2>(fuel_, head,
-                                                                  (acc + 1));
-      } else {
-        return acc;
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
-  next(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
-    return ptr_to_opt(
-        stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pair->forward[0u]));
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
-  findPrev_aux(F0 &&eqK, unsigned int fuel,
-               bsl::shared_ptr<SkipNode<T1, T2>> curr,
-               bsl::shared_ptr<SkipNode<T1, T2>> _x, const T1 &target) {
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_x = bsl::move(_x);
-    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-    unsigned int _loop_fuel = bsl::move(fuel);
-    while (true) {
-      if (_loop_fuel <= 0) {
-        return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>();
-      } else {
-        unsigned int fuel_ = _loop_fuel - 1;
-        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
-            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
-                _loop_curr->forward[0u]));
-        if (nextOpt.has_value()) {
-          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
-          if (eqK(next0->key, target)) {
-            return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
-                bsl::move(_loop_curr));
-          } else {
-            bsl::shared_ptr<SkipNode<T1, T2>> _next_curr = next0;
-            _loop_x = bsl::move(_loop_curr);
-            _loop_fuel = fuel_;
-            _loop_curr = bsl::move(_next_curr);
-          }
-        } else {
-          return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>();
-        }
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static T1 key(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
-    return pair->key;
-  }
-  template <typename T1, typename T2>
-  static T2 data(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
-    return stm::readTVar<T2>(pair->value);
-  }
-  static inline const unsigned int e_SUCCESS = 0u;
-  static inline const unsigned int e_NOT_FOUND = 1u;
-  static inline const unsigned int e_DUPLICATE = 2u;
-  static inline const unsigned int e_INVALID = 3u;
-  template <typename T1, typename T2>
-  static bsl::pair<unsigned int,
-                   bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>>
-  bde_next(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
-    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
-        SkipList<int, int>::template next<T1, T2>(pair);
-    if (nextOpt.has_value()) {
-      bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt;
-      return bsl::make_pair(
-          SkipList<int, int>::e_SUCCESS,
-          bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(node));
-    } else {
-      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
-                            bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>());
-    }
-  }
-  template <typename T1, typename T2>
-  static SkipList<T1, T2> create(const T1 &dummyKey, const T2 &dummyVal) {
-    bsl::shared_ptr<SkipNode<T1, T2>> headNode = SkipNode<T1, T2>::create(
-        dummyKey, dummyVal, (((16u - 1u) > 16u ? 0 : (16u - 1u))));
-    stm::TVar<unsigned int> lvlTV = stm::newTVar(0u);
-    stm::TVar<unsigned int> lenTV = stm::newTVar(0u);
-    return SkipList<T1, T2>{headNode, 16u, lvlTV, lenTV};
-  }
-  template <typename T1, typename T2>
-  static SkipList<T1, T2> createIO(const T1 &dummyKey, const T2 &dummyVal) {
-    return stm::atomically([&] {
-      return SkipList<int, int>::template create<T1, T2>(dummyKey, dummyVal);
-    });
-  }
+
+template<typename K, typename V>
+struct SkipList {
+bsl::shared_ptr<SkipNode<K, V>> slHead;
+unsigned int slMaxLevel;
+stm::TVar<unsigned int> slLevel;
+stm::TVar<unsigned int> slLength;
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+SkipPath<K, V> findPath(F0&& ltK,
+const K& target) const {
+unsigned int lvl = stm::readTVar(this->slLevel);
+SkipPath<K, V> path = SkipPath<K, V>{};
+return SkipList<int, int>::template findPath_aux<K, V>(ltK, this->slHead,
+target, lvl, bsl::move(path));}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::optional<V> lookup(F0&& ltK, F1&& eqK,
+const K& k) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+k)) { V v = stm::readTVar<V>(node->value);
+return bsl::make_optional<V>(v); } else { return bsl::optional<V>(); } } else { return bsl::optional<V>(); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+std::monostate insert(F0&& ltK, F1&& eqK, const K& k, const V& v,
+unsigned int newLevel) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(newLevel + 1),
+curLvl);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
+k)) { stm::writeTVar<V>(existing->value, v);
+return std::monostate{}; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return std::monostate{}; } else { return std::monostate{}; } } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return std::monostate{}; } else { return std::monostate{}; } }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+std::monostate remove(F0&& ltK, F1&& eqK,
+const K& k) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+k)) { unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(node->level + 1), curLvl);
+SkipList<int, int>::template unlinkNode<K, V>(bsl::move(path),
+node);
+return std::monostate{}; } else { return std::monostate{}; } } else { return std::monostate{}; }}
+bsl::optional<bsl::pair<K, V>> minimum() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; V v = stm::readTVar<V>(node->value);
+return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v)); } else { return bsl::optional<bsl::pair<K, V>>(); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool memberFast(F0&& ltK, F1&& eqK,
+const K& k) const {
+unsigned int lvl = stm::readTVar(this->slLevel);
+return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
+k, lvl);}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool member(F0&& ltK, F1&& eqK,
+const K& k) const {
+unsigned int lvl = stm::readTVar(this->slLevel);
+return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
+k,
+lvl);}
+bool isEmpty() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+return [=]() mutable -> bool {
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> _x = *firstOpt; return false; } else { return true; }
+}();}
+unsigned int length() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+return SkipList<int, int>::template length_aux<K, V>(10000u,
+bsl::move(firstOpt), 0u);}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool exists_(F0&& ltK, F1&& eqK,
+const K& k) const {
+unsigned int lvl = stm::readTVar(this->slLevel);
+return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
+k,
+lvl);}
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> front() const {
+return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));}
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> back() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt; return SkipList<int, int>::template findLast_aux<K,
+V>(10000u,
+first); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
+bsl::optional<bsl::pair<K, V>> popFront() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; SkipList<int, int>::template unlinkFirstFromHead<K,
+V>(this->slHead, node,
+node->level);
+V v = stm::readTVar<V>(node->value);
+return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v)); } else { return bsl::optional<bsl::pair<K, V>>(); }}
+unsigned int removeAll() const {
+unsigned int count = SkipList<int, int>::template removeAll_aux<K, V>(10000u,
+this->slHead,
+0u);
+stm::writeTVar(this->slLevel, 0u);
+return count;}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+std::monostate add(F0&& ltK, F1&& eqK, const K& k, const V& v,
+unsigned int newLevel) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(newLevel + 1),
+curLvl);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
+k)) { stm::writeTVar<V>(existing->value, v);
+return std::monostate{}; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return std::monostate{}; } else { return std::monostate{}; } } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return std::monostate{}; } else { return std::monostate{}; } }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool addUnique(F0&& ltK, F1&& eqK, const K& k, const V& v,
+unsigned int newLevel) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(newLevel + 1),
+curLvl);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
+k)) { return false; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return; } else { return; }
+}();
+return true; } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
+return; } else { return; }
+}();
+return true; }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> find(F0&& ltK, F1&& eqK,
+const K& k) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+k)) { return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> previous(F0&& eqK,
+bsl::shared_ptr<SkipNode<K, V>> pair) const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt; if (eqK(first->key,
+pair->key)) { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); } else { return SkipList<int, int>::template findPrev_aux<K,
+V>(eqK, 10000u, first, this->slHead,
+pair->key); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> findLowerBound(F0&& ltK,
+const K& k) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> findUpperBound(F0&& ltK,
+F1&& eqK, const K& k) const {
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+k)) { return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(node->forward[0u])); } else { return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool removePair(F0&& ltK, F1&& eqK,
+bsl::shared_ptr<SkipNode<K, V>> pair) const {
+K k = pair->key;
+SkipPath<K, V> path = this->findPath(ltK,
+k);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+k)) { SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(node->level + 1), curLvl);
+SkipList<int, int>::template unlinkNode<K, V>(path,
+node);
+return true; } else { return false; } } else { return false; }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::pair<bsl::shared_ptr<SkipNode<K, V>>, bool> bde_add(F0&& ltK, F1&& eqK,
+const K& key0, const V& data0,
+unsigned int level) const {
+SkipPath<K, V> path = this->findPath(ltK,
+key0);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(level + 1),
+curLvl);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+bool isNewFront;
+if (curFront.has_value()) { bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront; isNewFront = ltK(key0,
+frontNode->key); } else { isNewFront = true; }
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
+key0)) { stm::writeTVar<V>(existing->value, data0);
+return bsl::make_pair(existing, false); } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < level) { stm::writeTVar(this->slLevel, level);
+return; } else { return; }
+}();
+return bsl::make_pair(newN, isNewFront); } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < level) { stm::writeTVar(this->slLevel, level);
+return; } else { return; }
+}();
+return bsl::make_pair(newN, isNewFront); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::pair<bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>, bool> bde_addUnique(F0&& ltK,
+F1&& eqK, const K& key0, const V& data0,
+unsigned int level) const {
+SkipPath<K, V> path = this->findPath(ltK,
+key0);
+unsigned int curLvl = stm::readTVar(this->slLevel);
+SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+(level + 1),
+curLvl);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+bool isNewFront;
+if (curFront.has_value()) { bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront; isNewFront = ltK(key0,
+frontNode->key); } else { isNewFront = true; }
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
+key0)) { return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_DUPLICATE, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()), false); } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < level) { stm::writeTVar(this->slLevel, level);
+return; } else { return; }
+}();
+return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)), isNewFront); } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
+SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+newN);
+[&]() -> void {
+if (curLvl < level) { stm::writeTVar(this->slLevel, level);
+return; } else { return; }
+}();
+return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)), isNewFront); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_find(F0&& ltK,
+F1&& eqK, const K& key0) const {
+SkipPath<K, V> path = this->findPath(ltK,
+key0);
+bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
+key0)) { return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); } } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_front() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> frontOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (frontOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *frontOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_back() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> backOpt = this->back();
+if (backOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *backOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_popFront() const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; SkipList<int, int>::template unlinkFirstFromHead<K,
+V>(this->slHead, node,
+node->level);
+return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+unsigned int bde_remove(F0&& ltK, F1&& eqK,
+bsl::shared_ptr<SkipNode<K, V>> pair) const {
+bool result = this->removePair(ltK, eqK,
+pair);
+if (result) { return SkipList<int, int>::e_SUCCESS; } else { return SkipList<int, int>::e_NOT_FOUND; }}
+unsigned int bde_removeAll() const {
+return this->removeAll();}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bool bde_exists(F0&& ltK, F1&& eqK,
+const K& key0) const {
+unsigned int lvl = stm::readTVar(this->slLevel);
+return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
+key0,
+lvl);}
+bool bde_isEmpty() const {
+return this->isEmpty();}
+unsigned int bde_length() const {
+return this->length();}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_previous(F0&& eqK,
+bsl::shared_ptr<SkipNode<K, V>> pair) const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> prevOpt = this->previous(eqK,
+pair);
+if (prevOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *prevOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+template <typename
+F0>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_findLowerBound(F0&& ltK,
+const K& key0) const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result = this->findLowerBound(ltK,
+key0);
+if (result.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *result; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+template <typename F0, typename
+F1>
+  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_findUpperBound(F0&& ltK,
+F1&& eqK,
+const K& key0) const {
+bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result = this->findUpperBound(ltK,
+eqK,
+key0);
+if (result.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *result; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
+template <typename T1, typename T2, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::shared_ptr<SkipNode<T1, T2>> findPred_go(F0&& ltK,
+unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
+unsigned int level){bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+unsigned int _loop_fuel = bsl::move(fuel);
+while (true) {
+if (_loop_fuel <= 0) { return _loop_curr; } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[level]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; if (ltK(next0->key,
+target)) { _loop_curr = next0;
+_loop_fuel = fuel_; } else { return _loop_curr; } } else { return _loop_curr; } }
+}}template <typename T1, typename T2, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::shared_ptr<SkipNode<T1, T2>> findPred(F0&& ltK,
+bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
+unsigned int level){return SkipList<int, int>::template findPred_go<T1,
+T2>(ltK, 10000u, curr, target, level);}template <typename T1, typename T2,
+typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static SkipPath<T1, T2> findPath_aux(F0&& ltK,
+bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target, unsigned int level,
+SkipPath<T1, T2> path){unsigned int _loop_level = bsl::move(level);
+bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+while (true) {
+bsl::shared_ptr<SkipNode<T1, T2>> pred = SkipList<int, int>::template findPred<T1,
+T2>(ltK, _loop_curr, target,
+_loop_level);
+path.set(_loop_level, pred);
+if (_loop_level <= 0) { return path; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_;
+_loop_curr = bsl::move(pred); }
+}}template <typename T1, typename
+T2>static void linkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
+bsl::shared_ptr<SkipNode<T1, T2>> newNode,
+unsigned int level){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> oldNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level]));
+stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level], opt_to_ptr(bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(newNode)));
+stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(newNode)->forward[level], opt_to_ptr(bsl::move(oldNext)));
+return;}template <typename T1, typename
+T2>static void linkNode_aux(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>>, bsl::shared_ptr<SkipNode<T1, T2>> newNode,
+unsigned int level){unsigned int _loop_level = bsl::move(level);
+while (true) {
+bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
+SkipList<int, int>::template linkAtLevel<T1, T2>(pred, newNode,
+_loop_level);
+if (_loop_level <= 0) { return; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_; }
+}
+return;}template <typename T1, typename
+T2>static void extendPath_aux(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>> head, unsigned int level,
+unsigned int maxLevel){unsigned int _loop_level = bsl::move(level);
+while (true) {
+if (_loop_level <= 0) { path.set(0u, head);
+return; } else { unsigned int level_ = _loop_level - 1; path.set(_loop_level, head);
+if (maxLevel <= level_) { _loop_level = level_; } else { return; } }
+}
+return;}template <typename T1, typename
+T2>static void extendPath(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>> head, unsigned int needed,
+unsigned int currentMax){if (needed <= (currentMax + 1)) { return; } else { SkipList<int, int>::template extendPath_aux<T1,
+T2>(path, head, (((needed - 1u) > needed ? 0 : (needed - 1u))),
+(currentMax + 1u));
+return; }}template <typename T1, typename
+T2>static void linkNode(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>> head,
+bsl::shared_ptr<SkipNode<T1, T2>> newNode){unsigned int lvl = newNode->level;
+SkipList<int, int>::template linkNode_aux<T1, T2>(path, head, newNode,
+lvl);
+return;}template <typename T1, typename
+T2>static void unlinkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
+bsl::shared_ptr<SkipNode<T1, T2>> target,
+unsigned int level){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> targetNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(target->forward[level]));
+stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level], opt_to_ptr(bsl::move(targetNext)));
+return;}template <typename T1, typename
+T2>static void unlinkNode_aux(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>> target,
+unsigned int level){unsigned int _loop_level = bsl::move(level);
+while (true) {
+bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
+SkipList<int, int>::template unlinkAtLevel<T1, T2>(pred, target,
+_loop_level);
+if (_loop_level <= 0) { return; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_; }
+}
+return;}template <typename T1, typename
+T2>static void unlinkNode(SkipPath<T1, T2> path,
+bsl::shared_ptr<SkipNode<T1, T2>> target){unsigned int lvl = target->level;
+SkipList<int, int>::template unlinkNode_aux<T1, T2>(path, target,
+lvl);
+return;}template <typename T1, typename T2, typename F0, typename
+F1>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+      && bsl::is_invocable_r_v<bool, F1 &, T1 &, T1 &>
+static bool findKey_aux(F0&& ltK, F1&& eqK,
+bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
+unsigned int level){unsigned int _loop_level = bsl::move(level);
+bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+while (true) {
+bsl::shared_ptr<SkipNode<T1, T2>> pred = SkipList<int, int>::template findPred<T1,
+T2>(ltK, _loop_curr, target,
+_loop_level);
+if (_loop_level <= 0) { bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(pred)->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt; return eqK(node->key,
+target); } else { return false; } } else { unsigned int level_ = _loop_level - 1; _loop_level = level_;
+_loop_curr = bsl::move(pred); }
+}}template <typename T1, typename
+T2>static unsigned int length_aux(unsigned int fuel,
+const bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>& node,
+unsigned int acc){unsigned int _loop_acc = bsl::move(acc);
+bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> _loop_node = node;
+unsigned int _loop_fuel = bsl::move(fuel);
+while (true) {
+if (_loop_fuel <= 0) { return _loop_acc; } else { unsigned int fuel_ = _loop_fuel - 1; if (_loop_node.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> n = *_loop_node; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(n->forward[0u]));
+_loop_acc = (_loop_acc + 1);
+_loop_node = bsl::move(nextOpt);
+_loop_fuel = fuel_; } else { return _loop_acc; } }
+}}template <typename T1, typename
+T2>static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> findLast_aux(unsigned int fuel,
+bsl::shared_ptr<SkipNode<T1, T2>> curr){bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+unsigned int _loop_fuel = bsl::move(fuel);
+while (true) {
+if (_loop_fuel <= 0) { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr); } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; _loop_curr = next0;
+_loop_fuel = fuel_; } else { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(_loop_curr)); } }
+}}template <typename T1, typename
+T2>static void unlinkFirstFromHead(bsl::shared_ptr<SkipNode<T1, T2>> head,
+bsl::shared_ptr<SkipNode<T1, T2>> node,
+unsigned int lvl){unsigned int _loop_lvl = bsl::move(lvl);
+while (true) {
+bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(node->forward[_loop_lvl]));
+stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[_loop_lvl], opt_to_ptr(nodeNext));
+if (_loop_lvl <= 0) { return; } else { unsigned int lvl_ = _loop_lvl - 1; _loop_lvl = lvl_; }
+}
+return;}template <typename T1, typename
+T2>static void unlinkNodeAtAllLevels(bsl::shared_ptr<SkipNode<T1, T2>> head,
+bsl::shared_ptr<SkipNode<T1, T2>> node,
+unsigned int lvl){unsigned int _loop_lvl = bsl::move(lvl);
+while (true) {
+bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(node->forward[_loop_lvl]));
+stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[_loop_lvl], opt_to_ptr(nodeNext));
+if (_loop_lvl <= 0) { return; } else { unsigned int lvl_ = _loop_lvl - 1; _loop_lvl = lvl_; }
+}
+return;}template <typename T1, typename
+T2>static unsigned int removeAll_aux(unsigned int fuel,
+bsl::shared_ptr<SkipNode<T1, T2>> head,
+unsigned int acc){if (fuel <= 0) { return acc; } else { unsigned int fuel_ = fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[0u]));
+if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *firstOpt; SkipList<int, int>::template unlinkNodeAtAllLevels<T1,
+T2>(head, node,
+node->level);
+return SkipList<int, int>::template removeAll_aux<T1, T2>(fuel_, head,
+(acc + 1)); } else { return acc; } }}template <typename T1, typename
+T2>static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> next(bsl::shared_ptr<SkipNode<T1, T2>> pair){return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pair->forward[0u]));}
+template <typename T1, typename T2, typename F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> findPrev_aux(F0&& eqK,
+unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr,
+bsl::shared_ptr<SkipNode<T1, T2>> _x,
+const T1& target){bsl::shared_ptr<SkipNode<T1, T2>> _loop_x = bsl::move(_x);
+bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+unsigned int _loop_fuel = bsl::move(fuel);
+while (true) {
+if (_loop_fuel <= 0) { return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>(); } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[0u]));
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; if (eqK(next0->key,
+target)) { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(_loop_curr)); } else { bsl::shared_ptr<SkipNode<T1, T2>> _next_curr = next0;
+_loop_x = bsl::move(_loop_curr);
+_loop_fuel = fuel_;
+_loop_curr = bsl::move(_next_curr); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>(); } }
+}}template <typename T1, typename
+T2>static T1 key(bsl::shared_ptr<SkipNode<T1, T2>> pair){return pair->key;}
+template <typename T1, typename
+T2>static T2 data(bsl::shared_ptr<SkipNode<T1, T2>> pair){return stm::readTVar<T2>(pair->value);}
+static inline const unsigned int e_SUCCESS = 0u;static inline const unsigned int e_NOT_FOUND = 1u;static inline const unsigned int e_DUPLICATE = 2u;static inline const unsigned int e_INVALID = 3u;template <typename T1, typename T2>static bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>> bde_next(bsl::shared_ptr<SkipNode<T1, T2>> pair){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = SkipList<int, int>::template next<T1, T2>(pair);
+if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>()); }}
+template <typename T1, typename T2>static SkipList<T1, T2> create(const T1& dummyKey, const T2& dummyVal){bsl::shared_ptr<SkipNode<T1, T2>> headNode = SkipNode<T1, T2>::create(dummyKey, dummyVal, (((16u - 1u) > 16u ? 0 : (16u - 1u))));
+stm::TVar<unsigned int> lvlTV = stm::newTVar(0u);
+stm::TVar<unsigned int> lenTV = stm::newTVar(0u);
+return SkipList<T1, T2>{headNode, 16u, lvlTV, lenTV};}template <typename T1,
+typename T2>static SkipList<T1, T2> createIO(const T1& dummyKey,
+const T2& dummyVal){return stm::atomically([&] { return SkipList<int, int>::template create<T1,
+T2>(dummyKey,
+dummyVal); });}
 };
 
 #endif // INCLUDED_SKIPLIST_BDE

--- a/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.cpp
+++ b/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.cpp
@@ -1,21 +1,28 @@
 #include "stm_hash_map_bde.h"
 
 #include <bdlf_overloaded.h>
-#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
-#include <bsl_cstdint.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <fstream>
+#include <bsl_optional.h>
+#include <bsl_iostream.h>
+#include <bdls_filesystemutil.h>
 #include <stm_adapter.h>
+#include <bsl_utility.h>
+#include <bsl_cstdint.h>
+#include <bsl_vector.h>
+#include <bsl_memory.h>
 #include <variant>
+#include <fstream>
 
-namespace BloombergLP {}
+
+namespace BloombergLP {
+
+}
+

--- a/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.h
+++ b/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.h
@@ -1,25 +1,29 @@
 #ifndef INCLUDED_STM_HASH_MAP_BDE
 #define INCLUDED_STM_HASH_MAP_BDE
 
-#include <any>
 #include <bdlf_overloaded.h>
-#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
-#include <bsl_cstdint.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
-#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <fstream>
-#include <stm_adapter.h>
+#include <any>
 #include <utility>
+#include <bsl_optional.h>
+#include <bsl_iostream.h>
+#include <bdls_filesystemutil.h>
+#include <stm_adapter.h>
+#include <bsl_utility.h>
+#include <bsl_cstdint.h>
+#include <bsl_vector.h>
+#include <bsl_memory.h>
 #include <variant>
+#include <fstream>
+
 
 using namespace BloombergLP;
 template <class From, class To>
@@ -28,277 +32,206 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-template <typename t_A> struct List {
-  // TYPES
-  struct Nil {};
-  struct Cons {
-    t_A d_a;
-    bsl::shared_ptr<List<t_A>> d_l;
-  };
-  using variant_t = bsl::variant<Nil, Cons>;
 
+template <typename
+t_A>struct List {
+  // TYPES
+struct Nil {
+
+};
+struct Cons {
+t_A d_a;
+bsl::shared_ptr<List<t_A>> d_l;
+};
+using variant_t = bsl::variant<Nil,
+Cons>;
 private:
   // DATA
-  variant_t d_v_;
-
+variant_t d_v_;
 public:
   // CREATORS
-  List() {}
-  explicit List(Nil _v) : d_v_(_v) {}
-  explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
-  template <typename _U> explicit List(const List<_U> &_other) {
-    if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
-      this->d_v_ = Nil{};
-    } else {
-      const auto &[d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
-      this->d_v_ = Cons{
-          [&]() -> t_A {
-            if constexpr (std::is_same_v<_U, std::any>) {
-              if (d_a.type() == typeid(t_A))
-                return std::any_cast<t_A>(d_a);
-              if constexpr (requires {
-                              typename t_A::first_type;
-                              typename t_A::second_type;
-                            }) {
-                const auto &[_k, _v] =
-                    std::any_cast<std::pair<std::any, std::any>>(d_a);
-                return t_A{
-                    [&]() -> typename t_A::first_type {
-                      if constexpr (std::is_same_v<typename t_A::first_type,
-                                                   std::any>)
-                        return _k;
-                      else
-                        return std::any_cast<typename t_A::first_type>(_k);
-                    }(),
-                    [&]() -> typename t_A::second_type {
-                      if constexpr (std::is_same_v<typename t_A::second_type,
-                                                   std::any>)
-                        return _v;
-                      else
-                        return std::any_cast<typename t_A::second_type>(_v);
-                    }()};
-              }
-              return std::any_cast<t_A>(d_a);
-            } else
-              return t_A(d_a);
-          }(),
-          d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
-    }
-  }
-  static List<t_A> nil() { return List(Nil{}); }
-  static List<t_A> cons(t_A a, List<t_A> l) {
-    return List(Cons{bsl::move(a), bsl::make_shared<List<t_A>>(bsl::move(l))});
-  }
+List() {}
+explicit List(Nil _v) : d_v_(_v) {}
+explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
+template <typename
+_U>
+explicit List(const List<_U>& _other) {
+if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
+this->d_v_ = Nil{};
+} else {
+const auto& [d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
+this->d_v_ = Cons{[&]() -> t_A { if constexpr (std::is_same_v<_U, std::any>) { if (d_a.type() == typeid(t_A)) return std::any_cast<t_A>(d_a); if constexpr (requires { typename t_A::first_type; typename t_A::second_type; }) { const auto& [_k, _v] = std::any_cast<std::pair<std::any, std::any>>(d_a); return t_A{ [&]() -> typename t_A::first_type { if constexpr (std::is_same_v<typename t_A::first_type, std::any>) return _k; else return std::any_cast<typename t_A::first_type>(_k); }(), [&]() -> typename t_A::second_type { if constexpr (std::is_same_v<typename t_A::second_type, std::any>) return _v; else return std::any_cast<typename t_A::second_type>(_v); }() }; } return std::any_cast<t_A>(d_a); } else return t_A(d_a); }(),
+d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
+}}
+static List<t_A> nil(){
+return List(Nil{});}
+static List<t_A> cons(t_A a, List<t_A> l){
+return List(Cons{bsl::move(a),
+bsl::make_shared<List<t_A>>(bsl::move(l))});}
   // MANIPULATORS
-  ~List() {
-    bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
-    auto _drain = [&](variant_t &_v) {
-      if (auto *_alt = bsl::get_if<Cons>(&_v)) {
-        if (_alt->d_l) {
-          _stack.push_back(bsl::move(_alt->d_l));
-        }
-      }
-    };
-    _drain(v_mut());
-    while (!_stack.empty()) {
-      auto _cur = bsl::move(_stack.back());
-      _stack.pop_back();
-      if (_cur.use_count() == 1) {
-        _drain(_cur->v_mut());
-      }
-    }
-  }
-  inline variant_t &v_mut() { return d_v_; }
-  // ACCESSORS
-  const variant_t &v() const { return d_v_; }
+~List() {
+bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
+auto _drain = [&](variant_t&
+_v) {
+if (auto* _alt = bsl::get_if<Cons>(&_v)) {
+if (_alt->d_l) {
+_stack.push_back(bsl::move(_alt->d_l));
+}
+}
 };
-template <typename K, typename V> struct CHT {
-  bsl::function<bool(K, K)> cht_eqb;
-  bsl::function<int64_t(K)> cht_hash;
-  bsl::vector<stm::TVar<List<bsl::pair<K, V>>>> cht_buckets;
-  int64_t cht_nbuckets;
-  stm::TVar<List<bsl::pair<K, V>>> cht_fallback;
-  stm::TVar<List<bsl::pair<K, V>>> bucket_of(const K &k) const {
-    int64_t i = this->cht_hash(k) % this->cht_nbuckets;
-    return this->cht_buckets.at(i);
-  }
-  bsl::optional<V> stm_get(const K &k) const {
-    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-    List<bsl::pair<K, V>> xs = stm::readTVar(b);
-    return CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k, xs);
-  }
-  std::monostate stm_put(const K &k, const V &v) const {
-    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-    List<bsl::pair<K, V>> xs = stm::readTVar(b);
-    List<bsl::pair<K, V>> xs_ =
-        CHT<int, int>::template assoc_insert_or_replace<K, V>(this->cht_eqb, k,
-                                                              v, bsl::move(xs));
-    stm::writeTVar(b, xs_);
-    return std::monostate{};
-  }
-  bsl::optional<V> stm_delete(const K &k) const {
-    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-    List<bsl::pair<K, V>> xs = stm::readTVar(b);
-    bsl::pair<bsl::optional<V>, List<bsl::pair<K, V>>> p =
-        CHT<int, int>::template assoc_remove<K, V>(this->cht_eqb, k,
-                                                   bsl::move(xs));
-    auto _cs = p.first;
-    if (_cs.has_value()) {
-      V _x = *_cs;
-      stm::writeTVar(bsl::move(b), p.second);
-      return p.first;
-    } else {
-      return p.first;
-    }
-  }
-  template <typename F1>
-    requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
-  V stm_update(const K &k, F1 &&f) const {
-    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-    List<bsl::pair<K, V>> xs = stm::readTVar(b);
-    bsl::optional<V> ov =
-        CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k, xs);
-    V v = f(bsl::move(ov));
-    List<bsl::pair<K, V>> xs_ =
-        CHT<int, int>::template assoc_insert_or_replace<K, V>(this->cht_eqb, k,
-                                                              v, bsl::move(xs));
-    stm::writeTVar(b, xs_);
-    return v;
-  }
-  V stm_get_or(const K &k, const V &dflt) const {
-    bsl::optional<V> v = this->stm_get(k);
-    if (v.has_value()) {
-      V x = *v;
-      return x;
-    } else {
-      return dflt;
-    }
-  }
-  std::monostate put(const K &k, const V &v) const {
-    CHT<K, V> _self_val = *this;
-    return stm::atomically([&] {
-      return [=]() mutable {
-        _self_val.stm_put(k, v);
-        return std::monostate{};
-      }();
-    });
-  }
-  bsl::optional<V> get(const K &k) const {
-    return stm::atomically([&] { return this->stm_get(k); });
-  }
-  bsl::optional<V> hash_delete(const K &k) const {
-    return stm::atomically([&] { return this->stm_delete(k); });
-  }
-  template <typename F1>
-    requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
-  V hash_update(const K &k, F1 &&f) const {
-    return stm::atomically([&] { return this->stm_update(k, f); });
-  }
-  V get_or(const K &k, const V &dflt) const {
-    return stm::atomically([&] { return this->stm_get_or(k, dflt); });
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::optional<T2> assoc_lookup(F0 &&eqb, const T1 &k,
-                                        const List<bsl::pair<T1, T2>> &xs) {
-    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
-      return bsl::optional<T2>();
-    } else {
-      const auto &[d_a0, d_a1] =
-          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
-      auto [k_, v] = d_a0;
-      if (eqb(k, k_)) {
-        return bsl::make_optional<T2>(v);
-      } else {
-        return CHT<int, int>::template assoc_lookup<T1, T2>(eqb, k, *d_a1);
-      }
-    }
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static List<bsl::pair<T1, T2>>
-  assoc_insert_or_replace(F0 &&eqb, T1 k, T2 v,
-                          const List<bsl::pair<T1, T2>> &xs) {
-    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
-      return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v),
-                                           List<bsl::pair<T1, T2>>::nil());
-    } else {
-      const auto &[d_a0, d_a1] =
-          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
-      auto [k_, v_] = d_a0;
-      if (eqb(k, k_)) {
-        return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), *d_a1);
-      } else {
-        return List<bsl::pair<T1, T2>>::cons(
-            bsl::make_pair(k_, v_),
-            CHT<int, int>::template assoc_insert_or_replace<T1, T2>(eqb, k, v,
-                                                                    *d_a1));
-      }
-    }
-  }
-  template <typename T1, typename T2, typename F0>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-  static bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>>
-  assoc_remove(F0 &&eqb, const T1 &k, List<bsl::pair<T1, T2>> xs) {
-    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(
-            xs.v_mut())) {
-      return bsl::make_pair(bsl::optional<T2>(), xs);
-    } else {
-      auto &[d_a0, d_a1] =
-          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v_mut());
-      auto [k_, v_] = bsl::move(d_a0);
-      if (eqb(k, k_)) {
-        return bsl::make_pair(bsl::make_optional<T2>(v_), *d_a1);
-      } else {
-        bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> q =
-            CHT<int, int>::template assoc_remove<T1, T2>(eqb, k, *d_a1);
-        return bsl::make_pair(q.first, List<bsl::pair<T1, T2>>::cons(
-                                           bsl::make_pair(k_, v_), q.second));
-      }
-    }
-  }
-  template <typename T1, typename T2>
-  static bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>>
-  mk_buckets(int64_t num) {
-    bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> buckets = {};
-    auto f_impl =
-        [&](auto &_self_f,
-            unsigned int n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
-      if (n <= 0) {
-        return buckets;
-      } else {
-        unsigned int n_ = n - 1;
-        stm::TVar<List<bsl::pair<T1, T2>>> b = stm::atomically(
-            [&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
-        buckets.push_back(b);
-        return _self_f(_self_f, n_);
-      }
-    };
-    auto f =
-        [&](unsigned int n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
-      return f_impl(f_impl, n);
-    };
-    return f(static_cast<unsigned int>(num));
-  }
-  template <typename T1, typename T2, typename F0, typename F1>
-    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &> &&
-             bsl::is_invocable_r_v<int64_t, F1 &, T1 &>
-  static CHT<T1, T2> new_hash(F0 &&eqb, F1 &&hash, int64_t requested) {
-    int64_t n = bsl::max<int64_t>(requested, 1);
-    bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> bs =
-        CHT<int, int>::template mk_buckets<T1, T2>(n);
-    bool empt = bs.empty();
-    if (empt) {
-      stm::TVar<List<bsl::pair<T1, T2>>> fb = stm::atomically(
-          [&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
-      bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> v = {};
-      v.push_back(fb);
-      return CHT<T1, T2>{eqb, hash, v, 1, fb};
-    } else {
-      stm::TVar<List<bsl::pair<T1, T2>>> b = bs.at(0);
-      return CHT<T1, T2>{eqb, hash, bs, n, b};
-    }
-  }
+_drain(v_mut());
+while (!_stack.empty()) {
+auto _cur = bsl::move(_stack.back());
+_stack.pop_back();
+if (_cur.use_count() == 1) {
+_drain(_cur->v_mut());
+}
+}
+}
+inline variant_t& v_mut() {
+return d_v_;}
+  // ACCESSORS
+const variant_t& v() const {
+return d_v_;}
+};template<typename K, typename V>
+struct CHT {
+bsl::function<bool(K, K)> cht_eqb;
+bsl::function<int64_t(K)>
+cht_hash;
+bsl::vector<stm::TVar<List<bsl::pair<K, V>>>> cht_buckets;
+int64_t cht_nbuckets;
+stm::TVar<List<bsl::pair<K, V>>>
+cht_fallback;
+stm::TVar<List<bsl::pair<K, V>>> bucket_of(const K& k) const {
+int64_t i = this->cht_hash(k) % this->cht_nbuckets;
+return this->cht_buckets.at(i);}
+bsl::optional<V> stm_get(const K& k) const {
+stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+List<bsl::pair<K, V>> xs = stm::readTVar(b);
+return CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k,
+xs);}
+std::monostate stm_put(const K& k,
+const V& v) const {
+stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+List<bsl::pair<K, V>> xs = stm::readTVar(b);
+List<bsl::pair<K, V>> xs_ = CHT<int, int>::template assoc_insert_or_replace<K,
+V>(this->cht_eqb, k, v,
+bsl::move(xs));
+stm::writeTVar(b, xs_);
+return std::monostate{};}
+bsl::optional<V> stm_delete(const K& k) const {
+stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+List<bsl::pair<K, V>> xs = stm::readTVar(b);
+bsl::pair<bsl::optional<V>, List<bsl::pair<K, V>>> p = CHT<int, int>::template assoc_remove<K,
+V>(this->cht_eqb, k,
+bsl::move(xs));
+auto _cs = p.first;
+if (_cs.has_value()) { V _x = *_cs; stm::writeTVar(bsl::move(b), p.second);
+return p.first; } else { return p.first; }}
+template <typename
+F1>
+  requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
+V stm_update(const K& k,
+F1&& f) const {
+stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+List<bsl::pair<K, V>> xs = stm::readTVar(b);
+bsl::optional<V> ov = CHT<int, int>::template assoc_lookup<K,
+V>(this->cht_eqb, k,
+xs);
+V v = f(bsl::move(ov));
+List<bsl::pair<K, V>> xs_ = CHT<int, int>::template assoc_insert_or_replace<K,
+V>(this->cht_eqb, k, v,
+bsl::move(xs));
+stm::writeTVar(b, xs_);
+return v;}
+V stm_get_or(const K& k,
+const V& dflt) const {
+bsl::optional<V> v = this->stm_get(k);
+if (v.has_value()) { V x = *v; return x; } else { return dflt; }}
+std::monostate put(const K& k, const V& v) const {
+CHT<K,
+V> _self_val = *this;
+return stm::atomically([&] { return [=]() mutable {
+_self_val.stm_put(k,
+v);
+return std::monostate{};
+}(); });}
+bsl::optional<V> get(const K& k) const {
+return stm::atomically([&] { return this->stm_get(k); });}
+bsl::optional<V> hash_delete(const K& k) const {
+return stm::atomically([&] { return this->stm_delete(k); });}
+template <typename
+F1>
+  requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
+V hash_update(const K& k,
+F1&& f) const {
+return stm::atomically([&] { return this->stm_update(k,
+f); });}
+V get_or(const K& k,
+const V& dflt) const {
+return stm::atomically([&] { return this->stm_get_or(k,
+dflt); });}
+template <typename T1, typename T2, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::optional<T2> assoc_lookup(F0&& eqb, const T1& k,
+const List<bsl::pair<T1, T2>>& xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
+return bsl::optional<T2>();
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
+auto [k_, v] = d_a0; if (eqb(k,
+k_)) { return bsl::make_optional<T2>(v); } else { return CHT<int, int>::template assoc_lookup<T1,
+T2>(eqb, k, *d_a1); }
+}}template <typename T1, typename T2, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static List<bsl::pair<T1, T2>> assoc_insert_or_replace(F0&& eqb, T1 k, T2 v,
+const List<bsl::pair<T1, T2>>& xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
+return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), List<bsl::pair<T1, T2>>::nil());
+} else {
+const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
+auto [k_, v_] = d_a0; if (eqb(k,
+k_)) { return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), *d_a1); } else { return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k_, v_), CHT<int, int>::template assoc_insert_or_replace<T1,
+T2>(eqb, k, v, *d_a1)); }
+}}template <typename T1, typename T2, typename
+F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+static bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> assoc_remove(F0&& eqb,
+const T1& k,
+List<bsl::pair<T1, T2>> xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v_mut())) {
+return bsl::make_pair(bsl::optional<T2>(), xs);
+} else {
+auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v_mut());
+auto [k_, v_] = bsl::move(d_a0); if (eqb(k,
+k_)) { return bsl::make_pair(bsl::make_optional<T2>(v_), *d_a1); } else { bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> q = CHT<int, int>::template assoc_remove<T1,
+T2>(eqb, k,
+*d_a1);
+return bsl::make_pair(q.first, List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k_, v_), q.second)); }
+}}template <typename T1, typename
+T2>static bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> mk_buckets(int64_t num){bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> buckets = {};
+auto f_impl = [&](auto& _self_f, unsigned int
+n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
+if (n <= 0) { return buckets; } else { unsigned int n_ = n - 1; stm::TVar<List<bsl::pair<T1, T2>>> b = stm::atomically([&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
+buckets.push_back(b);
+return _self_f(_self_f, n_); }
+};
+auto f = [&](unsigned int
+n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
+return f_impl(f_impl, n);
+};
+return f(static_cast<unsigned int>(num));}template <typename T1, typename T2,
+typename F0, typename
+F1>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+      && bsl::is_invocable_r_v<int64_t, F1 &, T1 &>
+static CHT<T1, T2> new_hash(F0&& eqb, F1&& hash,
+int64_t requested){int64_t n = bsl::max<int64_t>(requested, 1);
+bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> bs = CHT<int, int>::template mk_buckets<T1,
+T2>(n);
+bool empt = bs.empty();
+if (empt) { stm::TVar<List<bsl::pair<T1, T2>>> fb = stm::atomically([&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
+bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> v = {};
+v.push_back(fb);
+return CHT<T1, T2>{eqb, hash, v, 1,
+fb}; } else { stm::TVar<List<bsl::pair<T1, T2>>> b = bs.at(0);
+return CHT<T1, T2>{eqb, hash, bs, n,
+b}; }}
 };
 
 #endif // INCLUDED_STM_HASH_MAP_BDE

--- a/tests/wip/local_fixpoint/local_fixpoint.h
+++ b/tests/wip/local_fixpoint/local_fixpoint.h
@@ -18,9 +18,7 @@ struct Monadic {
     requires std::is_invocable_r_v<State<T1, T3>, F1 &, T2 &>
   static State<T1, T3> state_bind(State<T1, T2> ma, F1 &&f) {
     return [=](const T1 &s) mutable {
-      auto _cs = ma(s);
-      T2 a = std::move(_cs.first);
-      T1 s_ = std::move(_cs.second);
+      auto [a, s_] = ma(s);
       return f(a)(s_);
     };
   }
@@ -34,9 +32,7 @@ struct Monadic {
                 return state_return<bool, std::monostate>(std::monostate{});
               });
         };
-    auto _cs = foo_state_(std::monostate{}, true);
-    std::monostate _x = std::move(_cs.first);
-    bool a = std::move(_cs.second);
+    auto [_x, a] = foo_state_(std::monostate{}, true);
     return a;
   }();
 };

--- a/tests/wip/type_args_extraction/TypeArgsExtraction.v
+++ b/tests/wip/type_args_extraction/TypeArgsExtraction.v
@@ -1,7 +1,7 @@
 (* Copyright 2026 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the GNU LGPL v2.1 license. *)
-(* Test: Type arguments to a function can be referred to with %t0,%t1,..., but they are
-    extracted as std::any. Accessing those arguments during extraction is invaluable for
+(* Test: Type arguments to a function can be referred to with %t0,%t1,...
+    Accessing those arguments during extraction is invaluable for
     correctly typing output terms, particularly lambda arguments passed to ITree loop combinators. *)
 
 From ITree Require Import
@@ -29,7 +29,6 @@ Definition double_n (n : nat) : itree void1 nat
 Require Import Crane.Mapping.NatIntStd.
 
 
-(* rec extraction, note that type arguments %t2,%t1 become std::any*)
 Crane Extract Inlined Constant rec =>
         "
          [&]() -> %t2 {
@@ -39,17 +38,6 @@ Crane Extract Inlined Constant rec =>
  }()
 " From "functional".
 Crane Extract Inlined Constant call => "__self(%a0)".
-
-
-(* NOTE: it extracts and tests correctly with the following specialized custom directive. *)
-(* Crane Extract Inlined Constant rec =>
- *         "
- *          [&]() -> uint64_t {
- *          static  std::function<uint64_t(uint64_t)> __self;
- *          __self = %a0;
- *          return __self(%a1);;
- *  }()
- * " From "functional". *)
 
 
 Crane Extraction "type_args_extraction" double_n.


### PR DESCRIPTION



**Describe your changes**
Custom inline mappings that refer to type arguments have them rendered in the extracted code as std::any.

This special-cases inline mappings by passing a new flag, ~preserve_positions:bool, which drops the all-or-nothing rule for erasing types, instead keeping the list with std::any instances.

**Testing performed**
This adds a new WIP test, `type_argument_extraction`, which exercises the custom mapping referring to types behavior, and does not break any existing tests.


