### PR TITLE
Security hardening of the extraction pipeline and runtime mappings

### DIFF
--- a/scripts/compile-bde.sh
+++ b/scripts/compile-bde.sh
@@ -17,10 +17,35 @@ THEORIES_CPP_BDE="$PROJECT_ROOT/theories/cpp_bde"
 
 OUTPUT="$1"
 shift
-SOURCES="$@"
+# Keep the source operands as a real array so they reach the compiler as
+# distinct argv entries. Never re-expand them as an unquoted scalar: word
+# splitting would let a source path containing spaces/metacharacters, or one
+# beginning with '-', turn into extra compiler options (CWE-88 / CWE-78).
+SOURCES=("$@")
 
-# Optimization level: O0 (default, fast compile), O1, O2, or O3
+# Reject any operand that clang would interpret as an option rather than an
+# input file: '-foo' is a flag and '@foo' is a response file, regardless of
+# quoting. Generated C++ sources never legitimately start with these.
+for _src in "${SOURCES[@]}"; do
+    case "$_src" in
+        -* | @*)
+            echo "Error: refusing source operand that could be read as a compiler option: '$_src'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Optimization level: O0 (default, fast compile), O1, O2, or O3. Validated
+# against a fixed allow-list because it is attacker-influenced (an environment
+# variable) and is spliced directly onto the compiler command line.
 OPT_LEVEL="${CRANE_CPP_OPTIMIZATION:-O0}"
+case "$OPT_LEVEL" in
+    O0 | O1 | O2 | O3) ;;
+    *)
+        echo "Error: invalid CRANE_CPP_OPTIMIZATION='$OPT_LEVEL' (expected O0, O1, O2, or O3)" >&2
+        exit 1
+        ;;
+esac
 
 # Find BDE installation via pkg-config
 # Users should set PKG_CONFIG_PATH to include BDE's pkgconfig directory
@@ -61,37 +86,49 @@ fi
 
 export PKG_CONFIG_PATH="$BDE_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-# Get compiler flags from pkg-config, overriding the prefix
-BDE_CFLAGS=$(pkg-config --define-variable=prefix="$BDE_PREFIX" --cflags bdl 2>/dev/null || echo "-I$BDE_PREFIX/include")
-BDE_LIBS=$(pkg-config --define-variable=prefix="$BDE_PREFIX" --libs bdl --static 2>/dev/null || echo "-L$BDE_PREFIX/lib -lbdl -lbsl -linteldfp -lpcre2 -lryu")
+# Get compiler flags from pkg-config, overriding the prefix. pkg-config emits a
+# single whitespace-separated string that legitimately needs to become several
+# argv entries. Split it with `read -ra`, which performs word splitting only —
+# no glob expansion and no command substitution — so a hostile .pc file or BDE
+# install path cannot smuggle in `$(...)`/`` `...` `` execution (CWE-88 / CWE-78).
+# The flags themselves remain trusted, but we stop treating them as shell code.
+BDE_CFLAGS_STR=$(pkg-config --define-variable=prefix="$BDE_PREFIX" --cflags bdl 2>/dev/null || echo "-I$BDE_PREFIX/include")
+BDE_LIBS_STR=$(pkg-config --define-variable=prefix="$BDE_PREFIX" --libs bdl --static 2>/dev/null || echo "-L$BDE_PREFIX/lib -lbdl -lbsl -linteldfp -lpcre2 -lryu")
 
 # On macOS, filter out -lrt (doesn't exist) and -lstdc++ (use libc++ instead)
 if [ "$(uname)" = "Darwin" ]; then
-    BDE_LIBS=$(echo "$BDE_LIBS" | sed 's/-lrt//g; s/-lstdc++//g')
+    BDE_LIBS_STR=$(echo "$BDE_LIBS_STR" | sed 's/-lrt//g; s/-lstdc++//g')
 fi
 
-# On macOS, clang may not find the SDK automatically
-SYSROOT_FLAGS=""
+read -ra BDE_CFLAGS <<< "$BDE_CFLAGS_STR"
+read -ra BDE_LIBS <<< "$BDE_LIBS_STR"
+
+# On macOS, clang may not find the SDK automatically. Hold the flag pair in an
+# array so the resolved path stays a single argv entry even if it contains
+# spaces.
+SYSROOT_FLAGS=()
 if [ "$(uname)" = "Darwin" ]; then
     SDK="${SDKROOT:-$(xcrun --show-sdk-path 2>/dev/null)}"
     if [ -n "$SDK" ] && [ -d "$SDK" ]; then
-        SYSROOT_FLAGS="-isysroot $SDK"
+        SYSROOT_FLAGS=(-isysroot "$SDK")
     fi
 fi
 
 # Sanitizer support
-SANITIZE_FLAGS=""
+SANITIZE_FLAGS=()
 if [ "${CRANE_CPP_SANITIZE:-}" = "1" ]; then
-    SANITIZE_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
+    SANITIZE_FLAGS=(-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer)
 fi
 
-# Compile with C++20, BDE ABI compatibility, and suppress deprecation warnings
+# Compile with C++20, BDE ABI compatibility, and suppress deprecation warnings.
+# Every expansion below is a quoted array so nothing is re-split or re-evaluated
+# by the shell on its way to clang++.
 exec clang++ \
     -std=c++20 \
     -DBSLS_LIBRARYFEATURES_FORCE_ABI_CPP17 \
     -Wno-deprecated-literal-operator \
-    -$OPT_LEVEL \
-    $SYSROOT_FLAGS \
+    -"$OPT_LEVEL" \
+    "${SYSROOT_FLAGS[@]}" \
     -I . \
     -I "$THEORIES_CPP_BDE" \
     -Wall -Wextra -Wpedantic -Wconversion -Wfloat-conversion \
@@ -102,9 +139,9 @@ exec clang++ \
     -Wno-unused-variable -Wno-unused-value \
     -Wno-constant-conversion -Wno-sign-conversion \
     -Wno-c11-extensions -Wno-dtor-name -Wno-nontrivial-memcall -Werror \
-    $SANITIZE_FLAGS \
-    $BDE_CFLAGS \
-    $SOURCES \
-    $BDE_LIBS \
-    $SANITIZE_FLAGS \
+    "${SANITIZE_FLAGS[@]}" \
+    "${BDE_CFLAGS[@]}" \
+    "${SOURCES[@]}" \
+    "${BDE_LIBS[@]}" \
+    "${SANITIZE_FLAGS[@]}" \
     -o "$OUTPUT"

--- a/scripts/compile-gmp.sh
+++ b/scripts/compile-gmp.sh
@@ -17,10 +17,35 @@ THEORIES_CPP="$PROJECT_ROOT/theories/cpp"
 
 OUTPUT="$1"
 shift
-SOURCES="$@"
+# Keep the source operands as a real array so they reach the compiler as
+# distinct argv entries. Never re-expand them as an unquoted scalar: word
+# splitting would let a source path containing spaces/metacharacters, or one
+# beginning with '-', turn into extra compiler options (CWE-88 / CWE-78).
+SOURCES=("$@")
 
-# Optimization level: O0 (default, fast compile), O1, O2, or O3
+# Reject any operand that clang would interpret as an option rather than an
+# input file: '-foo' is a flag and '@foo' is a response file, regardless of
+# quoting. Generated C++ sources never legitimately start with these.
+for _src in "${SOURCES[@]}"; do
+    case "$_src" in
+        -* | @*)
+            echo "Error: refusing source operand that could be read as a compiler option: '$_src'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Optimization level: O0 (default, fast compile), O1, O2, or O3. Validated
+# against a fixed allow-list because it is attacker-influenced (an environment
+# variable) and is spliced directly onto the compiler command line.
 OPT_LEVEL="${CRANE_CPP_OPTIMIZATION:-O0}"
+case "$OPT_LEVEL" in
+    O0 | O1 | O2 | O3) ;;
+    *)
+        echo "Error: invalid CRANE_CPP_OPTIMIZATION='$OPT_LEVEL' (expected O0, O1, O2, or O3)" >&2
+        exit 1
+        ;;
+esac
 
 # Find GMP installation
 GMP_PREFIX=""
@@ -135,4 +160,4 @@ if [ "${CRANE_CPP_SANITIZE:-}" = "1" ]; then
     )
 fi
 
-exec "$CXX" "${CXX_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" $SOURCES "${LINK_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" -o "$OUTPUT"
+exec "$CXX" "${CXX_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" "${SOURCES[@]}" "${LINK_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" -o "$OUTPUT"

--- a/scripts/compile-std.sh
+++ b/scripts/compile-std.sh
@@ -17,10 +17,35 @@ THEORIES_CPP="$PROJECT_ROOT/theories/cpp"
 
 OUTPUT="$1"
 shift
-SOURCES="$@"
+# Keep the source operands as a real array so they reach the compiler as
+# distinct argv entries. Never re-expand them as an unquoted scalar: word
+# splitting would let a source path containing spaces/metacharacters, or one
+# beginning with '-', turn into extra compiler options (CWE-88 / CWE-78).
+SOURCES=("$@")
 
-# Optimization level: O0 (default, fast compile), O1, O2, or O3
+# Reject any operand that clang would interpret as an option rather than an
+# input file: '-foo' is a flag and '@foo' is a response file, regardless of
+# quoting. Generated C++ sources never legitimately start with these.
+for _src in "${SOURCES[@]}"; do
+    case "$_src" in
+        -* | @*)
+            echo "Error: refusing source operand that could be read as a compiler option: '$_src'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Optimization level: O0 (default, fast compile), O1, O2, or O3. Validated
+# against a fixed allow-list because it is attacker-influenced (an environment
+# variable) and is spliced directly onto the compiler command line.
 OPT_LEVEL="${CRANE_CPP_OPTIMIZATION:-O0}"
+case "$OPT_LEVEL" in
+    O0 | O1 | O2 | O3) ;;
+    *)
+        echo "Error: invalid CRANE_CPP_OPTIMIZATION='$OPT_LEVEL' (expected O0, O1, O2, or O3)" >&2
+        exit 1
+        ;;
+esac
 
 # Precompiled header support
 PCH_SRC="$THEORIES_CPP/crane_pch.h"
@@ -116,4 +141,4 @@ if [ -n "$PCH_FILE" ] && [ -f "$PCH_FILE" ]; then
     PCH_FLAGS=(-include-pch "$PCH_FILE")
 fi
 
-exec "$CXX" "${CXX_FLAGS[@]}" "${PCH_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" $SOURCES "${LINK_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" -o "$OUTPUT"
+exec "$CXX" "${CXX_FLAGS[@]}" "${PCH_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" "${SOURCES[@]}" "${LINK_FLAGS[@]}" "${SANITIZE_FLAGS[@]}" -o "$OUTPUT"

--- a/scripts/run-infer.sh
+++ b/scripts/run-infer.sh
@@ -39,7 +39,15 @@ echo ""
 TMPDIR="${TMPDIR:-/tmp}"
 OBJ_DIR="$TMPDIR/crane_infer_$$"
 mkdir -p "$OBJ_DIR"
-trap "rm -rf $OBJ_DIR" EXIT
+# Clean up via a function rather than a trap *string*. A string trap is re-parsed
+# as shell code at EXIT, so metacharacters in the (environment-derived) path —
+# e.g. a TMPDIR containing ';' or '$(...)' — would be executed. A function body
+# expands the quoted path at run time instead; '--' stops a leading-dash path
+# being read as an rm option (CWE-78).
+cleanup() {
+    rm -rf -- "$OBJ_DIR"
+}
+trap cleanup EXIT
 
 # Clean previous Infer output
 rm -rf "$PROJECT_ROOT/infer-out"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -22,7 +22,15 @@ TMPDIR="${TMPDIR:-/tmp}"
 RESULTS_FILE="$TMPDIR/crane_test_results_$$"
 ERRORS_DIR="$TMPDIR/crane_test_errors_$$"
 mkdir -p "$ERRORS_DIR"
-trap "rm -rf $RESULTS_FILE $ERRORS_DIR" EXIT
+# Clean up via a function rather than a trap *string*. A string trap is re-parsed
+# as shell code at EXIT, so metacharacters in the (environment-derived) paths —
+# e.g. a TMPDIR containing ';' or '$(...)' — would be executed. A function body
+# expands the quoted paths at run time instead; '--' stops a leading-dash path
+# being read as an rm option (CWE-78).
+cleanup() {
+    rm -rf -- "$RESULTS_FILE" "$ERRORS_DIR"
+}
+trap cleanup EXIT
 
 # Print header
 echo ""

--- a/src/benchmark.ml
+++ b/src/benchmark.ml
@@ -262,7 +262,9 @@ let extract_managed_artifact
   | Cpp ->
     let source = Filename.concat temp_dir (stem ^ ".cpp") in
     let callable, unit =
+      (* [source] is an internal path under a private temp directory. *)
       Extract_env.full_extraction_with_result
+        ~validate:false
         ~opaque_access
         (Some source)
         [subject.benchmark_term]

--- a/src/cpp.ml
+++ b/src/cpp.ml
@@ -236,6 +236,14 @@ and pp_spec_as_requirement modtype_mp modtype_refs = function
       | ty -> pp_cpp_type false [] ty
     in
     if args = [] then
+      (* A nullary module value may be emitted either as a static data member
+         ([M::name]) or, inside a template where it becomes a Meyers singleton,
+         as a nullary accessor function ([M::name()]).  Which spelling a functor
+         body uses is decided later (by the [template_static_accessors] registry
+         and per-reference resolution) and is not reliably knowable here at
+         concept-generation time.  Accept BOTH forms so the concept never
+         rejects a module a generated body would in fact accept; the requirement
+         still enforces that the member exists with a convertible result type. *)
       let qualified_ret = qualify_type cpp_ret in
       str "requires ("
       ++ fnl ()
@@ -492,6 +500,45 @@ let rec get_concept_name_from_mt = function
   | MTwith (mt, _) -> get_concept_name_from_mt mt
   | MTfunsig (_, _, mt') -> get_concept_name_from_mt mt'
   | MTsig _ -> None
+
+(** Render the [MTwith] refinements of a module type ([BASE with Definition t
+    := nat], [OUTER with Module Inner := NatInner]) as C++ [std::same_as<…>]
+    constraints.
+
+    A refined module type such as [NAT_BASE := BASE with Definition t := nat]
+    would otherwise be emitted as a bare alias [concept NAT_BASE = BASE<M>;],
+    silently dropping the [t := nat] equality so any module satisfying [BASE]
+    is accepted — including ones whose [t] is not [nat] (CWE-345 / CWE-807).
+    Emitting [std::same_as<typename M::t, uint64_t>] as an extra conjunct
+    restores that fixed-type / fixed-submodule requirement at the concept
+    boundary.  Returns the constraint documents (one per refinement); the
+    caller conjoins them onto the base concept. *)
+let collect_with_refinements mt =
+  let rec go acc = function
+    | MTwith (inner, ML_With_type (idl, _vl, typ)) ->
+      let path = String.concat "::" (List.map Id.to_string idl) in
+      let cpp = convert_ml_type_to_cpp_type (empty_env ()) [] typ in
+      let clause =
+        str (sn ()).same_as
+        ++ str "<typename M::"
+        ++ str path
+        ++ str ", "
+        ++ pp_cpp_type false [] cpp
+        ++ str ">"
+      in
+      go (clause :: acc) inner
+    | MTwith (inner, ML_With_module _) ->
+      (* [with Module Inner := Concrete] would need a [std::same_as<typename
+         M::Inner, Concrete>] check, but the concept is emitted at namespace
+         scope before the concrete module's struct is declared, so a forward
+         reference to it does not compile.  Leave the submodule refinement
+         unenforced (as before) rather than emit a broken constraint. *)
+      go acc inner
+    | _ -> acc
+  in
+  let clauses = go [] mt in
+  if clauses <> [] then require_header "concepts";
+  clauses
 
 (** Render a functor parameter as a C++ template parameter.
 
@@ -834,6 +881,11 @@ let rec pp_structure_elem ~is_header f = function
                     match get_base_concept m with
                     | Some base_kn ->
                       let base_name = pp_concept_ref base_kn in
+                      let refine_pp =
+                        prlist
+                          (fun c -> str " && " ++ c)
+                          (collect_with_refinements m)
+                      in
                       str "template<typename M>"
                       ++ fnl ()
                       ++ hov
@@ -842,7 +894,9 @@ let rec pp_structure_elem ~is_header f = function
                            ++ modtype_name
                            ++ str " = "
                            ++ base_name
-                           ++ str "<M>;" )
+                           ++ str "<M>"
+                           ++ refine_pp
+                           ++ str ";" )
                     | None ->
                       let old_hoisted = !hoisted_concept_defs in
                       hoisted_concept_defs := [];
@@ -1286,7 +1340,17 @@ let rec pp_structure_elem ~is_header f = function
         match get_base_concept m with
         | Some base_kn ->
           let base_name = pp_concept_ref base_kn in
-          hov 1 (str "concept " ++ name ++ str " = " ++ base_name ++ str "<M>;")
+          let refine_pp =
+            prlist (fun c -> str " && " ++ c) (collect_with_refinements m)
+          in
+          hov 1
+            ( str "concept "
+            ++ name
+            ++ str " = "
+            ++ base_name
+            ++ str "<M>"
+            ++ refine_pp
+            ++ str ";" )
         | None ->
           let old_hoisted = !hoisted_concept_defs in
           hoisted_concept_defs := [];

--- a/src/cpp_print.ml
+++ b/src/cpp_print.ml
@@ -33,6 +33,32 @@ open Cpp_names
 (** Memoized regex for matching the [::] C++ scope-resolution operator. *)
 let re_double_colon = Str.regexp_string "::"
 
+(** Escape a byte string for emission inside a double-quoted C++ string literal.
+
+    A primitive Rocq [String] can contain any byte, including quotes,
+    backslashes, newlines, and comment delimiters. Emitting those verbatim would
+    terminate the literal early or otherwise corrupt (or inject into) the
+    generated C++ source (CWE-116/CWE-94). We therefore escape the C++-
+    significant characters and render every other non-printable byte as a
+    three-digit octal escape ([\\ooo]) — octal is bounded to three digits, so
+    unlike [\\x…] it cannot swallow a following hex digit. Note this differs from
+    OCaml's [String.escaped], whose [\\ddd] escapes are decimal and would be
+    misread by C++ as octal. *)
+let escape_cpp_string (s : string) : string =
+  let buf = Buffer.create (String.length s + 2) in
+  String.iter
+    (fun c ->
+      match c with
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c when Char.code c >= 0x20 && Char.code c < 0x7f -> Buffer.add_char buf c
+      | c -> Buffer.add_string buf (Printf.sprintf "\\%03o" (Char.code c)) )
+    s;
+  Buffer.contents buf
+
 (* Global mutable state in this file:
    - axiom_type_refs: accumulates across the full extraction session; never cleared
      because axiom classifications are global to a Rocq session. *)
@@ -1777,7 +1803,7 @@ and pp_cpp_expr env args t =
     | CPPderef _ | CPPraw _ ->
       str "(" ++ pp_cpp_expr env args e ++ str ")." ++ field_name
     | _ -> pp_cpp_expr env args e ++ str "." ++ field_name )
-  | CPPstring s -> str ("\"" ^ Pstring.to_string s ^ "\"")
+  | CPPstring s -> str ("\"" ^ escape_cpp_string (Pstring.to_string s) ^ "\"")
   | CPPparray (elems, _) ->
     str "{" ++ pp_list (pp_cpp_expr env args) (Array.to_list elems) ++ str "}"
   | CPPuint x ->

--- a/src/cpp_print.ml
+++ b/src/cpp_print.ml
@@ -3015,7 +3015,13 @@ let pp_template_type = function
   | TTtypename -> str "typename"
   | TTtypename_default _ -> str "typename"
   | TTfun _ -> str "typename"
-  | TTconcept concept -> pp_global Type concept
+  | TTconcept (concept, []) -> pp_global Type concept
+  | TTconcept (_, _ :: _) ->
+    (* Multi-parameter concept: the constraint cannot be written inline
+       ([C _tcI0] would apply C to only one argument), so declare the
+       parameter as a plain [typename] and attach [requires C<_tcI0, …>]
+       via {!pp_requires_of_tparams}. *)
+    str "typename"
 
 (** Print a complete template parameter including name and optional default *)
 let pp_template_param (tt, id) =
@@ -3058,6 +3064,19 @@ let pp_requires_of_tparams tparams =
             ++ List.fold_left
                  (fun acc ty -> acc ++ str ", " ++ pp_ref ty)
                  (mt ()) dom
+            ++ str ">" )
+        | TTconcept (concept, (_ :: _ as args)) ->
+          (* Multi-parameter concept constraint: [C<_tcI0, T1, …>].  The
+             constrained parameter [id] is the first concept argument, the
+             kept type args follow.  Emitting this as a [requires] clause is
+             what enforces the Rocq typeclass interface at the use site
+             instead of an unconstrained [typename] (CWE-693 / CWE-345). *)
+          Some
+            ( pp_global Type concept ++ str "<"
+            ++ Id.print id
+            ++ List.fold_left
+                 (fun acc ty -> acc ++ str ", " ++ pp_type ty)
+                 (mt ()) args
             ++ str ">" )
         | _ -> None)
       tparams

--- a/src/doc_comments.ml
+++ b/src/doc_comments.ml
@@ -369,13 +369,47 @@ let translate_brackets ~translate text =
 
     Shared helper for rendering doc comment text as C++ [///] comment lines. *)
 
+(** Normalize CRLF and bare CR line endings to LF. A bare [\r] left inside a
+    generated [///] line terminates the comment for the C++ compiler (which
+    treats CR as a line break) while the byte itself is invisible in most
+    editors, letting text after it escape the comment and be compiled as
+    source (finding 63, CWE-94/CWE-116). Folding every line ending to [\n]
+    before splitting ensures no raw [\r] ever reaches the emitted line. *)
+let normalize_line_endings text =
+  let len = String.length text in
+  let buf = Buffer.create len in
+  let i = ref 0 in
+  while !i < len do
+    ( match text.[!i] with
+    | '\r' ->
+      Buffer.add_char buf '\n';
+      if !i + 1 < len && text.[!i + 1] = '\n' then incr i
+    | c -> Buffer.add_char buf c );
+    incr i
+  done;
+  Buffer.contents buf
+
+(** A physical [///] line whose last character is a backslash gets spliced
+    with the next generated C++ line: the standard deletes a backslash
+    immediately followed by a newline, and both GCC and Clang additionally
+    splice (with only a warning) when trailing blanks separate the backslash
+    from the newline, so trimming alone cannot neutralize it. A spliced line
+    absorbs the following declaration into the comment, corrupting or
+    dropping generated code (finding 73, CWE-94/CWE-116). Appending a
+    non-blank, non-backslash marker guarantees the emitted line never ends in
+    a splicing backslash. *)
+let escape_trailing_backslash line =
+  let n = String.length line in
+  if n > 0 && line.[n - 1] = '\\' then line ^ "_" else line
+
 (** Format a doc comment string as a list of [///]-prefixed lines. Translates
     bracket references [[name]] by stripping the brackets. *)
 let format_as_cpp_lines text =
   let text = translate_brackets ~translate:(fun s -> s) text in
+  let text = normalize_line_endings text in
   let lines = String.split_on_char '\n' text in
   List.map
     (fun line ->
       let trimmed = String.trim line in
-      if trimmed = "" then "///" else "/// " ^ trimmed )
+      if trimmed = "" then "///" else "/// " ^ escape_trailing_backslash trimmed )
     lines

--- a/src/extract_env.ml
+++ b/src/extract_env.ml
@@ -903,11 +903,12 @@ let format_buffer_to_string (buf : Buffer.t) : string =
     Buffer.contents buf
   else
     let use_bde = Table.format_style () = "BDE" in
-    let formatter_cmd, available =
+    let formatter, formatter_args, available =
       if use_bde then
-        ("bde-format", bde_format_available ())
+        ("bde-format", [], bde_format_available ())
       else
-        ( "clang-format -style=" ^ Filename.quote (Table.format_style ()),
+        ( "clang-format",
+          ["-style=" ^ Table.format_style ()],
           clang_format_available () )
     in
     if not available then (
@@ -919,24 +920,10 @@ let format_buffer_to_string (buf : Buffer.t) : string =
       Buffer.contents buf )
     else
       let raw_output = Buffer.contents buf in
-      match Unix.open_process_full formatter_cmd (Unix.environment ()) with
+      match Subprocess.filter formatter formatter_args raw_output with
       | exception _ -> Buffer.contents buf
-      | chan_in, chan_out, chan_err ->
-        output_string chan_out raw_output;
-        close_out chan_out;
-        let fmt_buf = Buffer.create (Buffer.length buf) in
-        ( try
-            while true do
-              Buffer.add_string fmt_buf (input_line chan_in);
-              Buffer.add_char fmt_buf '\n'
-            done
-          with End_of_file -> () );
-        close_in chan_in;
-        close_in chan_err;
-        let status = Unix.close_process_full (chan_in, chan_out, chan_err) in
-        ( match status with
-        | Unix.WEXITED 0 -> Buffer.contents fmt_buf
-        | _ -> Buffer.contents buf )
+      | {status = Unix.WEXITED 0; stdout; _} -> stdout
+      | _ -> Buffer.contents buf
 
 (** Runs [clang-format -i] (or [bde-format]) on [filename] in place. No-op
     if the formatter is unavailable or style is set to ["None"]. *)
@@ -956,19 +943,16 @@ let format_file_inplace (filename : string) : unit =
         ++ spc ()
         ++ str "not found: skipping formatting" )
   else
-    let cmd =
+    let formatter, formatter_args =
       if use_bde then
-        "bde-format -i " ^ Filename.quote filename
+        ("bde-format", ["-i"; filename])
       else
-        "clang-format -i -style="
-        ^ Filename.quote (Table.format_style ())
-        ^ " "
-        ^ Filename.quote filename
+        ("clang-format", ["-i"; "-style=" ^ Table.format_style (); filename])
     in
     if skip_format then
       ()
     else
-      ignore (Sys.command cmd)
+      ignore (Subprocess.run formatter formatter_args)
 
 (** Scans the ML structure and marks all custom-extracted GlobRefs as "used"
     so their associated [From "header.h"] imports are included. Must run before
@@ -1298,14 +1282,21 @@ let full_extr opaque_access f refs =
   full_extr_with_result opaque_access f refs (fun () -> ())
 
 (** Main entry point for full library extraction. Extracts the given references
-    and module paths to a single output file. *)
-let full_extraction ~opaque_access f lr =
+    and module paths to a single output file.
+
+    [validate] (default [true]) rejects an output filename that would escape the
+    output directory; trusted callers that supply an already-vetted or internal
+    path (e.g. a temporary file) pass [~validate:false]. *)
+let full_extraction ?(validate = true) ~opaque_access f lr =
+  if validate then Option.iter Table.validate_output_target f;
   full_extr opaque_access f (locate_ref lr)
 
 (** Full extraction variant used by managed benchmarks.  [after_print] runs
     while the exact C++ renaming tables used to print the artifact are still
-    available. *)
-let full_extraction_with_result ~opaque_access f lr after_print =
+    available. See {!full_extraction} for [validate]. *)
+let full_extraction_with_result ?(validate = true) ~opaque_access f lr after_print
+    =
+  if validate then Option.iter Table.validate_output_target f;
   full_extr_with_result opaque_access f (locate_ref lr) after_print
 
 (** {2 Separate extraction is similar to recursive extraction, with the output
@@ -1724,6 +1715,9 @@ let emit_test_status status test_id_str source_file =
 (** Full extract-compile-test pipeline: extracts to C++, compiles with clang,
     optionally links and runs the [.t.cpp] test driver, and reports results. *)
 let extract_and_compile ~opaque_access file l =
+  (* Reject an output target that would escape the output directory before it is
+     turned into a path. *)
+  Option.iter Table.validate_output_target file;
   let filename =
     match mono_filename file with
     | Some fn, _, _ ->
@@ -1749,7 +1743,8 @@ let extract_and_compile ~opaque_access file l =
   (* Phase 1: Extract Rocq definitions to C++ code *)
   let extraction_ok =
     try
-      full_extraction ~opaque_access (Some filename) l;
+      (* [filename] is derived internally from the already-validated [file]. *)
+      full_extraction ~validate:false ~opaque_access (Some filename) l;
       true
     with exn ->
       (* Emit structured output for dune, or pretty error for interactive use *)

--- a/src/extract_env.mli
+++ b/src/extract_env.mli
@@ -27,16 +27,23 @@ open Libnames
 val simple_extraction : opaque_access:Global.indirect_accessor -> qualid -> unit
 
 (** [Crane Extraction "file" qualids]: extract listed definitions to a file.
+    @param validate reject an output filename that escapes the output directory
+      (default [true]); trusted callers with an internal path pass [false]
     @param opaque_access accessor for opaque constant bodies
     @param the optional output filename; [None] prints to stdout
     @param the list of qualified names to extract *)
 val full_extraction :
-  opaque_access:Global.indirect_accessor -> string option -> qualid list -> unit
+  ?validate:bool ->
+  opaque_access:Global.indirect_accessor ->
+  string option ->
+  qualid list ->
+  unit
 
 (** Perform a full extraction and evaluate [after_print] before the extraction
     state is reset. This lets consumers retain metadata derived from the exact
-    names used while printing. *)
+    names used while printing. See {!full_extraction} for [validate]. *)
 val full_extraction_with_result :
+  ?validate:bool ->
   opaque_access:Global.indirect_accessor ->
   string option ->
   qualid list ->

--- a/src/minicpp.ml
+++ b/src/minicpp.ml
@@ -340,7 +340,11 @@ and template_type =
   | TTtypename
   | TTtypename_default of cpp_type (* typename T = default_type *)
   | TTfun of (cpp_type list * cpp_type)
-  | TTconcept of GlobRef.t (* e.g., 'Eq T' *)
+  | TTconcept of GlobRef.t * cpp_type list
+      (* Concept-constrained parameter.  The [cpp_type list] holds the concept's
+         extra (kept) type arguments beyond the constrained parameter itself:
+         [] for a unary concept such as ['Eq T' -> Eq _tcI0], and the kept args
+         for a multi-parameter concept such as ['C<I,T>' -> C<_tcI0, T1>]. *)
 
 (** Struct/class field declarations. *)
 and cpp_field =

--- a/src/minicpp.mli
+++ b/src/minicpp.mli
@@ -339,7 +339,11 @@ and template_type =
       (** typename with default: typename T = default_type *)
   | TTfun of (cpp_type list * cpp_type)
       (** Function type parameter for higher-order templates *)
-  | TTconcept of GlobRef.t  (** Concept-constrained parameter, e.g., Eq T *)
+  | TTconcept of GlobRef.t * cpp_type list
+      (** Concept-constrained parameter.  The [cpp_type list] carries the
+          concept's extra kept type arguments: [] for a unary concept
+          ([Eq _tcI0]), or the kept args for a multi-parameter concept
+          ([C<_tcI0, T1>]). *)
 
 (** {2 Struct fields} *)
 

--- a/src/subprocess.ml
+++ b/src/subprocess.ml
@@ -49,26 +49,31 @@ let executable_available executable =
 
 (** Execute a program directly, with optional file redirection, and wait for
     its termination. Open redirection descriptors are always closed. *)
-let run ?stdout_file ?stderr_file program args =
+let run ?stdin_file ?stdout_file ?stderr_file program args =
   let open_output filename =
     Unix.openfile
       filename
       [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC]
       0o600
   in
+  let stdin_fd =
+    Option.map (fun filename -> Unix.openfile filename [Unix.O_RDONLY] 0) stdin_file
+  in
   let stdout_fd = Option.map open_output stdout_file in
   let stderr_fd = Option.map open_output stderr_file in
   let close_redirects () =
+    Option.iter Unix.close stdin_fd;
     Option.iter Unix.close stdout_fd;
     Option.iter Unix.close stderr_fd
   in
   Fun.protect
     ~finally:close_redirects
     (fun () ->
+      let stdin_fd = match stdin_fd with Some fd -> fd | None -> Unix.stdin in
       let stdout_fd = match stdout_fd with Some fd -> fd | None -> Unix.stdout in
       let stderr_fd = match stderr_fd with Some fd -> fd | None -> Unix.stderr in
       let argv = Array.of_list (program :: args) in
-      let pid = Unix.create_process program argv Unix.stdin stdout_fd stderr_fd in
+      let pid = Unix.create_process program argv stdin_fd stdout_fd stderr_fd in
       CUnix.waitpid_non_intr pid )
 
 (** Execute a program while capturing stdout and stderr in separate temporary
@@ -82,6 +87,31 @@ let capture program args =
       remove_if_exists stderr_file )
     (fun () ->
       let status = run ~stdout_file ~stderr_file program args in
+      {
+        status;
+        stdout = read_file stdout_file;
+        stderr = read_file stderr_file;
+      } )
+
+(** Run [program] with [input] fed on standard input, capturing stdout and
+    stderr. The child never sees a shell: [input] is staged through a temporary
+    file wired directly to the child's stdin descriptor. All temporary files are
+    removed even when execution raises. *)
+let filter program args input =
+  let stdin_file = Filename.temp_file "crane_process_stdin" ".in" in
+  let stdout_file = Filename.temp_file "crane_process_stdout" ".log" in
+  let stderr_file = Filename.temp_file "crane_process_stderr" ".log" in
+  Fun.protect
+    ~finally:(fun () ->
+      remove_if_exists stdin_file;
+      remove_if_exists stdout_file;
+      remove_if_exists stderr_file )
+    (fun () ->
+      let oc = open_out_bin stdin_file in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc input);
+      let status = run ~stdin_file ~stdout_file ~stderr_file program args in
       {
         status;
         stdout = read_file stdout_file;

--- a/src/subprocess.mli
+++ b/src/subprocess.mli
@@ -23,13 +23,15 @@ exception Invalid_arguments of string
     searched on [PATH]; explicit paths are checked directly. *)
 val executable_available : string -> bool
 
-(** [run ?stdout_file ?stderr_file program arguments] executes [program]
-    directly and waits for it to terminate. Redirection files are truncated or
-    created with permissions [0o600]. Unspecified streams remain inherited from
-    the parent process.
+(** [run ?stdin_file ?stdout_file ?stderr_file program arguments] executes
+    [program] directly and waits for it to terminate. [stdin_file] is opened
+    read-only; redirection output files are truncated or created with
+    permissions [0o600]. Unspecified streams remain inherited from the parent
+    process.
 
     @return the child's raw {!Unix.process_status} *)
 val run :
+  ?stdin_file:string ->
   ?stdout_file:string ->
   ?stderr_file:string ->
   string ->
@@ -41,6 +43,14 @@ val run :
 
     @return the child's status and captured streams *)
 val capture : string -> string list -> captured_output
+
+(** [filter program arguments input] runs [program] with [input] on standard
+    input and captures its stdout and stderr. The input is staged through a
+    temporary file wired directly to the child's stdin, so no shell is involved.
+    Temporary files are removed even when execution raises.
+
+    @return the child's status and captured streams *)
+val filter : string -> string list -> string -> captured_output
 
 (** [exit_code status] converts [status] to a conventional integer exit code.
     Normal exits retain their code; signals and stopped states use [128 + n]. *)

--- a/src/table.ml
+++ b/src/table.ml
@@ -1331,6 +1331,35 @@ let output_directory_for_module () =
     | _ -> base_dir
   with _ -> base_dir
 
+(** Reject a user-supplied extraction target filename that could place generated
+    files outside the configured output directory.
+
+    A monolithic extraction target such as [Crane Extraction "f" M] flows
+    directly into the [.h]/[.cpp] output paths. Allowing an absolute path or a
+    [..] component would let a malicious Rocq source create or overwrite files
+    anywhere the extracting user can write (CWE-22/CWE-73). We therefore reject
+    absolute paths and any parent-directory component outright; ordinary
+    relative subpaths (e.g. ["sub/name"]) remain allowed and, being relative and
+    free of [..], are guaranteed to stay under the output directory. *)
+let validate_output_target target =
+  if not (Filename.is_relative target) then
+    CErrors.user_err
+      Pp.(
+        strbrk
+          "Crane extraction target must be a relative path within the output \
+           directory, but got an absolute path: "
+        ++ str target );
+  if
+    List.exists
+      (fun component -> String.equal component Filename.parent_dir_name)
+      (String.split_on_char '/' target)
+  then
+    CErrors.user_err
+      Pp.(
+        strbrk
+          "Crane extraction target must not contain a '..' path component: "
+        ++ str target )
+
 (** {2 Crane Extraction AccessOpaque} *)
 
 let access_opaque = my_bool_option "AccessOpaque" true

--- a/src/table.ml
+++ b/src/table.ml
@@ -2575,8 +2575,56 @@ let in_numeral : GlobRef.t * numeral_info -> obj =
     and non-Peano numeric types (e.g. N, Z).  For Peano types, S(S(..O))
     chains are folded.  For all types, digit-chain converters like
     [of_num_uint] are resolved and registered for large-literal folding. *)
+(* A numeral format is documented as a numeric-literal formatting directive, but
+   it is rendered by textual [%n] substitution and emitted verbatim as C++
+   ([CPPraw]).  Without a syntax guard a format could smuggle arbitrary C++
+   (statements, string/char literals, lambdas, comments, extra placeholders)
+   into generated code (CWE-94, source injection).  Restrict it to a numeric
+   literal wrapper: exactly one [%n] placeholder and, apart from that, only
+   characters that build a numeric literal or a wrapping macro/cast
+   ([INT64_C(%n)], [%nu], [static_cast<int64_t>(%n)], [mpz_class(%n)], ...).
+   The allowlist excludes the characters needed for statement, string, char,
+   comment, or lambda injection (semicolon, braces, quotes, backslash, slash,
+   brackets) while leaving every legitimate numeric format valid. *)
+let validate_numeral_fmt fmt =
+  let len = String.length fmt in
+  let rec count_placeholders i acc =
+    if i >= len then acc
+    else if fmt.[i] = '%' then
+      if i + 1 < len && fmt.[i + 1] = 'n' then
+        count_placeholders (i + 2) (acc + 1)
+      else
+        CErrors.user_err
+          (Pp.str
+             "Crane Extract Numeral: the only placeholder allowed in a format \
+              is %n")
+    else count_placeholders (i + 1) acc
+  in
+  if count_placeholders 0 0 <> 1 then
+    CErrors.user_err
+      (Pp.str
+         "Crane Extract Numeral: format must contain exactly one %n placeholder");
+  String.iter
+    (fun c ->
+      let ok =
+        (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || List.mem c
+             [ '%'; '_'; '('; ')'; '<'; '>'; ','; ':'; '+'; '-'; ' ' ]
+      in
+      if not ok then
+        CErrors.user_err
+          (Pp.str
+             (Printf.sprintf
+                "Crane Extract Numeral: format contains disallowed character \
+                 %C; only numeric-literal wrappers are permitted"
+                c)))
+    fmt
+
 let extract_numeral r fmt =
   check_inside_section ();
+  validate_numeral_fmt fmt;
   let g = Smartlocate.global_with_alias r in
   Dumpglob.add_glob ?loc:r.CAst.loc g;
   match g with

--- a/src/table.ml
+++ b/src/table.ml
@@ -1908,7 +1908,38 @@ let reset_used_custom_imports () = used_refs := Refset'.empty
 
 let customs = Summary.ref Refmap'.empty ~name:"CraneExtrCustom"
 
-let add_custom r ids s = customs := Refmap'.add r (ids, s) !customs
+(* Fires when a global already has a Crane extraction mapping and a *different*
+   one is registered on top of it -- almost always the symptom of importing two
+   overlapping [Mapping.*] modules (e.g. an int-backed and a GMP-backed flavor of
+   [Z]), where the last import silently wins.  Identical re-registration (the
+   same target reached through a transitive import) is not reported. *)
+let warn_overlapping_mapping =
+  CWarnings.create
+    ~name:"crane-overlapping-mapping"
+    ~category:CWarnings.CoreCategories.extraction
+    (fun (r, old_s, new_s) ->
+      let one_line s =
+        String.concat " " (String.split_on_char '\n' s)
+      in
+      let trunc s =
+        let s = one_line s in
+        if String.length s <= 50 then s else String.sub s 0 50 ^ "..."
+      in
+      strbrk "Crane: the extraction mapping for "
+      ++ safe_pr_global r
+      ++ strbrk " is being overridden (was \""
+      ++ str (trunc old_s)
+      ++ strbrk "\", now \""
+      ++ str (trunc new_s)
+      ++ strbrk "\"). The later mapping wins; this usually means two overlapping "
+      ++ strbrk "Mapping modules were imported together.")
+
+let add_custom r ids s =
+  (match Refmap'.find_opt r !customs with
+  | Some (_old_ids, old_s) when not (String.equal old_s s) ->
+    warn_overlapping_mapping (r, old_s, s)
+  | _ -> ());
+  customs := Refmap'.add r (ids, s) !customs
 
 let is_custom r = Refmap'.mem r !customs
 

--- a/src/table.mli
+++ b/src/table.mli
@@ -479,6 +479,12 @@ val output_directory : unit -> string
     directory on error. *)
 val output_directory_for_module : unit -> string
 
+(** [validate_output_target target] rejects a user-supplied extraction target
+    filename that could escape the output directory. Absolute paths and [..]
+    components raise a Rocq user error; ordinary relative subpaths are accepted.
+    Guards against path traversal / arbitrary file write (CWE-22/CWE-73). *)
+val validate_output_target : string -> unit
+
 (** {2 AccessOpaque parameter} *)
 
 (** Check if accessing opaque definitions is enabled. *)

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -11336,15 +11336,21 @@ let gen_instance_struct (name : GlobRef.t) (body : ml_ast) (ty : ml_type) :
         let instance_name = tc_instance_id tc_idx in
         let tt =
           match arg_ty with
-          | Tglob (r, _, _) ->
-            (* Only use inline concept constraint for unary concepts.
-               A concept is unary iff it has no kept type variables
-               (nb_sign_keeps = 0), so its only template param is I.
-               Multi-parameter concepts like [Numeric<I, t_A>] cannot
-               use inline syntax because the remaining type args aren't
-               available at the template-param declaration site. *)
+          | Tglob (r, type_args, _) ->
+            (* Unary concepts (nb_sign_keeps = 0) are expressed inline as
+               [Eq _tcI0].  Multi-parameter concepts like [Numeric<I, t_A>]
+               carry their kept type args so a [requires C<_tcI0, T1>] clause
+               can be emitted at the use site instead of silently degrading to
+               an unconstrained [typename] (CWE-693 / CWE-345). *)
             let nb_keeps = Table.get_ind_nb_sign_keeps r in
-            if nb_keeps = 0 then TTconcept r else TTtypename
+            if nb_keeps = 0 then TTconcept (r, [])
+            else
+              let type_arg_cpp =
+                List.map
+                  (convert_ml_type_to_cpp_type (empty_env ()) [])
+                  type_args
+              in
+              TTconcept (r, type_arg_cpp)
           | _ -> TTtypename
         in
         strip_outer_layers
@@ -11859,7 +11865,7 @@ let gen_instance_struct (name : GlobRef.t) (body : ml_ast) (ty : ml_type) :
         List.concat_map
           (fun (tt, tc_name) ->
             match tt with
-            | TTconcept class_ref_tc ->
+            | TTconcept (class_ref_tc, _) ->
               let tc_ip_vars = Table.get_ind_ip_vars class_ref_tc in
               let tc_nb_keeps = Table.get_ind_nb_sign_keeps class_ref_tc in
               let tc_promoted =
@@ -12629,7 +12635,8 @@ let gen_dfun n b cty ty temps =
               in
               let tt =
                 let nb_keeps = Table.get_ind_nb_sign_keeps class_ref in
-                if nb_keeps = 0 then TTconcept class_ref else TTtypename
+                if nb_keeps = 0 then TTconcept (class_ref, [])
+                else TTconcept (class_ref, type_arg_cpp)
               in
               ( tt,
                 instance_name,

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -3568,6 +3568,27 @@ and gen_expr_custom_cons env (ty : ml_type) r ts =
   match folded with
   | Some e -> e
   | None ->
+  (* Some custom-extracted inductives (e.g. [sum1], registered as
+     [Crane Extract Inductive sum1 => "" ["%a0" "%a0"]]) are pure type-level
+     erasure markers: their constructor template forwards the argument
+     completely unboxed, with no runtime wrapper type at all. For these, the
+     generic "erase Tvar-typed fields into std::any" logic below must NOT
+     fire, because there is no field storage to box into — the value must
+     stay exactly as it was produced. Wrapping it anyway makes the erased
+     [std::any] hold the argument's own (possibly unique closure) type
+     instead of whatever a downstream consumer expects inside that [std::any]
+     (e.g. [itree_vis] expects [std::function<std::any()>], not a bare
+     lambda), and the mismatched [std::any_cast] throws at runtime
+     (CWE-704, finding 44). *)
+  let is_passthrough_ctor_arg i =
+    match r with
+    | GlobRef.ConstructRef ((kn, mi), cidx) ->
+      ( try
+          let tmpl = List.nth (Table.find_custom_ctor_templates (kn, mi)) (cidx - 1) in
+          String.trim tmpl = Printf.sprintf "%%a%d" i
+        with _ -> false )
+    | _ -> false
+  in
   (* PROMOTED TYPE VARIABLES in constructor expressions: Use module-level
      aliases (std::any) instead of template-qualified types.
 
@@ -3741,6 +3762,7 @@ and gen_expr_custom_cons env (ty : ml_type) r ts =
       let result = match List.nth_opt field_types_for_wrap i with
         | Some (Miniml.Tvar j | Miniml.Tvar' j) ->
           (match List.nth_opt draft_ctor_temps_for_wrap (j - 1) with
+          | _ when is_passthrough_ctor_arg i -> result
           | Some Tany ->
             (match result with
             | CPPlambda _ -> result

--- a/src/translation.ml
+++ b/src/translation.ml
@@ -15210,6 +15210,17 @@ let gen_ind_header_v2
                   Id.to_string _alt_id ^ "->"
                   ^ Id.to_string field_id
                 in
+                (* This iterative drain replaces the naive recursive destructor,
+                   so cleanup of a deep deque-backed recursive value no longer
+                   overflows the call stack (the primary CWE-674 mitigation;
+                   regression: tests/regression/deque_deep_tree_stackoverflow).
+                   Residual tradeoff (CWE-400): the drain heap-allocates one
+                   [make_shared] wrapper per element, so under extreme memory
+                   pressure an allocation inside this (noexcept) destructor can
+                   still terminate the process.  Eliminating that would require
+                   an allocation-free intrusive worklist -- a larger redesign
+                   deferred here; bounded call-stack depth is the property that
+                   matters for the adversarial-depth attack. *)
                 if Table.is_custom list_g then
                   [Sif_then (
                     CPPbinop ("&&", fe,

--- a/tests/basics/dune
+++ b/tests/basics/dune
@@ -636,3 +636,14 @@
   (alias runtest)
   (deps z_int.t.exe)
   (action (run ./z_int.t.exe))))
+
+(subdir string_get_bounds
+ (rule
+  (targets string_get_bounds.t.exe)
+  (deps StringGetBounds.vo string_get_bounds.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} string_get_bounds.t.exe string_get_bounds.cpp string_get_bounds.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps string_get_bounds.t.exe)
+  (action (run ./string_get_bounds.t.exe))))

--- a/tests/basics/eq_ord_show/eq_ord_show.h
+++ b/tests/basics/eq_ord_show/eq_ord_show.h
@@ -52,27 +52,33 @@ struct NatShow {
 
 static_assert(Show<NatShow, uint64_t>);
 
-template <typename _tcI0, typename T1> bool is_equal(const T1 &x, const T1 &y) {
+template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
+bool is_equal(const T1 &x, const T1 &y) {
   return _tcI0::eqb(x, y);
 }
 
 template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
 bool is_different(const T1 &x, const T1 &y) {
   return _tcI0::neqb(x, y);
 }
 
 template <typename _tcI0, typename _tcI1, typename T1>
+  requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
 bool is_less_than(const T1 &x, const T1 &y) {
   return _tcI0::lt(x, y);
 }
 
 template <typename _tcI0, typename _tcI1, typename T1>
+  requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
 bool is_less_or_equal(const T1 &x, const T1 &y) {
   return _tcI0::le(x, y);
 }
 enum class Ordering { LT, EQ, GT };
 
 template <typename _tcI0, typename _tcI1, typename T1>
+  requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
 Ordering compare(const T1 &x, const T1 &y) {
   if (_tcI0::lt(x, y)) {
     return Ordering::LT;
@@ -85,11 +91,14 @@ Ordering compare(const T1 &x, const T1 &y) {
   }
 }
 
-template <typename _tcI0, typename T1> std::string to_string(const T1 &x) {
+template <typename _tcI0, typename T1>
+  requires Show<_tcI0, T1>
+std::string to_string(const T1 &x) {
   return _tcI0::show(x);
 }
 
 template <typename _tcI0, typename _tcI1, typename T1>
+  requires Show<_tcI0, T1> && Eq<_tcI1, T1>
 std::string show_if_equal(const T1 &x, const T1 &y) {
   if (_tcI1::eqb(x, y)) {
     return _tcI0::show(x);
@@ -99,6 +108,7 @@ std::string show_if_equal(const T1 &x, const T1 &y) {
 }
 
 template <typename _tcI0, typename _tcI1, typename _tcI2, typename T1>
+  requires Show<_tcI0, T1> && Ord<_tcI1, T1> && Eq<_tcI2, T1>
 std::string show_comparison(const T1 &x, const T1 &y) {
   if (_tcI1::lt(x, y)) {
     return _tcI0::show(x) + " < "s + _tcI0::show(y);

--- a/tests/basics/graph/graph.h
+++ b/tests/basics/graph/graph.h
@@ -207,6 +207,7 @@ template <typename A> struct DirectedEdge {
 };
 
 template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
 bool directed_originates(const T1 &a, const DirectedEdge<T1> &e) {
   return _tcI0::eqb(e.edge_from, a);
 }
@@ -217,7 +218,9 @@ template <typename A> struct Directed {
   List<DirectedEdge<A>> directed_edges;
 };
 
-template <typename _tcI0, typename T1> struct DirectedGraph {
+template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
+struct DirectedGraph {
   using edge = DirectedEdge<T1>;
 
   static Directed<std::any> empty() {
@@ -252,6 +255,7 @@ template <typename A> struct UndirectedEdge {
 };
 
 template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
 bool undirected_originates(const T1 &a, const UndirectedEdge<T1> &e) {
   return (_tcI0::eqb(e.edge_first, a) || _tcI0::eqb(e.edge_second, a));
 }
@@ -261,7 +265,9 @@ template <typename A> struct Undirected {
   List<UndirectedEdge<A>> undirected_edges;
 };
 
-template <typename _tcI0, typename T1> struct UndirectedGraph {
+template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
+struct UndirectedGraph {
   using edge = UndirectedEdge<T1>;
 
   static Undirected<std::any> empty() {
@@ -299,7 +305,9 @@ struct NatEq {
 
 static_assert(Eq<NatEq, Nat>);
 
-template <typename _tcI0, typename T1> bool test_eq(const T1 &x, const T1 &y) {
+template <typename _tcI0, typename T1>
+  requires Eq<_tcI0, T1>
+bool test_eq(const T1 &x, const T1 &y) {
   return _tcI0::eqb(x, y);
 }
 

--- a/tests/basics/int63_arith/int63_arith.cpp
+++ b/tests/basics/int63_arith/int63_arith.cpp
@@ -2,7 +2,9 @@
 
 int64_t Int63Arith::i_abs(int64_t x) {
   if (x < INT64_C(0)) {
-    return ((INT64_C(0) - x) & 0x7FFFFFFFFFFFFFFFLL);
+    return static_cast<int64_t>(
+        (static_cast<uint64_t>(INT64_C(0)) - static_cast<uint64_t>(x)) &
+        0x7FFFFFFFFFFFFFFFULL);
   } else {
     return x;
   }

--- a/tests/basics/int63_arith/int63_arith.h
+++ b/tests/basics/int63_arith/int63_arith.h
@@ -7,11 +7,15 @@ struct Int63Arith {
   static inline const int64_t i_zero = INT64_C(0);
   static inline const int64_t i_one = INT64_C(1);
   static inline const int64_t i_add =
-      ((INT64_C(10) + INT64_C(20)) & 0x7FFFFFFFFFFFFFFFLL);
-  static inline const int64_t i_mul =
-      ((INT64_C(6) * INT64_C(7)) & 0x7FFFFFFFFFFFFFFFLL);
-  static inline const int64_t i_sub =
-      ((INT64_C(50) - INT64_C(8)) & 0x7FFFFFFFFFFFFFFFLL);
+      static_cast<int64_t>((static_cast<uint64_t>(INT64_C(10)) +
+                            static_cast<uint64_t>(INT64_C(20))) &
+                           0x7FFFFFFFFFFFFFFFULL);
+  static inline const int64_t i_mul = static_cast<int64_t>(
+      (static_cast<uint64_t>(INT64_C(6)) * static_cast<uint64_t>(INT64_C(7))) &
+      0x7FFFFFFFFFFFFFFFULL);
+  static inline const int64_t i_sub = static_cast<int64_t>(
+      (static_cast<uint64_t>(INT64_C(50)) - static_cast<uint64_t>(INT64_C(8))) &
+      0x7FFFFFFFFFFFFFFFULL);
   static inline const bool i_eqb_true = INT64_C(42) == INT64_C(42);
   static inline const bool i_eqb_false = INT64_C(42) == INT64_C(43);
   static inline const bool i_ltb_true = INT64_C(3) < INT64_C(5);
@@ -20,8 +24,9 @@ struct Int63Arith {
   static inline const bool i_leb_false = INT64_C(5) <= INT64_C(3);
   static int64_t i_abs(int64_t x);
   static inline const int64_t test_abs_pos = i_abs(INT64_C(42));
-  static inline const int64_t test_abs_neg =
-      i_abs(((INT64_C(0) - INT64_C(42)) & 0x7FFFFFFFFFFFFFFFLL));
+  static inline const int64_t test_abs_neg = i_abs(static_cast<int64_t>(
+      (static_cast<uint64_t>(INT64_C(0)) - static_cast<uint64_t>(INT64_C(42))) &
+      0x7FFFFFFFFFFFFFFFULL));
 };
 
 #endif // INCLUDED_INT63_ARITH

--- a/tests/basics/string_get_bounds/StringGetBounds.v
+++ b/tests/basics/string_get_bounds/StringGetBounds.v
@@ -1,0 +1,36 @@
+(* Copyright 2025 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+
+(** Boundary regression for checked string / string-view indexing.
+
+    Rocq's [PrimString.get] is total: [get_spec] gives
+    [get s i = nth (to_nat i) s 0], so an out-of-range index yields the null
+    char rather than undefined behavior. The extraction must reproduce that
+    (a bounds check), never an unchecked [operator[]]. Covers security-scan
+    findings 21 (PrimString.get) and 23 (StringView.sv_get) for the std flavor. *)
+Require Import PrimString PrimInt63.
+From Crane Require Import Extraction Mapping.Std External.StringViewStd.
+
+Open Scope pstring_scope.
+Open Scope int63.
+
+Module StringGetBounds.
+
+Definition s : string := "abc".
+
+(** In-bounds access returns the expected character. *)
+Definition first : char63 := PrimString.get s 0.
+
+(** Out-of-range access returns the null char (Rocq semantics), not an
+    out-of-bounds read. *)
+Definition oob : char63 := PrimString.get s 100.
+
+Definition sv : string_view := sv_of_string s.
+
+(** Same contract for string views. *)
+Definition sv_first : char63 := sv_get sv 0.
+Definition sv_oob : char63 := sv_get sv 100.
+
+End StringGetBounds.
+
+Crane Extraction "string_get_bounds" StringGetBounds.

--- a/tests/basics/string_get_bounds/string_get_bounds.cpp
+++ b/tests/basics/string_get_bounds/string_get_bounds.cpp
@@ -1,0 +1,1 @@
+#include "string_get_bounds.h"

--- a/tests/basics/string_get_bounds/string_get_bounds.h
+++ b/tests/basics/string_get_bounds/string_get_bounds.h
@@ -1,0 +1,34 @@
+#ifndef INCLUDED_STRING_GET_BOUNDS
+#define INCLUDED_STRING_GET_BOUNDS
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+struct StringGetBounds {
+  static inline const std::string s = "abc";
+  /// In-bounds access returns the expected character.
+  static inline const char first =
+      ((INT64_C(0) >= 0 && INT64_C(0) < static_cast<int64_t>(s.length()))
+           ? s[INT64_C(0)]
+           : static_cast<char>(0));
+  /// Out-of-range access returns the null char (Rocq semantics), not an
+  /// out-of-bounds read.
+  static inline const char oob =
+      ((INT64_C(100) >= 0 && INT64_C(100) < static_cast<int64_t>(s.length()))
+           ? s[INT64_C(100)]
+           : static_cast<char>(0));
+  static inline const std::basic_string_view<char> sv = {s.data(), s.size()};
+  /// Same contract for string views.
+  static inline const char sv_first =
+      ((INT64_C(0) >= 0 && INT64_C(0) < static_cast<int64_t>(sv.length()))
+           ? sv[INT64_C(0)]
+           : static_cast<char>(0));
+
+  static inline const char sv_oob =
+      ((INT64_C(100) >= 0 && INT64_C(100) < static_cast<int64_t>(sv.length()))
+           ? sv[INT64_C(100)]
+           : static_cast<char>(0));
+};
+
+#endif // INCLUDED_STRING_GET_BOUNDS

--- a/tests/basics/string_get_bounds/string_get_bounds.t.cpp
+++ b/tests/basics/string_get_bounds/string_get_bounds.t.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include <string_get_bounds.h>
+
+#include <iostream>
+
+int main() {
+  int status = 0;
+
+  // In-bounds indexing returns the expected character.
+  if (StringGetBounds::first != 'a') {
+    std::cout << "FAIL: PrimString.get in-bounds\n";
+    status = 1;
+  }
+  if (StringGetBounds::sv_first != 'a') {
+    std::cout << "FAIL: sv_get in-bounds\n";
+    status = 1;
+  }
+
+  // Out-of-range indexing returns the null char (Rocq's total [get]
+  // semantics) instead of performing an out-of-bounds read.
+  if (StringGetBounds::oob != '\0') {
+    std::cout << "FAIL: PrimString.get out-of-bounds should be '\\0'\n";
+    status = 1;
+  }
+  if (StringGetBounds::sv_oob != '\0') {
+    std::cout << "FAIL: sv_get out-of-bounds should be '\\0'\n";
+    status = 1;
+  }
+
+  if (status == 0) {
+    std::cout << "string_get_bounds: all checks passed\n";
+  }
+  return status;
+}

--- a/tests/basics/tokenizer/tokenizer.cpp
+++ b/tests/basics/tokenizer/tokenizer.cpp
@@ -19,7 +19,9 @@ Tokenizer::next_token(std::basic_string_view<char> input,
             std::string_view(nullptr, 0));
       } else {
         uint64_t fuel_ = fuel - 1;
-        char c = s[index];
+        char c = ((index >= 0 && index < static_cast<int64_t>(s.length()))
+                      ? s[index]
+                      : static_cast<char>(0));
         if (hard.contains(c)) {
           return std::make_pair(
               std::make_optional<std::basic_string_view<char>>(

--- a/tests/basics/tokenizer/tokenizer.cpp
+++ b/tests/basics/tokenizer/tokenizer.cpp
@@ -26,30 +26,50 @@ Tokenizer::next_token(std::basic_string_view<char> input,
           return std::make_pair(
               std::make_optional<std::basic_string_view<char>>(
                   s.substr(INT64_C(0), index)),
-              s.substr(((index + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL),
-                       ((input.length() -
-                         ((index + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL)) &
-                        0x7FFFFFFFFFFFFFFFLL)));
+              s.substr(
+                  static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                        static_cast<uint64_t>(INT64_C(1))) &
+                                       0x7FFFFFFFFFFFFFFFULL),
+                  static_cast<int64_t>(
+                      (static_cast<uint64_t>(input.length()) -
+                       static_cast<uint64_t>(static_cast<int64_t>(
+                           (static_cast<uint64_t>(index) +
+                            static_cast<uint64_t>(INT64_C(1))) &
+                           0x7FFFFFFFFFFFFFFFULL))) &
+                      0x7FFFFFFFFFFFFFFFULL)));
         } else {
           if (soft.contains(c)) {
             if (index == INT64_C(0)) {
-              return _self_aux(_self_aux, fuel_, INT64_C(0),
-                               std::move(s).substr(
-                                   INT64_C(1), ((input.length() - INT64_C(1)) &
-                                                0x7FFFFFFFFFFFFFFFLL)));
+              return _self_aux(
+                  _self_aux, fuel_, INT64_C(0),
+                  std::move(s).substr(
+                      INT64_C(1), static_cast<int64_t>(
+                                      (static_cast<uint64_t>(input.length()) -
+                                       static_cast<uint64_t>(INT64_C(1))) &
+                                      0x7FFFFFFFFFFFFFFFULL)));
             } else {
               return std::make_pair(
                   std::make_optional<std::basic_string_view<char>>(
                       s.substr(INT64_C(0), index)),
-                  s.substr(((index + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL),
-                           ((input.length() -
-                             ((index + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL)) &
-                            0x7FFFFFFFFFFFFFFFLL)));
+                  s.substr(
+                      static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                            static_cast<uint64_t>(INT64_C(1))) &
+                                           0x7FFFFFFFFFFFFFFFULL),
+                      static_cast<int64_t>(
+                          (static_cast<uint64_t>(input.length()) -
+                           static_cast<uint64_t>(static_cast<int64_t>(
+                               (static_cast<uint64_t>(index) +
+                                static_cast<uint64_t>(INT64_C(1))) &
+                               0x7FFFFFFFFFFFFFFFULL))) &
+                          0x7FFFFFFFFFFFFFFFULL)));
             }
           } else {
-            return _self_aux(_self_aux, fuel_,
-                             ((index + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL),
-                             std::move(s));
+            return _self_aux(
+                _self_aux, fuel_,
+                static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                      static_cast<uint64_t>(INT64_C(1))) &
+                                     0x7FFFFFFFFFFFFFFFULL),
+                std::move(s));
           }
         }
       }

--- a/tests/basics/tokenizer/tokenizer.cpp
+++ b/tests/basics/tokenizer/tokenizer.cpp
@@ -25,43 +25,70 @@ Tokenizer::next_token(std::basic_string_view<char> input,
         if (hard.contains(c)) {
           return std::make_pair(
               std::make_optional<std::basic_string_view<char>>(
-                  s.substr(INT64_C(0), index)),
-              s.substr(
-                  static_cast<int64_t>((static_cast<uint64_t>(index) +
+                  ((INT64_C(0) >= 0 &&
+                    INT64_C(0) <= static_cast<int64_t>(s.length()))
+                       ? s.substr(INT64_C(0), index)
+                       : std::basic_string_view<char>())),
+              ((static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                      static_cast<uint64_t>(INT64_C(1))) &
+                                     0x7FFFFFFFFFFFFFFFULL) >= 0 &&
+                static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                      static_cast<uint64_t>(INT64_C(1))) &
+                                     0x7FFFFFFFFFFFFFFFULL) <=
+                    static_cast<int64_t>(s.length()))
+                   ? s.substr(static_cast<int64_t>(
+                                  (static_cast<uint64_t>(index) +
+                                   static_cast<uint64_t>(INT64_C(1))) &
+                                  0x7FFFFFFFFFFFFFFFULL),
+                              static_cast<int64_t>(
+                                  (static_cast<uint64_t>(input.length()) -
+                                   static_cast<uint64_t>(static_cast<int64_t>(
+                                       (static_cast<uint64_t>(index) +
                                         static_cast<uint64_t>(INT64_C(1))) &
-                                       0x7FFFFFFFFFFFFFFFULL),
-                  static_cast<int64_t>(
-                      (static_cast<uint64_t>(input.length()) -
-                       static_cast<uint64_t>(static_cast<int64_t>(
-                           (static_cast<uint64_t>(index) +
-                            static_cast<uint64_t>(INT64_C(1))) &
-                           0x7FFFFFFFFFFFFFFFULL))) &
-                      0x7FFFFFFFFFFFFFFFULL)));
+                                       0x7FFFFFFFFFFFFFFFULL))) &
+                                  0x7FFFFFFFFFFFFFFFULL))
+                   : std::basic_string_view<char>()));
         } else {
           if (soft.contains(c)) {
             if (index == INT64_C(0)) {
               return _self_aux(
                   _self_aux, fuel_, INT64_C(0),
-                  std::move(s).substr(
-                      INT64_C(1), static_cast<int64_t>(
-                                      (static_cast<uint64_t>(input.length()) -
-                                       static_cast<uint64_t>(INT64_C(1))) &
-                                      0x7FFFFFFFFFFFFFFFULL)));
+                  ((INT64_C(1) >= 0 &&
+                    INT64_C(1) <= static_cast<int64_t>(std::move(s).length()))
+                       ? std::move(s).substr(
+                             INT64_C(1),
+                             static_cast<int64_t>(
+                                 (static_cast<uint64_t>(input.length()) -
+                                  static_cast<uint64_t>(INT64_C(1))) &
+                                 0x7FFFFFFFFFFFFFFFULL))
+                       : std::basic_string_view<char>()));
             } else {
               return std::make_pair(
                   std::make_optional<std::basic_string_view<char>>(
-                      s.substr(INT64_C(0), index)),
-                  s.substr(
-                      static_cast<int64_t>((static_cast<uint64_t>(index) +
-                                            static_cast<uint64_t>(INT64_C(1))) &
-                                           0x7FFFFFFFFFFFFFFFULL),
-                      static_cast<int64_t>(
-                          (static_cast<uint64_t>(input.length()) -
-                           static_cast<uint64_t>(static_cast<int64_t>(
-                               (static_cast<uint64_t>(index) +
-                                static_cast<uint64_t>(INT64_C(1))) &
-                               0x7FFFFFFFFFFFFFFFULL))) &
-                          0x7FFFFFFFFFFFFFFFULL)));
+                      ((INT64_C(0) >= 0 &&
+                        INT64_C(0) <= static_cast<int64_t>(s.length()))
+                           ? s.substr(INT64_C(0), index)
+                           : std::basic_string_view<char>())),
+                  ((static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                          static_cast<uint64_t>(INT64_C(1))) &
+                                         0x7FFFFFFFFFFFFFFFULL) >= 0 &&
+                    static_cast<int64_t>((static_cast<uint64_t>(index) +
+                                          static_cast<uint64_t>(INT64_C(1))) &
+                                         0x7FFFFFFFFFFFFFFFULL) <=
+                        static_cast<int64_t>(s.length()))
+                       ? s.substr(
+                             static_cast<int64_t>(
+                                 (static_cast<uint64_t>(index) +
+                                  static_cast<uint64_t>(INT64_C(1))) &
+                                 0x7FFFFFFFFFFFFFFFULL),
+                             static_cast<int64_t>(
+                                 (static_cast<uint64_t>(input.length()) -
+                                  static_cast<uint64_t>(static_cast<int64_t>(
+                                      (static_cast<uint64_t>(index) +
+                                       static_cast<uint64_t>(INT64_C(1))) &
+                                      0x7FFFFFFFFFFFFFFFULL))) &
+                                 0x7FFFFFFFFFFFFFFFULL))
+                       : std::basic_string_view<char>()));
             }
           } else {
             return _self_aux(

--- a/tests/basics/topological_sort_bde/topological_sort_bde.cpp
+++ b/tests/basics/topological_sort_bde/topological_sort_bde.cpp
@@ -5,20 +5,20 @@
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <bsl_optional.h>
-#include <bsl_utility.h>
-#include <bsl_string.h>
-#include <bsl_memory.h>
 
-
-namespace BloombergLP {
-
+namespace BloombergLP {}
+List<unsigned int> ListDef::seq(unsigned int start, unsigned int len) {
+  if (len <= 0) {
+    return List<unsigned int>::nil();
+  } else {
+    unsigned int len0 = len - 1;
+    return List<unsigned int>::cons(start, ListDef::seq((start + 1), len0));
+  }
 }
-List<unsigned int> ListDef::seq(unsigned int start,
-unsigned int len){if (len <= 0) { return List<unsigned int>::nil(); } else { unsigned int len0 = len - 1; return List<unsigned int>::cons(start, ListDef::seq((start + 1),
-len0)); }}

--- a/tests/basics/topological_sort_bde/topological_sort_bde.h
+++ b/tests/basics/topological_sort_bde/topological_sort_bde.h
@@ -1,23 +1,20 @@
 #ifndef INCLUDED_TOPOLOGICAL_SORT_BDE
 #define INCLUDED_TOPOLOGICAL_SORT_BDE
 
+#include <any>
 #include <bdlf_overloaded.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <any>
 #include <utility>
-#include <bsl_optional.h>
-#include <bsl_utility.h>
-#include <bsl_string.h>
-#include <bsl_memory.h>
-
 
 using namespace BloombergLP;
 using namespace bsl::string_literals;
@@ -28,349 +25,485 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-
-template <typename
-t_A>struct List {
+template <typename t_A> struct List {
   // TYPES
-struct Nil {
+  struct Nil {};
+  struct Cons {
+    t_A d_a;
+    bsl::shared_ptr<List<t_A>> d_l;
+  };
+  using variant_t = bsl::variant<Nil, Cons>;
 
-};
-struct Cons {
-t_A d_a;
-bsl::shared_ptr<List<t_A>> d_l;
-};
-using variant_t = bsl::variant<Nil,
-Cons>;
 private:
   // DATA
-variant_t d_v_;
+  variant_t d_v_;
+
 public:
   // CREATORS
-List() {}
-explicit List(Nil _v) : d_v_(_v) {}
-explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
-template <typename
-_U>
-explicit List(const List<_U>& _other) {
-if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
-this->d_v_ = Nil{};
-} else {
-const auto& [d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
-this->d_v_ = Cons{[&]() -> t_A { if constexpr (std::is_same_v<_U, std::any>) { if (d_a.type() == typeid(t_A)) return std::any_cast<t_A>(d_a); if constexpr (requires { typename t_A::first_type; typename t_A::second_type; }) { const auto& [_k, _v] = std::any_cast<std::pair<std::any, std::any>>(d_a); return t_A{ [&]() -> typename t_A::first_type { if constexpr (std::is_same_v<typename t_A::first_type, std::any>) return _k; else return std::any_cast<typename t_A::first_type>(_k); }(), [&]() -> typename t_A::second_type { if constexpr (std::is_same_v<typename t_A::second_type, std::any>) return _v; else return std::any_cast<typename t_A::second_type>(_v); }() }; } return std::any_cast<t_A>(d_a); } else return t_A(d_a); }(),
-d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
-}}
-static List<t_A> nil(){
-return List(Nil{});}
-static List<t_A> cons(t_A a, List<t_A> l){
-return List(Cons{bsl::move(a),
-bsl::make_shared<List<t_A>>(bsl::move(l))});}
+  List() {}
+  explicit List(Nil _v) : d_v_(_v) {}
+  explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
+  template <typename _U> explicit List(const List<_U> &_other) {
+    if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
+      this->d_v_ = Nil{};
+    } else {
+      const auto &[d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
+      this->d_v_ = Cons{
+          [&]() -> t_A {
+            if constexpr (std::is_same_v<_U, std::any>) {
+              if (d_a.type() == typeid(t_A))
+                return std::any_cast<t_A>(d_a);
+              if constexpr (requires {
+                              typename t_A::first_type;
+                              typename t_A::second_type;
+                            }) {
+                const auto &[_k, _v] =
+                    std::any_cast<std::pair<std::any, std::any>>(d_a);
+                return t_A{
+                    [&]() -> typename t_A::first_type {
+                      if constexpr (std::is_same_v<typename t_A::first_type,
+                                                   std::any>)
+                        return _k;
+                      else
+                        return std::any_cast<typename t_A::first_type>(_k);
+                    }(),
+                    [&]() -> typename t_A::second_type {
+                      if constexpr (std::is_same_v<typename t_A::second_type,
+                                                   std::any>)
+                        return _v;
+                      else
+                        return std::any_cast<typename t_A::second_type>(_v);
+                    }()};
+              }
+              return std::any_cast<t_A>(d_a);
+            } else
+              return t_A(d_a);
+          }(),
+          d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
+    }
+  }
+  static List<t_A> nil() { return List(Nil{}); }
+  static List<t_A> cons(t_A a, List<t_A> l) {
+    return List(Cons{bsl::move(a), bsl::make_shared<List<t_A>>(bsl::move(l))});
+  }
   // MANIPULATORS
-~List() {
-bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
-auto _drain = [&](variant_t&
-_v) {
-if (auto* _alt = bsl::get_if<Cons>(&_v)) {
-if (_alt->d_l) {
-_stack.push_back(bsl::move(_alt->d_l));
-}
-}
-};
-_drain(v_mut());
-while (!_stack.empty()) {
-auto _cur = bsl::move(_stack.back());
-_stack.pop_back();
-if (_cur.use_count() == 1) {
-_drain(_cur->v_mut());
-}
-}
-}
-inline variant_t& v_mut() {
-return d_v_;}
+  ~List() {
+    bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
+    auto _drain = [&](variant_t &_v) {
+      if (auto *_alt = bsl::get_if<Cons>(&_v)) {
+        if (_alt->d_l) {
+          _stack.push_back(bsl::move(_alt->d_l));
+        }
+      }
+    };
+    _drain(v_mut());
+    while (!_stack.empty()) {
+      auto _cur = bsl::move(_stack.back());
+      _stack.pop_back();
+      if (_cur.use_count() == 1) {
+        _drain(_cur->v_mut());
+      }
+    }
+  }
+  inline variant_t &v_mut() { return d_v_; }
   // ACCESSORS
-const variant_t& v() const {
-return d_v_;}
-template <typename
-T1>
-List<bsl::pair<t_A, T1>> combine(const List<T1>& l_) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return List<bsl::pair<t_A, T1>>::nil();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-if (bsl::holds_alternative<typename List<T1>::Nil>(l_.v())) {
-return List<bsl::pair<t_A, T1>>::nil();
-} else {
-const auto& [d_a00, d_a10] = bsl::get<typename List<T1>::Cons>(l_.v());
-return List<bsl::pair<t_A, T1>>::cons(bsl::make_pair(d_a0, d_a00), d_a1->template combine<T1>(*d_a10));
-}
-}}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
-bsl::optional<t_A> find(F0&& f) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return bsl::optional<t_A>();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-if (f(d_a0)) { return bsl::make_optional<t_A>(d_a0); } else { return d_a1->find(f); }
-}}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
-List<t_A> filter(F0&& f) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return List<t_A>::nil();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-if (f(d_a0)) { return List<t_A>::cons(d_a0, d_a1->filter(f)); } else { return d_a1->filter(f); }
-}}
-template <typename T1, typename
-F0>
-  requires bsl::is_invocable_r_v<T1, F0 &, t_A &, T1 &>
-T1 fold_right(F0&& f,
-T1 a0) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return a0;
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-return f(d_a0, d_a1->template fold_right<T1>(f, a0));
-}}
-template <typename
-T1>
-List<T1> concat() const {
-if (bsl::holds_alternative<typename List<List<T1>>::Nil>(this->v())) {
-return List<T1>::nil();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<List<T1>>::Cons>(this->v());
-return d_a0.app(d_a1->template concat<T1>());
-}}
-template <typename T1, typename
-F0>
-  requires bsl::is_invocable_r_v<T1, F0 &, t_A &>
-List<T1> map(F0&& f) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return List<T1>::nil();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-return List<T1>::cons(f(d_a0), d_a1->template map<T1>(f));
-}}
-unsigned int length() const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return 0u;
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-return (d_a1->length() + 1);
-}}
-List<t_A> app(List<t_A> m) const {
-if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
-return m;
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
-return List<t_A>::cons(d_a0, d_a1->app(bsl::move(m)));
-}}
-};struct ListDef {
-static List<unsigned int> seq(unsigned int start, unsigned int len);
-};struct ToString {
-template <typename T1, typename T2, typename F0, typename
-F1>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
-      && bsl::is_invocable_r_v<bsl::string, F1 &, T2 &>
-static bsl::string pair_to_string(F0&& p1, F1&& p2,
-const bsl::pair<T1, T2>& x){auto [a, b] = x; return "("_s + p1(a) + ", "_s + p2(b) + ")"_s;}
-template <typename T1, typename F0>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
-static bsl::string intersperse(F0&& p, bsl::string sep,
-const List<T1>& l){if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
-return "";
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
-auto&& _sv = *d_a1;
-if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
-return sep + p(d_a0);
-} else {
-return sep + p(d_a0) + intersperse<T1>(p, sep, *d_a1);
-}
-}}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
-static bsl::string list_to_string(F0&& p,
-const List<T1>& l){if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
-return "[]";
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
-auto&& _sv = *d_a1;
-if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
-return "["_s + p(d_a0) + "]"_s;
-} else {
-return "["_s + p(d_a0) + intersperse<T1>(p, "; ", *d_a1) + "]"_s;
-}
-}}
-};struct TopologicalSort {
-template <typename node> using entry = bsl::pair<node, List<node>>;
-template <typename node> using graph = List<entry<node>>;
-template <typename node> using order = List<List<node>>;template <typename
-T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<T1> get_elems(F0&& eqb_node,
-const List<bsl::pair<T1, T1>>& l){auto get_elems_aux_impl = [&](auto&
-_self_get_elems_aux, const List<bsl::pair<T1, T1>>& l0, List<T1>
-h) -> List<T1> {
-if (bsl::holds_alternative<typename List<bsl::pair<T1, T1>>::Nil>(l0.v())) {
-return h;
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T1>>::Cons>(l0.v());
-const List<bsl::pair<T1, T1>>& d_a1_value = *d_a1;
-auto [e1, e2] = d_a0; bsl::optional<T1> f1 = h.find([=](const T1&
-x) mutable {
-return eqb_node(e1, x);
-});
-bsl::optional<T1> f2 = h.find([=](const T1& x) mutable {
-return eqb_node(e2,
-x);
-});
-if (f1.has_value()) { T1 _x = *f1; if (f2.has_value()) { T1 _x0 = *f2; return _self_get_elems_aux(_self_get_elems_aux,
-d_a1_value,
-bsl::move(h)); } else { return _self_get_elems_aux(_self_get_elems_aux,
-d_a1_value,
-List<T1>::cons(e2, bsl::move(h))); } } else { if (f2.has_value()) { T1 _x = *f2; return _self_get_elems_aux(_self_get_elems_aux,
-d_a1_value, List<T1>::cons(e1, bsl::move(h))); } else { if (eqb_node(e1,
-e2)) { return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
-List<T1>::cons(e1, bsl::move(h))); } else { return _self_get_elems_aux(_self_get_elems_aux,
-d_a1_value,
-List<T1>::cons(e1, List<T1>::cons(e2, bsl::move(h)))); } } }
-}
+  const variant_t &v() const { return d_v_; }
+  template <typename T1>
+  List<bsl::pair<t_A, T1>> combine(const List<T1> &l_) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return List<bsl::pair<t_A, T1>>::nil();
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      if (bsl::holds_alternative<typename List<T1>::Nil>(l_.v())) {
+        return List<bsl::pair<t_A, T1>>::nil();
+      } else {
+        const auto &[d_a00, d_a10] = bsl::get<typename List<T1>::Cons>(l_.v());
+        return List<bsl::pair<t_A, T1>>::cons(
+            bsl::make_pair(d_a0, d_a00), d_a1->template combine<T1>(*d_a10));
+      }
+    }
+  }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
+  bsl::optional<t_A> find(F0 &&f) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return bsl::optional<t_A>();
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      if (f(d_a0)) {
+        return bsl::make_optional<t_A>(d_a0);
+      } else {
+        return d_a1->find(f);
+      }
+    }
+  }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, t_A &>
+  List<t_A> filter(F0 &&f) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return List<t_A>::nil();
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      if (f(d_a0)) {
+        return List<t_A>::cons(d_a0, d_a1->filter(f));
+      } else {
+        return d_a1->filter(f);
+      }
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<T1, F0 &, t_A &, T1 &>
+  T1 fold_right(F0 &&f, T1 a0) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return a0;
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      return f(d_a0, d_a1->template fold_right<T1>(f, a0));
+    }
+  }
+  template <typename T1> List<T1> concat() const {
+    if (bsl::holds_alternative<typename List<List<T1>>::Nil>(this->v())) {
+      return List<T1>::nil();
+    } else {
+      const auto &[d_a0, d_a1] =
+          bsl::get<typename List<List<T1>>::Cons>(this->v());
+      return d_a0.app(d_a1->template concat<T1>());
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<T1, F0 &, t_A &>
+  List<T1> map(F0 &&f) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return List<T1>::nil();
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      return List<T1>::cons(f(d_a0), d_a1->template map<T1>(f));
+    }
+  }
+  unsigned int length() const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return 0u;
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      return (d_a1->length() + 1);
+    }
+  }
+  List<t_A> app(List<t_A> m) const {
+    if (bsl::holds_alternative<typename List<t_A>::Nil>(this->v())) {
+      return m;
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<t_A>::Cons>(this->v());
+      return List<t_A>::cons(d_a0, d_a1->app(bsl::move(m)));
+    }
+  }
 };
-auto get_elems_aux = [&](const List<bsl::pair<T1, T1>>& l0, List<T1>
-h) -> List<T1> {
-return get_elems_aux_impl(get_elems_aux_impl, l0,
-h);
+struct ListDef {
+  static List<unsigned int> seq(unsigned int start, unsigned int len);
 };
-return get_elems_aux(l, List<T1>::nil());}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static entry<T1> make_entry(F0&& eqb_node, const List<bsl::pair<T1, T1>>& l,
-T1 e){return bsl::make_pair(e, l.template fold_right<List<T1>>([=](const bsl::pair<T1, T1>&
-x, List<T1> ret) mutable {
-if (eqb_node(e,
-x.first)) { return List<T1>::cons(x.second, ret); } else { return ret; }
-}, List<T1>::nil()));}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static graph<T1> make_graph(F0&& eqb_node,
-List<bsl::pair<T1, T1>> l){List<T1> elems = get_elems<T1>(eqb_node,
-l);
-return bsl::move(elems).template fold_right<List<entry<T1>>>([=](const T1& e,
-List<bsl::pair<T1, List<T1>>>
-ret) mutable {
-return List<bsl::pair<T1, List<T1>>>::cons(make_entry<T1>(eqb_node, l,
-e), ret);
-}, List<bsl::pair<T1, List<T1>>>::nil());}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<T1> graph_lookup(F0&& eqb_node, const T1& elem,
-const List<bsl::pair<T1, List<T1>>>& graph0){auto _cs = graph0.find([=](const bsl::pair<T1, List<T1>>&
-entry0) mutable {
-return eqb_node(elem,
-entry0.first);
-});
-if (_cs.has_value()) { bsl::pair<T1, List<T1>> p = *_cs; auto [_x, es] = p; return es; } else { return List<T1>::nil(); }}
-template <typename T1, typename F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bool contains(F0&& eqb_node, const T1& elem,
-const List<T1>& es){auto _cs = es.find([=](const T1&
-x) mutable {
-return eqb_node(elem,
-x);
-});
-if (_cs.has_value()) { T1 _x = *_cs; return true; } else { return false; }}
-template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static T1 cycle_entry_aux(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0, List<T1> seens, T1 elem,
-unsigned int counter){if (contains<T1>(eqb_node, elem,
-seens)) { return elem; } else { if (counter <= 0) { return elem; } else { unsigned int c = counter - 1; List<T1> l = graph_lookup<T1>(eqb_node,
-elem,
-graph0);
-if (bsl::holds_alternative<typename List<T1>::Nil>(l.v_mut())) {
-return elem;
-} else {
-auto& [d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v_mut());
-return cycle_entry_aux<T1>(eqb_node, graph0,
-List<T1>::cons(elem, bsl::move(seens)), bsl::move(d_a0), c);
-} } }}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::optional<T1> cycle_entry(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0){if (bsl::holds_alternative<typename List<bsl::pair<T1, List<T1>>>::Nil>(graph0.v())) {
-return bsl::optional<T1>();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, List<T1>>>::Cons>(graph0.v());
-auto [e, _x0] = d_a0; return bsl::make_optional<T1>(cycle_entry_aux<T1>(eqb_node,
-graph0, List<T1>::nil(), e, graph0.length()));
-}}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<T1> cycle_extract_aux(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0, unsigned int counter, T1 elem,
-List<T1> cycl){if (counter <= 0) { return cycl; } else { unsigned int c = counter - 1; if (contains<T1>(eqb_node,
-elem, cycl)) { return cycl; } else { return graph_lookup<T1>(eqb_node, elem,
-graph0).template fold_right<List<T1>>([=](T1 _x0, List<T1>
-_x1) mutable -> List<T1> {
-return cycle_extract_aux<T1>(eqb_node, graph0, c, _x0, _x1);
-}, List<T1>::cons(elem, bsl::move(cycl))); } }}template <typename T1,
-typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<T1> cycle_extract(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0){auto _cs = cycle_entry<T1>(eqb_node,
-graph0);
-if (_cs.has_value()) { T1 elem = *_cs; return cycle_extract_aux<T1>(eqb_node,
-graph0, graph0.length(), elem,
-List<T1>::nil()); } else { return List<T1>::nil(); }}template <typename
-T1>static bool null(const List<T1>& xs){if (bsl::holds_alternative<typename List<T1>::Nil>(xs.v())) {
-return true;
-} else {
-return false;
-}}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static order<T1> topological_sort_aux(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0,
-unsigned int counter){if (counter <= 0) { return List<List<T1>>::nil(); } else { unsigned int c = counter - 1; if (null<entry<T1>>(graph0)) { return List<List<T1>>::nil(); } else { List<T1> mins = graph0.filter([](const bsl::pair<T1, List<T1>>&
-p) {
-return null<T1>(p.second);
-}).template map<T1>([](bsl::pair<T1, List<T1>>
-_x0) -> T1 {
-return _x0.first;
-});
-List<T1> mins_;
-if (null<T1>(mins)) { mins_ = cycle_extract<T1>(eqb_node,
-graph0); } else { mins_ = mins; }
-List<bsl::pair<T1, List<T1>>> rest = graph0.filter([=](const bsl::pair<T1, List<T1>>&
-entry0) mutable {
-return !(contains<T1>(eqb_node, entry0.first,
-mins_));
-});
-List<bsl::pair<T1, List<T1>>> rest_ = bsl::move(rest).template map<bsl::pair<T1, List<T1>>>([=](const bsl::pair<T1, List<T1>>&
-entry0) mutable {
-return bsl::make_pair(entry0.first, entry0.second.filter([=](const T1&
-e) mutable {
-return !(contains<T1>(eqb_node, e,
-mins_));
-}));
-});
-return List<List<T1>>::cons(bsl::move(mins_), topological_sort_aux<T1>(eqb_node,
-bsl::move(rest_), c)); } }}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<List<T1>> topological_sort(F0&& eqb_node,
-const List<bsl::pair<T1, T1>>& g){List<bsl::pair<T1, List<T1>>> g_ = make_graph<T1>(eqb_node,
-g);
-return topological_sort_aux<T1>(eqb_node, g_, g_.length());}
-template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static order<T1> topological_sort_graph(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0){return topological_sort_aux<T1>(eqb_node,
-graph0, graph0.length());}template <typename T1, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<bsl::pair<T1, unsigned int>> topological_rank_list(F0&& eqb_node,
-const List<bsl::pair<T1, List<T1>>>& graph0){List<List<T1>> lorder = topological_sort_graph<T1>(eqb_node,
-graph0);
-return lorder.template combine<unsigned int>(ListDef::seq(0u,
-lorder.length())).template map<List<bsl::pair<T1, unsigned int>>>([](bsl::pair<List<T1>, unsigned int>
-x) {
-auto [fs, rk] = x; return fs.template map<bsl::pair<T1, unsigned int>>([=](T1
-f) mutable {
-return bsl::make_pair(f, rk);
-});
-}).template concat<bsl::pair<T1, unsigned int>>();}
+struct ToString {
+  template <typename T1, typename T2, typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &> &&
+             bsl::is_invocable_r_v<bsl::string, F1 &, T2 &>
+  static bsl::string pair_to_string(F0 &&p1, F1 &&p2,
+                                    const bsl::pair<T1, T2> &x) {
+    auto [a, b] = x;
+    return "("_s + p1(a) + ", "_s + p2(b) + ")"_s;
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
+  static bsl::string intersperse(F0 &&p, bsl::string sep, const List<T1> &l) {
+    if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
+      return "";
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
+      auto &&_sv = *d_a1;
+      if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
+        return sep + p(d_a0);
+      } else {
+        return sep + p(d_a0) + intersperse<T1>(p, sep, *d_a1);
+      }
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bsl::string, F0 &, T1 &>
+  static bsl::string list_to_string(F0 &&p, const List<T1> &l) {
+    if (bsl::holds_alternative<typename List<T1>::Nil>(l.v())) {
+      return "[]";
+    } else {
+      const auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v());
+      auto &&_sv = *d_a1;
+      if (bsl::holds_alternative<typename List<T1>::Nil>(_sv.v())) {
+        return "["_s + p(d_a0) + "]"_s;
+      } else {
+        return "["_s + p(d_a0) + intersperse<T1>(p, "; ", *d_a1) + "]"_s;
+      }
+    }
+  }
+};
+struct TopologicalSort {
+  template <typename node> using entry = bsl::pair<node, List<node>>;
+  template <typename node> using graph = List<entry<node>>;
+  template <typename node> using order = List<List<node>>;
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<T1> get_elems(F0 &&eqb_node, const List<bsl::pair<T1, T1>> &l) {
+    auto get_elems_aux_impl = [&](auto &_self_get_elems_aux,
+                                  const List<bsl::pair<T1, T1>> &l0,
+                                  List<T1> h) -> List<T1> {
+      if (bsl::holds_alternative<typename List<bsl::pair<T1, T1>>::Nil>(
+              l0.v())) {
+        return h;
+      } else {
+        const auto &[d_a0, d_a1] =
+            bsl::get<typename List<bsl::pair<T1, T1>>::Cons>(l0.v());
+        const List<bsl::pair<T1, T1>> &d_a1_value = *d_a1;
+        auto [e1, e2] = d_a0;
+        bsl::optional<T1> f1 =
+            h.find([=](const T1 &x) mutable { return eqb_node(e1, x); });
+        bsl::optional<T1> f2 =
+            h.find([=](const T1 &x) mutable { return eqb_node(e2, x); });
+        if (f1.has_value()) {
+          T1 _x = *f1;
+          if (f2.has_value()) {
+            T1 _x0 = *f2;
+            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
+                                       bsl::move(h));
+          } else {
+            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
+                                       List<T1>::cons(e2, bsl::move(h)));
+          }
+        } else {
+          if (f2.has_value()) {
+            T1 _x = *f2;
+            return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
+                                       List<T1>::cons(e1, bsl::move(h)));
+          } else {
+            if (eqb_node(e1, e2)) {
+              return _self_get_elems_aux(_self_get_elems_aux, d_a1_value,
+                                         List<T1>::cons(e1, bsl::move(h)));
+            } else {
+              return _self_get_elems_aux(
+                  _self_get_elems_aux, d_a1_value,
+                  List<T1>::cons(e1, List<T1>::cons(e2, bsl::move(h))));
+            }
+          }
+        }
+      }
+    };
+    auto get_elems_aux = [&](const List<bsl::pair<T1, T1>> &l0,
+                             List<T1> h) -> List<T1> {
+      return get_elems_aux_impl(get_elems_aux_impl, l0, h);
+    };
+    return get_elems_aux(l, List<T1>::nil());
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static entry<T1> make_entry(F0 &&eqb_node, const List<bsl::pair<T1, T1>> &l,
+                              T1 e) {
+    return bsl::make_pair(
+        e, l.template fold_right<List<T1>>(
+               [=](const bsl::pair<T1, T1> &x, List<T1> ret) mutable {
+                 if (eqb_node(e, x.first)) {
+                   return List<T1>::cons(x.second, ret);
+                 } else {
+                   return ret;
+                 }
+               },
+               List<T1>::nil()));
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static graph<T1> make_graph(F0 &&eqb_node, List<bsl::pair<T1, T1>> l) {
+    List<T1> elems = get_elems<T1>(eqb_node, l);
+    return bsl::move(elems).template fold_right<List<entry<T1>>>(
+        [=](const T1 &e, List<bsl::pair<T1, List<T1>>> ret) mutable {
+          return List<bsl::pair<T1, List<T1>>>::cons(
+              make_entry<T1>(eqb_node, l, e), ret);
+        },
+        List<bsl::pair<T1, List<T1>>>::nil());
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<T1> graph_lookup(F0 &&eqb_node, const T1 &elem,
+                               const List<bsl::pair<T1, List<T1>>> &graph0) {
+    auto _cs = graph0.find([=](const bsl::pair<T1, List<T1>> &entry0) mutable {
+      return eqb_node(elem, entry0.first);
+    });
+    if (_cs.has_value()) {
+      bsl::pair<T1, List<T1>> p = *_cs;
+      auto [_x, es] = p;
+      return es;
+    } else {
+      return List<T1>::nil();
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bool contains(F0 &&eqb_node, const T1 &elem, const List<T1> &es) {
+    auto _cs = es.find([=](const T1 &x) mutable { return eqb_node(elem, x); });
+    if (_cs.has_value()) {
+      T1 _x = *_cs;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static T1 cycle_entry_aux(F0 &&eqb_node,
+                            const List<bsl::pair<T1, List<T1>>> &graph0,
+                            List<T1> seens, T1 elem, unsigned int counter) {
+    if (contains<T1>(eqb_node, elem, seens)) {
+      return elem;
+    } else {
+      if (counter <= 0) {
+        return elem;
+      } else {
+        unsigned int c = counter - 1;
+        List<T1> l = graph_lookup<T1>(eqb_node, elem, graph0);
+        if (bsl::holds_alternative<typename List<T1>::Nil>(l.v_mut())) {
+          return elem;
+        } else {
+          auto &[d_a0, d_a1] = bsl::get<typename List<T1>::Cons>(l.v_mut());
+          return cycle_entry_aux<T1>(eqb_node, graph0,
+                                     List<T1>::cons(elem, bsl::move(seens)),
+                                     bsl::move(d_a0), c);
+        }
+      }
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::optional<T1>
+  cycle_entry(F0 &&eqb_node, const List<bsl::pair<T1, List<T1>>> &graph0) {
+    if (bsl::holds_alternative<typename List<bsl::pair<T1, List<T1>>>::Nil>(
+            graph0.v())) {
+      return bsl::optional<T1>();
+    } else {
+      const auto &[d_a0, d_a1] =
+          bsl::get<typename List<bsl::pair<T1, List<T1>>>::Cons>(graph0.v());
+      auto [e, _x0] = d_a0;
+      return bsl::make_optional<T1>(cycle_entry_aux<T1>(
+          eqb_node, graph0, List<T1>::nil(), e, graph0.length()));
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<T1>
+  cycle_extract_aux(F0 &&eqb_node, const List<bsl::pair<T1, List<T1>>> &graph0,
+                    unsigned int counter, T1 elem, List<T1> cycl) {
+    if (counter <= 0) {
+      return cycl;
+    } else {
+      unsigned int c = counter - 1;
+      if (contains<T1>(eqb_node, elem, cycl)) {
+        return cycl;
+      } else {
+        return graph_lookup<T1>(eqb_node, elem, graph0)
+            .template fold_right<List<T1>>(
+                [=](T1 _x0, List<T1> _x1) mutable -> List<T1> {
+                  return cycle_extract_aux<T1>(eqb_node, graph0, c, _x0, _x1);
+                },
+                List<T1>::cons(elem, bsl::move(cycl)));
+      }
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<T1> cycle_extract(F0 &&eqb_node,
+                                const List<bsl::pair<T1, List<T1>>> &graph0) {
+    auto _cs = cycle_entry<T1>(eqb_node, graph0);
+    if (_cs.has_value()) {
+      T1 elem = *_cs;
+      return cycle_extract_aux<T1>(eqb_node, graph0, graph0.length(), elem,
+                                   List<T1>::nil());
+    } else {
+      return List<T1>::nil();
+    }
+  }
+  template <typename T1> static bool null(const List<T1> &xs) {
+    if (bsl::holds_alternative<typename List<T1>::Nil>(xs.v())) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static order<T1>
+  topological_sort_aux(F0 &&eqb_node,
+                       const List<bsl::pair<T1, List<T1>>> &graph0,
+                       unsigned int counter) {
+    if (counter <= 0) {
+      return List<List<T1>>::nil();
+    } else {
+      unsigned int c = counter - 1;
+      if (null<entry<T1>>(graph0)) {
+        return List<List<T1>>::nil();
+      } else {
+        List<T1> mins =
+            graph0
+                .filter([](const bsl::pair<T1, List<T1>> &p) {
+                  return null<T1>(p.second);
+                })
+                .template map<T1>([](bsl::pair<T1, List<T1>> _x0) -> T1 {
+                  return _x0.first;
+                });
+        List<T1> mins_;
+        if (null<T1>(mins)) {
+          mins_ = cycle_extract<T1>(eqb_node, graph0);
+        } else {
+          mins_ = mins;
+        }
+        List<bsl::pair<T1, List<T1>>> rest =
+            graph0.filter([=](const bsl::pair<T1, List<T1>> &entry0) mutable {
+              return !(contains<T1>(eqb_node, entry0.first, mins_));
+            });
+        List<bsl::pair<T1, List<T1>>> rest_ =
+            bsl::move(rest).template map<bsl::pair<T1, List<T1>>>(
+                [=](const bsl::pair<T1, List<T1>> &entry0) mutable {
+                  return bsl::make_pair(
+                      entry0.first,
+                      entry0.second.filter([=](const T1 &e) mutable {
+                        return !(contains<T1>(eqb_node, e, mins_));
+                      }));
+                });
+        return List<List<T1>>::cons(
+            bsl::move(mins_),
+            topological_sort_aux<T1>(eqb_node, bsl::move(rest_), c));
+      }
+    }
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<List<T1>> topological_sort(F0 &&eqb_node,
+                                         const List<bsl::pair<T1, T1>> &g) {
+    List<bsl::pair<T1, List<T1>>> g_ = make_graph<T1>(eqb_node, g);
+    return topological_sort_aux<T1>(eqb_node, g_, g_.length());
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static order<T1>
+  topological_sort_graph(F0 &&eqb_node,
+                         const List<bsl::pair<T1, List<T1>>> &graph0) {
+    return topological_sort_aux<T1>(eqb_node, graph0, graph0.length());
+  }
+  template <typename T1, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<bsl::pair<T1, unsigned int>>
+  topological_rank_list(F0 &&eqb_node,
+                        const List<bsl::pair<T1, List<T1>>> &graph0) {
+    List<List<T1>> lorder = topological_sort_graph<T1>(eqb_node, graph0);
+    return lorder
+        .template combine<unsigned int>(ListDef::seq(0u, lorder.length()))
+        .template map<List<bsl::pair<T1, unsigned int>>>(
+            [](bsl::pair<List<T1>, unsigned int> x) {
+              auto [fs, rk] = x;
+              return fs.template map<bsl::pair<T1, unsigned int>>(
+                  [=](T1 f) mutable { return bsl::make_pair(f, rk); });
+            })
+        .template concat<bsl::pair<T1, unsigned int>>();
+  }
 };
 
 #endif // INCLUDED_TOPOLOGICAL_SORT_BDE

--- a/tests/basics/typeclasses/typeclasses.h
+++ b/tests/basics/typeclasses/typeclasses.h
@@ -135,7 +135,9 @@ struct Typeclasses {
 
   static_assert(Numeric<numBool, bool>);
 
-  template <typename _tcI0, typename T1> struct numOption {
+  template <typename _tcI0, typename T1>
+    requires Numeric<_tcI0, T1>
+  struct numOption {
     static uint64_t to_nat(std::optional<T1> o) {
       if (o.has_value()) {
         const T1 &x = *o;
@@ -146,7 +148,9 @@ struct Typeclasses {
     }
   };
 
-  template <typename _tcI0, typename T1> struct numList {
+  template <typename _tcI0, typename T1>
+    requires Numeric<_tcI0, T1>
+  struct numList {
     static uint64_t to_nat(List<T1> a0) {
       auto sum_impl = [&](auto &_self_sum, const List<T1> &l) -> uint64_t {
         if (std::holds_alternative<typename List<T1>::Nil>(l.v())) {
@@ -164,11 +168,13 @@ struct Typeclasses {
   };
 
   template <typename _tcI0, typename T1>
+    requires Numeric<_tcI0, T1>
   static uint64_t numeric_sum(const List<T1> &l) {
     return numList<_tcI0, T1>::to_nat(l);
   }
 
   template <typename _tcI0, typename T1>
+    requires Numeric<_tcI0, T1>
   static uint64_t numeric_double(const T1 &x) {
     return (_tcI0::to_nat(x) + _tcI0::to_nat(x));
   }
@@ -186,6 +192,7 @@ struct Typeclasses {
   static_assert(Ord<ordNat, uint64_t>);
 
   template <typename _tcI0, typename _tcI1, typename T1>
+    requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
   static std::pair<T1, T1> sort_pair(T1 x, T1 y) {
     if (_tcI0::leb(x, y)) {
       return std::make_pair(x, y);
@@ -195,6 +202,7 @@ struct Typeclasses {
   }
 
   template <typename _tcI0, typename _tcI1, typename T1>
+    requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
   static T1 min_of(T1 x, T1 y) {
     if (_tcI0::leb(x, y)) {
       return x;
@@ -204,6 +212,7 @@ struct Typeclasses {
   }
 
   template <typename _tcI0, typename _tcI1, typename T1>
+    requires Ord<_tcI0, T1> && Eq<_tcI1, T1>
   static T1 max_of(T1 x, T1 y) {
     if (_tcI0::leb(x, y)) {
       return y;
@@ -213,6 +222,7 @@ struct Typeclasses {
   }
 
   template <typename _tcI0, typename _tcI1, typename T1>
+    requires Eq<_tcI0, T1> && Numeric<_tcI1, T1>
   static uint64_t describe(const T1 &x, const T1 &y) {
     if (_tcI0::eqb(x, y)) {
       return _tcI1::to_nat(x);

--- a/tests/basics/z_int/z_int.cpp
+++ b/tests/basics/z_int/z_int.cpp
@@ -1,14 +1,27 @@
 #include "z_int.h"
 
-int64_t ZIntTest::add_test(int64_t _x0, int64_t _x1) { return (_x0 + _x1); }
+int64_t ZIntTest::add_test(int64_t _x0, int64_t _x1) {
+  return static_cast<int64_t>(static_cast<uint64_t>(_x0) +
+                              static_cast<uint64_t>(_x1));
+}
 
-int64_t ZIntTest::mul_test(int64_t _x0, int64_t _x1) { return (_x0 * _x1); }
+int64_t ZIntTest::mul_test(int64_t _x0, int64_t _x1) {
+  return static_cast<int64_t>(static_cast<uint64_t>(_x0) *
+                              static_cast<uint64_t>(_x1));
+}
 
-int64_t ZIntTest::sub_test(int64_t _x0, int64_t _x1) { return (_x0 - _x1); }
+int64_t ZIntTest::sub_test(int64_t _x0, int64_t _x1) {
+  return static_cast<int64_t>(static_cast<uint64_t>(_x0) -
+                              static_cast<uint64_t>(_x1));
+}
 
-int64_t ZIntTest::abs_test(int64_t _x0) { return std::abs(_x0); }
+int64_t ZIntTest::abs_test(int64_t _x0) {
+  return (_x0 < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(_x0)) : _x0);
+}
 
-int64_t ZIntTest::opp_test(int64_t _x0) { return (-_x0); }
+int64_t ZIntTest::opp_test(int64_t _x0) {
+  return static_cast<int64_t>(-static_cast<uint64_t>(_x0));
+}
 
 bool ZIntTest::eqb_test(int64_t _x0, int64_t _x1) { return _x0 == _x1; }
 

--- a/tests/basics/z_int/z_int.h
+++ b/tests/basics/z_int/z_int.h
@@ -2,7 +2,6 @@
 #define INCLUDED_Z_INT
 
 #include <cstdint>
-#include <cstdlib>
 
 struct ZIntTest {
   static int64_t add_test(int64_t _x0, int64_t _x1);

--- a/tests/monadic/itree_reified/itree_reified.h
+++ b/tests/monadic/itree_reified/itree_reified.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDED_ITREE_REIFIED
 #define INCLUDED_ITREE_REIFIED
 
-#include <any>
 #include <crane_itree.h>
 #include <memory>
 #include <string>
@@ -32,29 +31,30 @@ struct ITreeReified {
     } else if (std::holds_alternative<typename ITree<T2>::Tau>(ot)) {
       const auto &_itf = *std::get_if<typename ITree<T2>::Tau>(&ot);
       auto t_ = _itf.next;
-      return itree_vis(std::any([&]() -> std::any {
-                         std::cout << "[tau]"s << '\n';
-                         return std::any{};
-                       }),
-                       [=](const auto &) mutable {
-                         return [&]() {
-                           auto t = rec(t_);
-                           return ITree<decltype(t->run())>::tau(t);
-                         }();
-                       });
+      return itree_vis(
+          [&]() -> std::any {
+            std::cout << "[tau]"s << '\n';
+            return std::any{};
+          },
+          [=](const auto &) mutable {
+            return [&]() {
+              auto t = rec(t_);
+              return ITree<decltype(t->run())>::tau(t);
+            }();
+          });
     } else {
       const auto &_itf = *std::get_if<typename ITree<T2>::Vis>(&ot);
       auto e = _itf.effect;
       auto k = _itf.cont;
-      return itree_vis(std::any([&]() -> std::any {
-                         std::cout << "[vis]"s << '\n';
-                         return std::any{};
-                       }),
-                       [=](const auto &) mutable {
-                         return itree_vis(
-                             std::any(e),
+      return itree_vis(
+          [&]() -> std::any {
+            std::cout << "[vis]"s << '\n';
+            return std::any{};
+          },
+          [=](const auto &) mutable {
+            return itree_vis(e,
                              [=](const auto &x) mutable { return rec(k(x)); });
-                       });
+          });
     }
   }
 

--- a/tests/monadic/mutable_vector/mutable_vector.cpp
+++ b/tests/monadic/mutable_vector/mutable_vector.cpp
@@ -8,7 +8,9 @@ int64_t MutableVectorTest::test1(int64_t) {
   int64_t x = v.size();
   v.pop_back();
   int64_t y = v.size();
-  return ((x - y) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(x) - static_cast<uint64_t>(y)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 std::vector<int64_t> MutableVectorTest::test2(int64_t) {

--- a/tests/monadic/skiplist_bde/skiplist_bde.cpp
+++ b/tests/monadic/skiplist_bde/skiplist_bde.cpp
@@ -1,27 +1,21 @@
 #include "skiplist_bde.h"
 
 #include <bdlf_overloaded.h>
+#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <bsl_optional.h>
-#include <bsl_iostream.h>
-#include <bdls_filesystemutil.h>
-#include <stm_adapter.h>
-#include <bsl_utility.h>
-#include <bsl_memory.h>
-#include <skipnode.h>
-#include <variant>
 #include <fstream>
+#include <skipnode.h>
+#include <stm_adapter.h>
+#include <variant>
 
-
-namespace BloombergLP {
-
-}
-
+namespace BloombergLP {}

--- a/tests/monadic/skiplist_bde/skiplist_bde.h
+++ b/tests/monadic/skiplist_bde/skiplist_bde.h
@@ -2,26 +2,23 @@
 #define INCLUDED_SKIPLIST_BDE
 
 #include <bdlf_overloaded.h>
+#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <utility>
-#include <bsl_optional.h>
-#include <bsl_iostream.h>
-#include <bdls_filesystemutil.h>
-#include <stm_adapter.h>
-#include <bsl_utility.h>
-#include <bsl_memory.h>
-#include <skipnode.h>
-#include <variant>
 #include <fstream>
-
+#include <skipnode.h>
+#include <stm_adapter.h>
+#include <utility>
+#include <variant>
 
 using namespace BloombergLP;
 template <class From, class To>
@@ -30,580 +27,1052 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-
-template<typename K, typename V>
-struct SkipList {
-bsl::shared_ptr<SkipNode<K, V>> slHead;
-unsigned int slMaxLevel;
-stm::TVar<unsigned int> slLevel;
-stm::TVar<unsigned int> slLength;
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-SkipPath<K, V> findPath(F0&& ltK,
-const K& target) const {
-unsigned int lvl = stm::readTVar(this->slLevel);
-SkipPath<K, V> path = SkipPath<K, V>{};
-return SkipList<int, int>::template findPath_aux<K, V>(ltK, this->slHead,
-target, lvl, bsl::move(path));}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::optional<V> lookup(F0&& ltK, F1&& eqK,
-const K& k) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-k)) { V v = stm::readTVar<V>(node->value);
-return bsl::make_optional<V>(v); } else { return bsl::optional<V>(); } } else { return bsl::optional<V>(); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-std::monostate insert(F0&& ltK, F1&& eqK, const K& k, const V& v,
-unsigned int newLevel) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(newLevel + 1),
-curLvl);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
-k)) { stm::writeTVar<V>(existing->value, v);
-return std::monostate{}; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return std::monostate{}; } else { return std::monostate{}; } } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return std::monostate{}; } else { return std::monostate{}; } }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-std::monostate remove(F0&& ltK, F1&& eqK,
-const K& k) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-k)) { unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(node->level + 1), curLvl);
-SkipList<int, int>::template unlinkNode<K, V>(bsl::move(path),
-node);
-return std::monostate{}; } else { return std::monostate{}; } } else { return std::monostate{}; }}
-bsl::optional<bsl::pair<K, V>> minimum() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; V v = stm::readTVar<V>(node->value);
-return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v)); } else { return bsl::optional<bsl::pair<K, V>>(); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool memberFast(F0&& ltK, F1&& eqK,
-const K& k) const {
-unsigned int lvl = stm::readTVar(this->slLevel);
-return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
-k, lvl);}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool member(F0&& ltK, F1&& eqK,
-const K& k) const {
-unsigned int lvl = stm::readTVar(this->slLevel);
-return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
-k,
-lvl);}
-bool isEmpty() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-return [=]() mutable -> bool {
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> _x = *firstOpt; return false; } else { return true; }
-}();}
-unsigned int length() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-return SkipList<int, int>::template length_aux<K, V>(10000u,
-bsl::move(firstOpt), 0u);}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool exists_(F0&& ltK, F1&& eqK,
-const K& k) const {
-unsigned int lvl = stm::readTVar(this->slLevel);
-return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
-k,
-lvl);}
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> front() const {
-return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));}
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> back() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt; return SkipList<int, int>::template findLast_aux<K,
-V>(10000u,
-first); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
-bsl::optional<bsl::pair<K, V>> popFront() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; SkipList<int, int>::template unlinkFirstFromHead<K,
-V>(this->slHead, node,
-node->level);
-V v = stm::readTVar<V>(node->value);
-return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v)); } else { return bsl::optional<bsl::pair<K, V>>(); }}
-unsigned int removeAll() const {
-unsigned int count = SkipList<int, int>::template removeAll_aux<K, V>(10000u,
-this->slHead,
-0u);
-stm::writeTVar(this->slLevel, 0u);
-return count;}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-std::monostate add(F0&& ltK, F1&& eqK, const K& k, const V& v,
-unsigned int newLevel) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(newLevel + 1),
-curLvl);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
-k)) { stm::writeTVar<V>(existing->value, v);
-return std::monostate{}; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return std::monostate{}; } else { return std::monostate{}; } } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return std::monostate{}; } else { return std::monostate{}; } }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool addUnique(F0&& ltK, F1&& eqK, const K& k, const V& v,
-unsigned int newLevel) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(newLevel + 1),
-curLvl);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
-k)) { return false; } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return; } else { return; }
-}();
-return true; } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(k, v, newLevel);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < newLevel) { stm::writeTVar(this->slLevel, newLevel);
-return; } else { return; }
-}();
-return true; }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> find(F0&& ltK, F1&& eqK,
-const K& k) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-k)) { return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> previous(F0&& eqK,
-bsl::shared_ptr<SkipNode<K, V>> pair) const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt; if (eqK(first->key,
-pair->key)) { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); } else { return SkipList<int, int>::template findPrev_aux<K,
-V>(eqK, 10000u, first, this->slHead,
-pair->key); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> findLowerBound(F0&& ltK,
-const K& k) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> findUpperBound(F0&& ltK,
-F1&& eqK, const K& k) const {
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-k)) { return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(node->forward[0u])); } else { return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>(); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool removePair(F0&& ltK, F1&& eqK,
-bsl::shared_ptr<SkipNode<K, V>> pair) const {
-K k = pair->key;
-SkipPath<K, V> path = this->findPath(ltK,
-k);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-k)) { SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(node->level + 1), curLvl);
-SkipList<int, int>::template unlinkNode<K, V>(path,
-node);
-return true; } else { return false; } } else { return false; }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::pair<bsl::shared_ptr<SkipNode<K, V>>, bool> bde_add(F0&& ltK, F1&& eqK,
-const K& key0, const V& data0,
-unsigned int level) const {
-SkipPath<K, V> path = this->findPath(ltK,
-key0);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(level + 1),
-curLvl);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-bool isNewFront;
-if (curFront.has_value()) { bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront; isNewFront = ltK(key0,
-frontNode->key); } else { isNewFront = true; }
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
-key0)) { stm::writeTVar<V>(existing->value, data0);
-return bsl::make_pair(existing, false); } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < level) { stm::writeTVar(this->slLevel, level);
-return; } else { return; }
-}();
-return bsl::make_pair(newN, isNewFront); } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < level) { stm::writeTVar(this->slLevel, level);
-return; } else { return; }
-}();
-return bsl::make_pair(newN, isNewFront); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::pair<bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>, bool> bde_addUnique(F0&& ltK,
-F1&& eqK, const K& key0, const V& data0,
-unsigned int level) const {
-SkipPath<K, V> path = this->findPath(ltK,
-key0);
-unsigned int curLvl = stm::readTVar(this->slLevel);
-SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
-(level + 1),
-curLvl);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-bool isNewFront;
-if (curFront.has_value()) { bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront; isNewFront = ltK(key0,
-frontNode->key); } else { isNewFront = true; }
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt; if (eqK(existing->key,
-key0)) { return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_DUPLICATE, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()), false); } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < level) { stm::writeTVar(this->slLevel, level);
-return; } else { return; }
-}();
-return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)), isNewFront); } } else { bsl::shared_ptr<SkipNode<K, V>> newN = SkipNode<K, V>::create(key0, data0, level);
-SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
-newN);
-[&]() -> void {
-if (curLvl < level) { stm::writeTVar(this->slLevel, level);
-return; } else { return; }
-}();
-return bsl::make_pair(bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)), isNewFront); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_find(F0&& ltK,
-F1&& eqK, const K& key0) const {
-SkipPath<K, V> path = this->findPath(ltK,
-key0);
-bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt; if (eqK(node->key,
-key0)) { return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); } } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_front() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> frontOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (frontOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *frontOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_back() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> backOpt = this->back();
-if (backOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *backOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_popFront() const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(this->slHead->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt; SkipList<int, int>::template unlinkFirstFromHead<K,
-V>(this->slHead, node,
-node->level);
-return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-unsigned int bde_remove(F0&& ltK, F1&& eqK,
-bsl::shared_ptr<SkipNode<K, V>> pair) const {
-bool result = this->removePair(ltK, eqK,
-pair);
-if (result) { return SkipList<int, int>::e_SUCCESS; } else { return SkipList<int, int>::e_NOT_FOUND; }}
-unsigned int bde_removeAll() const {
-return this->removeAll();}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bool bde_exists(F0&& ltK, F1&& eqK,
-const K& key0) const {
-unsigned int lvl = stm::readTVar(this->slLevel);
-return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK, this->slHead,
-key0,
-lvl);}
-bool bde_isEmpty() const {
-return this->isEmpty();}
-unsigned int bde_length() const {
-return this->length();}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_previous(F0&& eqK,
-bsl::shared_ptr<SkipNode<K, V>> pair) const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> prevOpt = this->previous(eqK,
-pair);
-if (prevOpt.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *prevOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-template <typename
-F0>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_findLowerBound(F0&& ltK,
-const K& key0) const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result = this->findLowerBound(ltK,
-key0);
-if (result.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *result; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-template <typename F0, typename
-F1>
-  requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
-      && bsl::is_invocable_r_v<bool, F1 &, K &, K &>
-bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>> bde_findUpperBound(F0&& ltK,
-F1&& eqK,
-const K& key0) const {
-bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result = this->findUpperBound(ltK,
-eqK,
-key0);
-if (result.has_value()) { bsl::shared_ptr<SkipNode<K, V>> node = *result; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()); }}
-template <typename T1, typename T2, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::shared_ptr<SkipNode<T1, T2>> findPred_go(F0&& ltK,
-unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
-unsigned int level){bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-unsigned int _loop_fuel = bsl::move(fuel);
-while (true) {
-if (_loop_fuel <= 0) { return _loop_curr; } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[level]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; if (ltK(next0->key,
-target)) { _loop_curr = next0;
-_loop_fuel = fuel_; } else { return _loop_curr; } } else { return _loop_curr; } }
-}}template <typename T1, typename T2, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::shared_ptr<SkipNode<T1, T2>> findPred(F0&& ltK,
-bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
-unsigned int level){return SkipList<int, int>::template findPred_go<T1,
-T2>(ltK, 10000u, curr, target, level);}template <typename T1, typename T2,
-typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static SkipPath<T1, T2> findPath_aux(F0&& ltK,
-bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target, unsigned int level,
-SkipPath<T1, T2> path){unsigned int _loop_level = bsl::move(level);
-bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-while (true) {
-bsl::shared_ptr<SkipNode<T1, T2>> pred = SkipList<int, int>::template findPred<T1,
-T2>(ltK, _loop_curr, target,
-_loop_level);
-path.set(_loop_level, pred);
-if (_loop_level <= 0) { return path; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_;
-_loop_curr = bsl::move(pred); }
-}}template <typename T1, typename
-T2>static void linkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
-bsl::shared_ptr<SkipNode<T1, T2>> newNode,
-unsigned int level){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> oldNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level]));
-stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level], opt_to_ptr(bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(newNode)));
-stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(newNode)->forward[level], opt_to_ptr(bsl::move(oldNext)));
-return;}template <typename T1, typename
-T2>static void linkNode_aux(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>>, bsl::shared_ptr<SkipNode<T1, T2>> newNode,
-unsigned int level){unsigned int _loop_level = bsl::move(level);
-while (true) {
-bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
-SkipList<int, int>::template linkAtLevel<T1, T2>(pred, newNode,
-_loop_level);
-if (_loop_level <= 0) { return; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_; }
-}
-return;}template <typename T1, typename
-T2>static void extendPath_aux(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>> head, unsigned int level,
-unsigned int maxLevel){unsigned int _loop_level = bsl::move(level);
-while (true) {
-if (_loop_level <= 0) { path.set(0u, head);
-return; } else { unsigned int level_ = _loop_level - 1; path.set(_loop_level, head);
-if (maxLevel <= level_) { _loop_level = level_; } else { return; } }
-}
-return;}template <typename T1, typename
-T2>static void extendPath(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>> head, unsigned int needed,
-unsigned int currentMax){if (needed <= (currentMax + 1)) { return; } else { SkipList<int, int>::template extendPath_aux<T1,
-T2>(path, head, (((needed - 1u) > needed ? 0 : (needed - 1u))),
-(currentMax + 1u));
-return; }}template <typename T1, typename
-T2>static void linkNode(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>> head,
-bsl::shared_ptr<SkipNode<T1, T2>> newNode){unsigned int lvl = newNode->level;
-SkipList<int, int>::template linkNode_aux<T1, T2>(path, head, newNode,
-lvl);
-return;}template <typename T1, typename
-T2>static void unlinkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
-bsl::shared_ptr<SkipNode<T1, T2>> target,
-unsigned int level){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> targetNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(target->forward[level]));
-stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level], opt_to_ptr(bsl::move(targetNext)));
-return;}template <typename T1, typename
-T2>static void unlinkNode_aux(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>> target,
-unsigned int level){unsigned int _loop_level = bsl::move(level);
-while (true) {
-bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
-SkipList<int, int>::template unlinkAtLevel<T1, T2>(pred, target,
-_loop_level);
-if (_loop_level <= 0) { return; } else { unsigned int level_ = _loop_level - 1; _loop_level = level_; }
-}
-return;}template <typename T1, typename
-T2>static void unlinkNode(SkipPath<T1, T2> path,
-bsl::shared_ptr<SkipNode<T1, T2>> target){unsigned int lvl = target->level;
-SkipList<int, int>::template unlinkNode_aux<T1, T2>(path, target,
-lvl);
-return;}template <typename T1, typename T2, typename F0, typename
-F1>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-      && bsl::is_invocable_r_v<bool, F1 &, T1 &, T1 &>
-static bool findKey_aux(F0&& ltK, F1&& eqK,
-bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1& target,
-unsigned int level){unsigned int _loop_level = bsl::move(level);
-bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-while (true) {
-bsl::shared_ptr<SkipNode<T1, T2>> pred = SkipList<int, int>::template findPred<T1,
-T2>(ltK, _loop_curr, target,
-_loop_level);
-if (_loop_level <= 0) { bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(pred)->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt; return eqK(node->key,
-target); } else { return false; } } else { unsigned int level_ = _loop_level - 1; _loop_level = level_;
-_loop_curr = bsl::move(pred); }
-}}template <typename T1, typename
-T2>static unsigned int length_aux(unsigned int fuel,
-const bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>& node,
-unsigned int acc){unsigned int _loop_acc = bsl::move(acc);
-bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> _loop_node = node;
-unsigned int _loop_fuel = bsl::move(fuel);
-while (true) {
-if (_loop_fuel <= 0) { return _loop_acc; } else { unsigned int fuel_ = _loop_fuel - 1; if (_loop_node.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> n = *_loop_node; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(n->forward[0u]));
-_loop_acc = (_loop_acc + 1);
-_loop_node = bsl::move(nextOpt);
-_loop_fuel = fuel_; } else { return _loop_acc; } }
-}}template <typename T1, typename
-T2>static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> findLast_aux(unsigned int fuel,
-bsl::shared_ptr<SkipNode<T1, T2>> curr){bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-unsigned int _loop_fuel = bsl::move(fuel);
-while (true) {
-if (_loop_fuel <= 0) { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr); } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; _loop_curr = next0;
-_loop_fuel = fuel_; } else { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(_loop_curr)); } }
-}}template <typename T1, typename
-T2>static void unlinkFirstFromHead(bsl::shared_ptr<SkipNode<T1, T2>> head,
-bsl::shared_ptr<SkipNode<T1, T2>> node,
-unsigned int lvl){unsigned int _loop_lvl = bsl::move(lvl);
-while (true) {
-bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(node->forward[_loop_lvl]));
-stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[_loop_lvl], opt_to_ptr(nodeNext));
-if (_loop_lvl <= 0) { return; } else { unsigned int lvl_ = _loop_lvl - 1; _loop_lvl = lvl_; }
-}
-return;}template <typename T1, typename
-T2>static void unlinkNodeAtAllLevels(bsl::shared_ptr<SkipNode<T1, T2>> head,
-bsl::shared_ptr<SkipNode<T1, T2>> node,
-unsigned int lvl){unsigned int _loop_lvl = bsl::move(lvl);
-while (true) {
-bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(node->forward[_loop_lvl]));
-stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[_loop_lvl], opt_to_ptr(nodeNext));
-if (_loop_lvl <= 0) { return; } else { unsigned int lvl_ = _loop_lvl - 1; _loop_lvl = lvl_; }
-}
-return;}template <typename T1, typename
-T2>static unsigned int removeAll_aux(unsigned int fuel,
-bsl::shared_ptr<SkipNode<T1, T2>> head,
-unsigned int acc){if (fuel <= 0) { return acc; } else { unsigned int fuel_ = fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> firstOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(head->forward[0u]));
-if (firstOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *firstOpt; SkipList<int, int>::template unlinkNodeAtAllLevels<T1,
-T2>(head, node,
-node->level);
-return SkipList<int, int>::template removeAll_aux<T1, T2>(fuel_, head,
-(acc + 1)); } else { return acc; } }}template <typename T1, typename
-T2>static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> next(bsl::shared_ptr<SkipNode<T1, T2>> pair){return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pair->forward[0u]));}
-template <typename T1, typename T2, typename F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> findPrev_aux(F0&& eqK,
-unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr,
-bsl::shared_ptr<SkipNode<T1, T2>> _x,
-const T1& target){bsl::shared_ptr<SkipNode<T1, T2>> _loop_x = bsl::move(_x);
-bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
-unsigned int _loop_fuel = bsl::move(fuel);
-while (true) {
-if (_loop_fuel <= 0) { return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>(); } else { unsigned int fuel_ = _loop_fuel - 1; bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(_loop_curr->forward[0u]));
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt; if (eqK(next0->key,
-target)) { return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(bsl::move(_loop_curr)); } else { bsl::shared_ptr<SkipNode<T1, T2>> _next_curr = next0;
-_loop_x = bsl::move(_loop_curr);
-_loop_fuel = fuel_;
-_loop_curr = bsl::move(_next_curr); } } else { return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>(); } }
-}}template <typename T1, typename
-T2>static T1 key(bsl::shared_ptr<SkipNode<T1, T2>> pair){return pair->key;}
-template <typename T1, typename
-T2>static T2 data(bsl::shared_ptr<SkipNode<T1, T2>> pair){return stm::readTVar<T2>(pair->value);}
-static inline const unsigned int e_SUCCESS = 0u;static inline const unsigned int e_NOT_FOUND = 1u;static inline const unsigned int e_DUPLICATE = 2u;static inline const unsigned int e_INVALID = 3u;template <typename T1, typename T2>static bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>> bde_next(bsl::shared_ptr<SkipNode<T1, T2>> pair){bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = SkipList<int, int>::template next<T1, T2>(pair);
-if (nextOpt.has_value()) { bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt; return bsl::make_pair(SkipList<int, int>::e_SUCCESS, bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(node)); } else { return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND, bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>()); }}
-template <typename T1, typename T2>static SkipList<T1, T2> create(const T1& dummyKey, const T2& dummyVal){bsl::shared_ptr<SkipNode<T1, T2>> headNode = SkipNode<T1, T2>::create(dummyKey, dummyVal, (((16u - 1u) > 16u ? 0 : (16u - 1u))));
-stm::TVar<unsigned int> lvlTV = stm::newTVar(0u);
-stm::TVar<unsigned int> lenTV = stm::newTVar(0u);
-return SkipList<T1, T2>{headNode, 16u, lvlTV, lenTV};}template <typename T1,
-typename T2>static SkipList<T1, T2> createIO(const T1& dummyKey,
-const T2& dummyVal){return stm::atomically([&] { return SkipList<int, int>::template create<T1,
-T2>(dummyKey,
-dummyVal); });}
+template <typename K, typename V> struct SkipList {
+  bsl::shared_ptr<SkipNode<K, V>> slHead;
+  unsigned int slMaxLevel;
+  stm::TVar<unsigned int> slLevel;
+  stm::TVar<unsigned int> slLength;
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+  SkipPath<K, V> findPath(F0 &&ltK, const K &target) const {
+    unsigned int lvl = stm::readTVar(this->slLevel);
+    SkipPath<K, V> path = SkipPath<K, V>{};
+    return SkipList<int, int>::template findPath_aux<K, V>(
+        ltK, this->slHead, target, lvl, bsl::move(path));
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::optional<V> lookup(F0 &&ltK, F1 &&eqK, const K &k) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, k)) {
+        V v = stm::readTVar<V>(node->value);
+        return bsl::make_optional<V>(v);
+      } else {
+        return bsl::optional<V>();
+      }
+    } else {
+      return bsl::optional<V>();
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  std::monostate insert(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
+                        unsigned int newLevel) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+                                                  (newLevel + 1), curLvl);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
+      if (eqK(existing->key, k)) {
+        stm::writeTVar<V>(existing->value, v);
+        return std::monostate{};
+      } else {
+        bsl::shared_ptr<SkipNode<K, V>> newN =
+            SkipNode<K, V>::create(k, v, newLevel);
+        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
+                                                    this->slHead, newN);
+        if (curLvl < newLevel) {
+          stm::writeTVar(this->slLevel, newLevel);
+          return std::monostate{};
+        } else {
+          return std::monostate{};
+        }
+      }
+    } else {
+      bsl::shared_ptr<SkipNode<K, V>> newN =
+          SkipNode<K, V>::create(k, v, newLevel);
+      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+                                                  newN);
+      if (curLvl < newLevel) {
+        stm::writeTVar(this->slLevel, newLevel);
+        return std::monostate{};
+      } else {
+        return std::monostate{};
+      }
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  std::monostate remove(F0 &&ltK, F1 &&eqK, const K &k) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, k)) {
+        unsigned int curLvl = stm::readTVar(this->slLevel);
+        SkipList<int, int>::template extendPath<K, V>(
+            path, this->slHead, (node->level + 1), curLvl);
+        SkipList<int, int>::template unlinkNode<K, V>(bsl::move(path), node);
+        return std::monostate{};
+      } else {
+        return std::monostate{};
+      }
+    } else {
+      return std::monostate{};
+    }
+  }
+  bsl::optional<bsl::pair<K, V>> minimum() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (firstOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
+      V v = stm::readTVar<V>(node->value);
+      return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v));
+    } else {
+      return bsl::optional<bsl::pair<K, V>>();
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool memberFast(F0 &&ltK, F1 &&eqK, const K &k) const {
+    unsigned int lvl = stm::readTVar(this->slLevel);
+    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
+                                                          this->slHead, k, lvl);
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool member(F0 &&ltK, F1 &&eqK, const K &k) const {
+    unsigned int lvl = stm::readTVar(this->slLevel);
+    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
+                                                          this->slHead, k, lvl);
+  }
+  bool isEmpty() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    return [=]() mutable -> bool {
+      if (firstOpt.has_value()) {
+        bsl::shared_ptr<SkipNode<K, V>> _x = *firstOpt;
+        return false;
+      } else {
+        return true;
+      }
+    }();
+  }
+  unsigned int length() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    return SkipList<int, int>::template length_aux<K, V>(
+        10000u, bsl::move(firstOpt), 0u);
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool exists_(F0 &&ltK, F1 &&eqK, const K &k) const {
+    unsigned int lvl = stm::readTVar(this->slLevel);
+    return SkipList<int, int>::template findKey_aux<K, V>(ltK, eqK,
+                                                          this->slHead, k, lvl);
+  }
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> front() const {
+    return ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+        this->slHead->forward[0u]));
+  }
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> back() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (firstOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt;
+      return SkipList<int, int>::template findLast_aux<K, V>(10000u, first);
+    } else {
+      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+    }
+  }
+  bsl::optional<bsl::pair<K, V>> popFront() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (firstOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
+      SkipList<int, int>::template unlinkFirstFromHead<K, V>(this->slHead, node,
+                                                             node->level);
+      V v = stm::readTVar<V>(node->value);
+      return bsl::make_optional<bsl::pair<K, V>>(bsl::make_pair(node->key, v));
+    } else {
+      return bsl::optional<bsl::pair<K, V>>();
+    }
+  }
+  unsigned int removeAll() const {
+    unsigned int count = SkipList<int, int>::template removeAll_aux<K, V>(
+        10000u, this->slHead, 0u);
+    stm::writeTVar(this->slLevel, 0u);
+    return count;
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  std::monostate add(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
+                     unsigned int newLevel) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+                                                  (newLevel + 1), curLvl);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
+      if (eqK(existing->key, k)) {
+        stm::writeTVar<V>(existing->value, v);
+        return std::monostate{};
+      } else {
+        bsl::shared_ptr<SkipNode<K, V>> newN =
+            SkipNode<K, V>::create(k, v, newLevel);
+        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
+                                                    this->slHead, newN);
+        if (curLvl < newLevel) {
+          stm::writeTVar(this->slLevel, newLevel);
+          return std::monostate{};
+        } else {
+          return std::monostate{};
+        }
+      }
+    } else {
+      bsl::shared_ptr<SkipNode<K, V>> newN =
+          SkipNode<K, V>::create(k, v, newLevel);
+      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+                                                  newN);
+      if (curLvl < newLevel) {
+        stm::writeTVar(this->slLevel, newLevel);
+        return std::monostate{};
+      } else {
+        return std::monostate{};
+      }
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool addUnique(F0 &&ltK, F1 &&eqK, const K &k, const V &v,
+                 unsigned int newLevel) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+                                                  (newLevel + 1), curLvl);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
+      if (eqK(existing->key, k)) {
+        return false;
+      } else {
+        bsl::shared_ptr<SkipNode<K, V>> newN =
+            SkipNode<K, V>::create(k, v, newLevel);
+        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
+                                                    this->slHead, newN);
+        [&]() -> void {
+          if (curLvl < newLevel) {
+            stm::writeTVar(this->slLevel, newLevel);
+            return;
+          } else {
+            return;
+          }
+        }();
+        return true;
+      }
+    } else {
+      bsl::shared_ptr<SkipNode<K, V>> newN =
+          SkipNode<K, V>::create(k, v, newLevel);
+      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+                                                  newN);
+      [&]() -> void {
+        if (curLvl < newLevel) {
+          stm::writeTVar(this->slLevel, newLevel);
+          return;
+        } else {
+          return;
+        }
+      }();
+      return true;
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> find(F0 &&ltK, F1 &&eqK,
+                                                      const K &k) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, k)) {
+        return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
+      } else {
+        return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+      }
+    } else {
+      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+    }
+  }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
+  previous(F0 &&eqK, bsl::shared_ptr<SkipNode<K, V>> pair) const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (firstOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> first = *firstOpt;
+      if (eqK(first->key, pair->key)) {
+        return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+      } else {
+        return SkipList<int, int>::template findPrev_aux<K, V>(
+            eqK, 10000u, first, this->slHead, pair->key);
+      }
+    } else {
+      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+    }
+  }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
+  findLowerBound(F0 &&ltK, const K &k) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
+    } else {
+      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>
+  findUpperBound(F0 &&ltK, F1 &&eqK, const K &k) const {
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, k)) {
+        return ptr_to_opt(
+            stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(node->forward[0u]));
+      } else {
+        return bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node);
+      }
+    } else {
+      return bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>();
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool removePair(F0 &&ltK, F1 &&eqK,
+                  bsl::shared_ptr<SkipNode<K, V>> pair) const {
+    K k = pair->key;
+    SkipPath<K, V> path = this->findPath(ltK, k);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, k)) {
+        SkipList<int, int>::template extendPath<K, V>(
+            path, this->slHead, (node->level + 1), curLvl);
+        SkipList<int, int>::template unlinkNode<K, V>(path, node);
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::pair<bsl::shared_ptr<SkipNode<K, V>>, bool>
+  bde_add(F0 &&ltK, F1 &&eqK, const K &key0, const V &data0,
+          unsigned int level) const {
+    SkipPath<K, V> path = this->findPath(ltK, key0);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+                                                  (level + 1), curLvl);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    bool isNewFront;
+    if (curFront.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront;
+      isNewFront = ltK(key0, frontNode->key);
+    } else {
+      isNewFront = true;
+    }
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
+      if (eqK(existing->key, key0)) {
+        stm::writeTVar<V>(existing->value, data0);
+        return bsl::make_pair(existing, false);
+      } else {
+        bsl::shared_ptr<SkipNode<K, V>> newN =
+            SkipNode<K, V>::create(key0, data0, level);
+        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
+                                                    this->slHead, newN);
+        [&]() -> void {
+          if (curLvl < level) {
+            stm::writeTVar(this->slLevel, level);
+            return;
+          } else {
+            return;
+          }
+        }();
+        return bsl::make_pair(newN, isNewFront);
+      }
+    } else {
+      bsl::shared_ptr<SkipNode<K, V>> newN =
+          SkipNode<K, V>::create(key0, data0, level);
+      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+                                                  newN);
+      [&]() -> void {
+        if (curLvl < level) {
+          stm::writeTVar(this->slLevel, level);
+          return;
+        } else {
+          return;
+        }
+      }();
+      return bsl::make_pair(newN, isNewFront);
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::pair<
+      bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>,
+      bool>
+  bde_addUnique(F0 &&ltK, F1 &&eqK, const K &key0, const V &data0,
+                unsigned int level) const {
+    SkipPath<K, V> path = this->findPath(ltK, key0);
+    unsigned int curLvl = stm::readTVar(this->slLevel);
+    SkipList<int, int>::template extendPath<K, V>(path, this->slHead,
+                                                  (level + 1), curLvl);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> curFront =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    bool isNewFront;
+    if (curFront.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> frontNode = *curFront;
+      isNewFront = ltK(key0, frontNode->key);
+    } else {
+      isNewFront = true;
+    }
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> existing = *nextOpt;
+      if (eqK(existing->key, key0)) {
+        return bsl::make_pair(
+            bsl::make_pair(SkipList<int, int>::e_DUPLICATE,
+                           bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>()),
+            false);
+      } else {
+        bsl::shared_ptr<SkipNode<K, V>> newN =
+            SkipNode<K, V>::create(key0, data0, level);
+        SkipList<int, int>::template linkNode<K, V>(bsl::move(path),
+                                                    this->slHead, newN);
+        [&]() -> void {
+          if (curLvl < level) {
+            stm::writeTVar(this->slLevel, level);
+            return;
+          } else {
+            return;
+          }
+        }();
+        return bsl::make_pair(
+            bsl::make_pair(
+                SkipList<int, int>::e_SUCCESS,
+                bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)),
+            isNewFront);
+      }
+    } else {
+      bsl::shared_ptr<SkipNode<K, V>> newN =
+          SkipNode<K, V>::create(key0, data0, level);
+      SkipList<int, int>::template linkNode<K, V>(bsl::move(path), this->slHead,
+                                                  newN);
+      [&]() -> void {
+        if (curLvl < level) {
+          stm::writeTVar(this->slLevel, level);
+          return;
+        } else {
+          return;
+        }
+      }();
+      return bsl::make_pair(
+          bsl::make_pair(
+              SkipList<int, int>::e_SUCCESS,
+              bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(newN)),
+          isNewFront);
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_find(F0 &&ltK, F1 &&eqK, const K &key0) const {
+    SkipPath<K, V> path = this->findPath(ltK, key0);
+    bsl::shared_ptr<SkipNode<K, V>> pred0 = path.get(0u);
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> nextOpt = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(pred0->forward[0u]));
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *nextOpt;
+      if (eqK(node->key, key0)) {
+        return bsl::make_pair(
+            SkipList<int, int>::e_SUCCESS,
+            bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+      } else {
+        return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                              bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+      }
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_front() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> frontOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (frontOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *frontOpt;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_back() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> backOpt = this->back();
+    if (backOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *backOpt;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_popFront() const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> firstOpt =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<K, V>>>(
+            this->slHead->forward[0u]));
+    if (firstOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *firstOpt;
+      SkipList<int, int>::template unlinkFirstFromHead<K, V>(this->slHead, node,
+                                                             node->level);
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  unsigned int bde_remove(F0 &&ltK, F1 &&eqK,
+                          bsl::shared_ptr<SkipNode<K, V>> pair) const {
+    bool result = this->removePair(ltK, eqK, pair);
+    if (result) {
+      return SkipList<int, int>::e_SUCCESS;
+    } else {
+      return SkipList<int, int>::e_NOT_FOUND;
+    }
+  }
+  unsigned int bde_removeAll() const { return this->removeAll(); }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bool bde_exists(F0 &&ltK, F1 &&eqK, const K &key0) const {
+    unsigned int lvl = stm::readTVar(this->slLevel);
+    return SkipList<int, int>::template findKey_aux<K, V>(
+        ltK, eqK, this->slHead, key0, lvl);
+  }
+  bool bde_isEmpty() const { return this->isEmpty(); }
+  unsigned int bde_length() const { return this->length(); }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_previous(F0 &&eqK, bsl::shared_ptr<SkipNode<K, V>> pair) const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> prevOpt =
+        this->previous(eqK, pair);
+    if (prevOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *prevOpt;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  template <typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &>
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_findLowerBound(F0 &&ltK, const K &key0) const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result =
+        this->findLowerBound(ltK, key0);
+    if (result.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *result;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  template <typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, K &, K &> &&
+             bsl::is_invocable_r_v<bool, F1 &, K &, K &>
+  bsl::pair<unsigned int, bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>>
+  bde_findUpperBound(F0 &&ltK, F1 &&eqK, const K &key0) const {
+    bsl::optional<bsl::shared_ptr<SkipNode<K, V>>> result =
+        this->findUpperBound(ltK, eqK, key0);
+    if (result.has_value()) {
+      bsl::shared_ptr<SkipNode<K, V>> node = *result;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<K, V>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<K, V>>>());
+    }
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::shared_ptr<SkipNode<T1, T2>>
+  findPred_go(F0 &&ltK, unsigned int fuel,
+              bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1 &target,
+              unsigned int level) {
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+    unsigned int _loop_fuel = bsl::move(fuel);
+    while (true) {
+      if (_loop_fuel <= 0) {
+        return _loop_curr;
+      } else {
+        unsigned int fuel_ = _loop_fuel - 1;
+        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
+            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                _loop_curr->forward[level]));
+        if (nextOpt.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
+          if (ltK(next0->key, target)) {
+            _loop_curr = next0;
+            _loop_fuel = fuel_;
+          } else {
+            return _loop_curr;
+          }
+        } else {
+          return _loop_curr;
+        }
+      }
+    }
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::shared_ptr<SkipNode<T1, T2>>
+  findPred(F0 &&ltK, bsl::shared_ptr<SkipNode<T1, T2>> curr, const T1 &target,
+           unsigned int level) {
+    return SkipList<int, int>::template findPred_go<T1, T2>(ltK, 10000u, curr,
+                                                            target, level);
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static SkipPath<T1, T2>
+  findPath_aux(F0 &&ltK, bsl::shared_ptr<SkipNode<T1, T2>> curr,
+               const T1 &target, unsigned int level, SkipPath<T1, T2> path) {
+    unsigned int _loop_level = bsl::move(level);
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+    while (true) {
+      bsl::shared_ptr<SkipNode<T1, T2>> pred =
+          SkipList<int, int>::template findPred<T1, T2>(ltK, _loop_curr, target,
+                                                        _loop_level);
+      path.set(_loop_level, pred);
+      if (_loop_level <= 0) {
+        return path;
+      } else {
+        unsigned int level_ = _loop_level - 1;
+        _loop_level = level_;
+        _loop_curr = bsl::move(pred);
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static void linkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
+                          bsl::shared_ptr<SkipNode<T1, T2>> newNode,
+                          unsigned int level) {
+    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> oldNext = ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pred->forward[level]));
+    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+        pred->forward[level],
+        opt_to_ptr(
+            bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(newNode)));
+    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+        bsl::move(newNode)->forward[level], opt_to_ptr(bsl::move(oldNext)));
+    return;
+  }
+  template <typename T1, typename T2>
+  static void
+  linkNode_aux(SkipPath<T1, T2> path, bsl::shared_ptr<SkipNode<T1, T2>>,
+               bsl::shared_ptr<SkipNode<T1, T2>> newNode, unsigned int level) {
+    unsigned int _loop_level = bsl::move(level);
+    while (true) {
+      bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
+      SkipList<int, int>::template linkAtLevel<T1, T2>(pred, newNode,
+                                                       _loop_level);
+      if (_loop_level <= 0) {
+        return;
+      } else {
+        unsigned int level_ = _loop_level - 1;
+        _loop_level = level_;
+      }
+    }
+    return;
+  }
+  template <typename T1, typename T2>
+  static void extendPath_aux(SkipPath<T1, T2> path,
+                             bsl::shared_ptr<SkipNode<T1, T2>> head,
+                             unsigned int level, unsigned int maxLevel) {
+    unsigned int _loop_level = bsl::move(level);
+    while (true) {
+      if (_loop_level <= 0) {
+        path.set(0u, head);
+        return;
+      } else {
+        unsigned int level_ = _loop_level - 1;
+        path.set(_loop_level, head);
+        if (maxLevel <= level_) {
+          _loop_level = level_;
+        } else {
+          return;
+        }
+      }
+    }
+    return;
+  }
+  template <typename T1, typename T2>
+  static void extendPath(SkipPath<T1, T2> path,
+                         bsl::shared_ptr<SkipNode<T1, T2>> head,
+                         unsigned int needed, unsigned int currentMax) {
+    if (needed <= (currentMax + 1)) {
+      return;
+    } else {
+      SkipList<int, int>::template extendPath_aux<T1, T2>(
+          path, head, (((needed - 1u) > needed ? 0 : (needed - 1u))),
+          (currentMax + 1u));
+      return;
+    }
+  }
+  template <typename T1, typename T2>
+  static void linkNode(SkipPath<T1, T2> path,
+                       bsl::shared_ptr<SkipNode<T1, T2>> head,
+                       bsl::shared_ptr<SkipNode<T1, T2>> newNode) {
+    unsigned int lvl = newNode->level;
+    SkipList<int, int>::template linkNode_aux<T1, T2>(path, head, newNode, lvl);
+    return;
+  }
+  template <typename T1, typename T2>
+  static void unlinkAtLevel(bsl::shared_ptr<SkipNode<T1, T2>> pred,
+                            bsl::shared_ptr<SkipNode<T1, T2>> target,
+                            unsigned int level) {
+    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> targetNext =
+        ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+            target->forward[level]));
+    stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+        pred->forward[level], opt_to_ptr(bsl::move(targetNext)));
+    return;
+  }
+  template <typename T1, typename T2>
+  static void unlinkNode_aux(SkipPath<T1, T2> path,
+                             bsl::shared_ptr<SkipNode<T1, T2>> target,
+                             unsigned int level) {
+    unsigned int _loop_level = bsl::move(level);
+    while (true) {
+      bsl::shared_ptr<SkipNode<T1, T2>> pred = path.get(_loop_level);
+      SkipList<int, int>::template unlinkAtLevel<T1, T2>(pred, target,
+                                                         _loop_level);
+      if (_loop_level <= 0) {
+        return;
+      } else {
+        unsigned int level_ = _loop_level - 1;
+        _loop_level = level_;
+      }
+    }
+    return;
+  }
+  template <typename T1, typename T2>
+  static void unlinkNode(SkipPath<T1, T2> path,
+                         bsl::shared_ptr<SkipNode<T1, T2>> target) {
+    unsigned int lvl = target->level;
+    SkipList<int, int>::template unlinkNode_aux<T1, T2>(path, target, lvl);
+    return;
+  }
+  template <typename T1, typename T2, typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &> &&
+             bsl::is_invocable_r_v<bool, F1 &, T1 &, T1 &>
+  static bool findKey_aux(F0 &&ltK, F1 &&eqK,
+                          bsl::shared_ptr<SkipNode<T1, T2>> curr,
+                          const T1 &target, unsigned int level) {
+    unsigned int _loop_level = bsl::move(level);
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+    while (true) {
+      bsl::shared_ptr<SkipNode<T1, T2>> pred =
+          SkipList<int, int>::template findPred<T1, T2>(ltK, _loop_curr, target,
+                                                        _loop_level);
+      if (_loop_level <= 0) {
+        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
+            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                bsl::move(pred)->forward[0u]));
+        if (nextOpt.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt;
+          return eqK(node->key, target);
+        } else {
+          return false;
+        }
+      } else {
+        unsigned int level_ = _loop_level - 1;
+        _loop_level = level_;
+        _loop_curr = bsl::move(pred);
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static unsigned int
+  length_aux(unsigned int fuel,
+             const bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> &node,
+             unsigned int acc) {
+    unsigned int _loop_acc = bsl::move(acc);
+    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> _loop_node = node;
+    unsigned int _loop_fuel = bsl::move(fuel);
+    while (true) {
+      if (_loop_fuel <= 0) {
+        return _loop_acc;
+      } else {
+        unsigned int fuel_ = _loop_fuel - 1;
+        if (_loop_node.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> n = *_loop_node;
+          bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt = ptr_to_opt(
+              stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(n->forward[0u]));
+          _loop_acc = (_loop_acc + 1);
+          _loop_node = bsl::move(nextOpt);
+          _loop_fuel = fuel_;
+        } else {
+          return _loop_acc;
+        }
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
+  findLast_aux(unsigned int fuel, bsl::shared_ptr<SkipNode<T1, T2>> curr) {
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+    unsigned int _loop_fuel = bsl::move(fuel);
+    while (true) {
+      if (_loop_fuel <= 0) {
+        return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
+            _loop_curr);
+      } else {
+        unsigned int fuel_ = _loop_fuel - 1;
+        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
+            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                _loop_curr->forward[0u]));
+        if (nextOpt.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
+          _loop_curr = next0;
+          _loop_fuel = fuel_;
+        } else {
+          return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
+              bsl::move(_loop_curr));
+        }
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static void unlinkFirstFromHead(bsl::shared_ptr<SkipNode<T1, T2>> head,
+                                  bsl::shared_ptr<SkipNode<T1, T2>> node,
+                                  unsigned int lvl) {
+    unsigned int _loop_lvl = bsl::move(lvl);
+    while (true) {
+      bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext =
+          ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+              node->forward[_loop_lvl]));
+      stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+          head->forward[_loop_lvl], opt_to_ptr(nodeNext));
+      if (_loop_lvl <= 0) {
+        return;
+      } else {
+        unsigned int lvl_ = _loop_lvl - 1;
+        _loop_lvl = lvl_;
+      }
+    }
+    return;
+  }
+  template <typename T1, typename T2>
+  static void unlinkNodeAtAllLevels(bsl::shared_ptr<SkipNode<T1, T2>> head,
+                                    bsl::shared_ptr<SkipNode<T1, T2>> node,
+                                    unsigned int lvl) {
+    unsigned int _loop_lvl = bsl::move(lvl);
+    while (true) {
+      bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nodeNext =
+          ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+              node->forward[_loop_lvl]));
+      stm::writeTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+          head->forward[_loop_lvl], opt_to_ptr(nodeNext));
+      if (_loop_lvl <= 0) {
+        return;
+      } else {
+        unsigned int lvl_ = _loop_lvl - 1;
+        _loop_lvl = lvl_;
+      }
+    }
+    return;
+  }
+  template <typename T1, typename T2>
+  static unsigned int removeAll_aux(unsigned int fuel,
+                                    bsl::shared_ptr<SkipNode<T1, T2>> head,
+                                    unsigned int acc) {
+    unsigned int _loop_acc = bsl::move(acc);
+    unsigned int _loop_fuel = bsl::move(fuel);
+    while (true) {
+      if (_loop_fuel <= 0) {
+        return _loop_acc;
+      } else {
+        unsigned int fuel_ = _loop_fuel - 1;
+        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> firstOpt =
+            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                head->forward[0u]));
+        if (firstOpt.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> node = *firstOpt;
+          SkipList<int, int>::template unlinkNodeAtAllLevels<T1, T2>(
+              head, node, node->level);
+          _loop_acc = (_loop_acc + 1);
+          _loop_fuel = fuel_;
+        } else {
+          return _loop_acc;
+        }
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
+  next(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
+    return ptr_to_opt(
+        stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(pair->forward[0u]));
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>
+  findPrev_aux(F0 &&eqK, unsigned int fuel,
+               bsl::shared_ptr<SkipNode<T1, T2>> curr,
+               bsl::shared_ptr<SkipNode<T1, T2>> _x, const T1 &target) {
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_x = bsl::move(_x);
+    bsl::shared_ptr<SkipNode<T1, T2>> _loop_curr = bsl::move(curr);
+    unsigned int _loop_fuel = bsl::move(fuel);
+    while (true) {
+      if (_loop_fuel <= 0) {
+        return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>();
+      } else {
+        unsigned int fuel_ = _loop_fuel - 1;
+        bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
+            ptr_to_opt(stm::readTVar<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                _loop_curr->forward[0u]));
+        if (nextOpt.has_value()) {
+          bsl::shared_ptr<SkipNode<T1, T2>> next0 = *nextOpt;
+          if (eqK(next0->key, target)) {
+            return bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(
+                bsl::move(_loop_curr));
+          } else {
+            bsl::shared_ptr<SkipNode<T1, T2>> _next_curr = next0;
+            _loop_x = bsl::move(_loop_curr);
+            _loop_fuel = fuel_;
+            _loop_curr = bsl::move(_next_curr);
+          }
+        } else {
+          return bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>();
+        }
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static T1 key(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
+    return pair->key;
+  }
+  template <typename T1, typename T2>
+  static T2 data(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
+    return stm::readTVar<T2>(pair->value);
+  }
+  static inline const unsigned int e_SUCCESS = 0u;
+  static inline const unsigned int e_NOT_FOUND = 1u;
+  static inline const unsigned int e_DUPLICATE = 2u;
+  static inline const unsigned int e_INVALID = 3u;
+  template <typename T1, typename T2>
+  static bsl::pair<unsigned int,
+                   bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>>
+  bde_next(bsl::shared_ptr<SkipNode<T1, T2>> pair) {
+    bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>> nextOpt =
+        SkipList<int, int>::template next<T1, T2>(pair);
+    if (nextOpt.has_value()) {
+      bsl::shared_ptr<SkipNode<T1, T2>> node = *nextOpt;
+      return bsl::make_pair(
+          SkipList<int, int>::e_SUCCESS,
+          bsl::make_optional<bsl::shared_ptr<SkipNode<T1, T2>>>(node));
+    } else {
+      return bsl::make_pair(SkipList<int, int>::e_NOT_FOUND,
+                            bsl::optional<bsl::shared_ptr<SkipNode<T1, T2>>>());
+    }
+  }
+  template <typename T1, typename T2>
+  static SkipList<T1, T2> create(const T1 &dummyKey, const T2 &dummyVal) {
+    bsl::shared_ptr<SkipNode<T1, T2>> headNode = SkipNode<T1, T2>::create(
+        dummyKey, dummyVal, (((16u - 1u) > 16u ? 0 : (16u - 1u))));
+    stm::TVar<unsigned int> lvlTV = stm::newTVar(0u);
+    stm::TVar<unsigned int> lenTV = stm::newTVar(0u);
+    return SkipList<T1, T2>{headNode, 16u, lvlTV, lenTV};
+  }
+  template <typename T1, typename T2>
+  static SkipList<T1, T2> createIO(const T1 &dummyKey, const T2 &dummyVal) {
+    return stm::atomically([&] {
+      return SkipList<int, int>::template create<T1, T2>(dummyKey, dummyVal);
+    });
+  }
 };
 
 #endif // INCLUDED_SKIPLIST_BDE

--- a/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.cpp
+++ b/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.cpp
@@ -1,28 +1,21 @@
 #include "stm_hash_map_bde.h"
 
 #include <bdlf_overloaded.h>
+#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
+#include <bsl_cstdint.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <bsl_optional.h>
-#include <bsl_iostream.h>
-#include <bdls_filesystemutil.h>
-#include <stm_adapter.h>
-#include <bsl_utility.h>
-#include <bsl_cstdint.h>
-#include <bsl_vector.h>
-#include <bsl_memory.h>
-#include <variant>
 #include <fstream>
+#include <stm_adapter.h>
+#include <variant>
 
-
-namespace BloombergLP {
-
-}
-
+namespace BloombergLP {}

--- a/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.h
+++ b/tests/monadic/stm_hash_map_bde/stm_hash_map_bde.h
@@ -1,29 +1,25 @@
 #ifndef INCLUDED_STM_HASH_MAP_BDE
 #define INCLUDED_STM_HASH_MAP_BDE
 
+#include <any>
 #include <bdlf_overloaded.h>
+#include <bdls_filesystemutil.h>
 #include <bsl_concepts.h>
+#include <bsl_cstdint.h>
 #include <bsl_functional.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
+#include <bsl_optional.h>
 #include <bsl_stdexcept.h>
 #include <bsl_string.h>
 #include <bsl_type_traits.h>
+#include <bsl_utility.h>
 #include <bsl_variant.h>
 #include <bsl_vector.h>
-#include <any>
-#include <utility>
-#include <bsl_optional.h>
-#include <bsl_iostream.h>
-#include <bdls_filesystemutil.h>
-#include <stm_adapter.h>
-#include <bsl_utility.h>
-#include <bsl_cstdint.h>
-#include <bsl_vector.h>
-#include <bsl_memory.h>
-#include <variant>
 #include <fstream>
-
+#include <stm_adapter.h>
+#include <utility>
+#include <variant>
 
 using namespace BloombergLP;
 template <class From, class To>
@@ -32,206 +28,278 @@ concept convertible_to = bsl::is_convertible<From, To>::value;
 template <class T, class U>
 concept same_as = bsl::is_same<T, U>::value && bsl::is_same<U, T>::value;
 
-
-template <typename
-t_A>struct List {
+template <typename t_A> struct List {
   // TYPES
-struct Nil {
+  struct Nil {};
+  struct Cons {
+    t_A d_a;
+    bsl::shared_ptr<List<t_A>> d_l;
+  };
+  using variant_t = bsl::variant<Nil, Cons>;
 
-};
-struct Cons {
-t_A d_a;
-bsl::shared_ptr<List<t_A>> d_l;
-};
-using variant_t = bsl::variant<Nil,
-Cons>;
 private:
   // DATA
-variant_t d_v_;
+  variant_t d_v_;
+
 public:
   // CREATORS
-List() {}
-explicit List(Nil _v) : d_v_(_v) {}
-explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
-template <typename
-_U>
-explicit List(const List<_U>& _other) {
-if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
-this->d_v_ = Nil{};
-} else {
-const auto& [d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
-this->d_v_ = Cons{[&]() -> t_A { if constexpr (std::is_same_v<_U, std::any>) { if (d_a.type() == typeid(t_A)) return std::any_cast<t_A>(d_a); if constexpr (requires { typename t_A::first_type; typename t_A::second_type; }) { const auto& [_k, _v] = std::any_cast<std::pair<std::any, std::any>>(d_a); return t_A{ [&]() -> typename t_A::first_type { if constexpr (std::is_same_v<typename t_A::first_type, std::any>) return _k; else return std::any_cast<typename t_A::first_type>(_k); }(), [&]() -> typename t_A::second_type { if constexpr (std::is_same_v<typename t_A::second_type, std::any>) return _v; else return std::any_cast<typename t_A::second_type>(_v); }() }; } return std::any_cast<t_A>(d_a); } else return t_A(d_a); }(),
-d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
-}}
-static List<t_A> nil(){
-return List(Nil{});}
-static List<t_A> cons(t_A a, List<t_A> l){
-return List(Cons{bsl::move(a),
-bsl::make_shared<List<t_A>>(bsl::move(l))});}
+  List() {}
+  explicit List(Nil _v) : d_v_(_v) {}
+  explicit List(Cons _v) : d_v_(bsl::move(_v)) {}
+  template <typename _U> explicit List(const List<_U> &_other) {
+    if (bsl::holds_alternative<typename List<_U>::Nil>(_other.v())) {
+      this->d_v_ = Nil{};
+    } else {
+      const auto &[d_a, d_l] = std::get<typename List<_U>::Cons>(_other.v());
+      this->d_v_ = Cons{
+          [&]() -> t_A {
+            if constexpr (std::is_same_v<_U, std::any>) {
+              if (d_a.type() == typeid(t_A))
+                return std::any_cast<t_A>(d_a);
+              if constexpr (requires {
+                              typename t_A::first_type;
+                              typename t_A::second_type;
+                            }) {
+                const auto &[_k, _v] =
+                    std::any_cast<std::pair<std::any, std::any>>(d_a);
+                return t_A{
+                    [&]() -> typename t_A::first_type {
+                      if constexpr (std::is_same_v<typename t_A::first_type,
+                                                   std::any>)
+                        return _k;
+                      else
+                        return std::any_cast<typename t_A::first_type>(_k);
+                    }(),
+                    [&]() -> typename t_A::second_type {
+                      if constexpr (std::is_same_v<typename t_A::second_type,
+                                                   std::any>)
+                        return _v;
+                      else
+                        return std::any_cast<typename t_A::second_type>(_v);
+                    }()};
+              }
+              return std::any_cast<t_A>(d_a);
+            } else
+              return t_A(d_a);
+          }(),
+          d_l ? std::make_shared<List<t_A>>(*d_l) : nullptr};
+    }
+  }
+  static List<t_A> nil() { return List(Nil{}); }
+  static List<t_A> cons(t_A a, List<t_A> l) {
+    return List(Cons{bsl::move(a), bsl::make_shared<List<t_A>>(bsl::move(l))});
+  }
   // MANIPULATORS
-~List() {
-bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
-auto _drain = [&](variant_t&
-_v) {
-if (auto* _alt = bsl::get_if<Cons>(&_v)) {
-if (_alt->d_l) {
-_stack.push_back(bsl::move(_alt->d_l));
-}
-}
-};
-_drain(v_mut());
-while (!_stack.empty()) {
-auto _cur = bsl::move(_stack.back());
-_stack.pop_back();
-if (_cur.use_count() == 1) {
-_drain(_cur->v_mut());
-}
-}
-}
-inline variant_t& v_mut() {
-return d_v_;}
+  ~List() {
+    bsl::vector<bsl::shared_ptr<List<t_A>>> _stack = {};
+    auto _drain = [&](variant_t &_v) {
+      if (auto *_alt = bsl::get_if<Cons>(&_v)) {
+        if (_alt->d_l) {
+          _stack.push_back(bsl::move(_alt->d_l));
+        }
+      }
+    };
+    _drain(v_mut());
+    while (!_stack.empty()) {
+      auto _cur = bsl::move(_stack.back());
+      _stack.pop_back();
+      if (_cur.use_count() == 1) {
+        _drain(_cur->v_mut());
+      }
+    }
+  }
+  inline variant_t &v_mut() { return d_v_; }
   // ACCESSORS
-const variant_t& v() const {
-return d_v_;}
-};template<typename K, typename V>
-struct CHT {
-bsl::function<bool(K, K)> cht_eqb;
-bsl::function<int64_t(K)>
-cht_hash;
-bsl::vector<stm::TVar<List<bsl::pair<K, V>>>> cht_buckets;
-int64_t cht_nbuckets;
-stm::TVar<List<bsl::pair<K, V>>>
-cht_fallback;
-stm::TVar<List<bsl::pair<K, V>>> bucket_of(const K& k) const {
-int64_t i = this->cht_hash(k) % this->cht_nbuckets;
-return this->cht_buckets.at(i);}
-bsl::optional<V> stm_get(const K& k) const {
-stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-List<bsl::pair<K, V>> xs = stm::readTVar(b);
-return CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k,
-xs);}
-std::monostate stm_put(const K& k,
-const V& v) const {
-stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-List<bsl::pair<K, V>> xs = stm::readTVar(b);
-List<bsl::pair<K, V>> xs_ = CHT<int, int>::template assoc_insert_or_replace<K,
-V>(this->cht_eqb, k, v,
-bsl::move(xs));
-stm::writeTVar(b, xs_);
-return std::monostate{};}
-bsl::optional<V> stm_delete(const K& k) const {
-stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-List<bsl::pair<K, V>> xs = stm::readTVar(b);
-bsl::pair<bsl::optional<V>, List<bsl::pair<K, V>>> p = CHT<int, int>::template assoc_remove<K,
-V>(this->cht_eqb, k,
-bsl::move(xs));
-auto _cs = p.first;
-if (_cs.has_value()) { V _x = *_cs; stm::writeTVar(bsl::move(b), p.second);
-return p.first; } else { return p.first; }}
-template <typename
-F1>
-  requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
-V stm_update(const K& k,
-F1&& f) const {
-stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
-List<bsl::pair<K, V>> xs = stm::readTVar(b);
-bsl::optional<V> ov = CHT<int, int>::template assoc_lookup<K,
-V>(this->cht_eqb, k,
-xs);
-V v = f(bsl::move(ov));
-List<bsl::pair<K, V>> xs_ = CHT<int, int>::template assoc_insert_or_replace<K,
-V>(this->cht_eqb, k, v,
-bsl::move(xs));
-stm::writeTVar(b, xs_);
-return v;}
-V stm_get_or(const K& k,
-const V& dflt) const {
-bsl::optional<V> v = this->stm_get(k);
-if (v.has_value()) { V x = *v; return x; } else { return dflt; }}
-std::monostate put(const K& k, const V& v) const {
-CHT<K,
-V> _self_val = *this;
-return stm::atomically([&] { return [=]() mutable {
-_self_val.stm_put(k,
-v);
-return std::monostate{};
-}(); });}
-bsl::optional<V> get(const K& k) const {
-return stm::atomically([&] { return this->stm_get(k); });}
-bsl::optional<V> hash_delete(const K& k) const {
-return stm::atomically([&] { return this->stm_delete(k); });}
-template <typename
-F1>
-  requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
-V hash_update(const K& k,
-F1&& f) const {
-return stm::atomically([&] { return this->stm_update(k,
-f); });}
-V get_or(const K& k,
-const V& dflt) const {
-return stm::atomically([&] { return this->stm_get_or(k,
-dflt); });}
-template <typename T1, typename T2, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::optional<T2> assoc_lookup(F0&& eqb, const T1& k,
-const List<bsl::pair<T1, T2>>& xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
-return bsl::optional<T2>();
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
-auto [k_, v] = d_a0; if (eqb(k,
-k_)) { return bsl::make_optional<T2>(v); } else { return CHT<int, int>::template assoc_lookup<T1,
-T2>(eqb, k, *d_a1); }
-}}template <typename T1, typename T2, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static List<bsl::pair<T1, T2>> assoc_insert_or_replace(F0&& eqb, T1 k, T2 v,
-const List<bsl::pair<T1, T2>>& xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
-return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), List<bsl::pair<T1, T2>>::nil());
-} else {
-const auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
-auto [k_, v_] = d_a0; if (eqb(k,
-k_)) { return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), *d_a1); } else { return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k_, v_), CHT<int, int>::template assoc_insert_or_replace<T1,
-T2>(eqb, k, v, *d_a1)); }
-}}template <typename T1, typename T2, typename
-F0>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-static bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> assoc_remove(F0&& eqb,
-const T1& k,
-List<bsl::pair<T1, T2>> xs){if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v_mut())) {
-return bsl::make_pair(bsl::optional<T2>(), xs);
-} else {
-auto& [d_a0, d_a1] = bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v_mut());
-auto [k_, v_] = bsl::move(d_a0); if (eqb(k,
-k_)) { return bsl::make_pair(bsl::make_optional<T2>(v_), *d_a1); } else { bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> q = CHT<int, int>::template assoc_remove<T1,
-T2>(eqb, k,
-*d_a1);
-return bsl::make_pair(q.first, List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k_, v_), q.second)); }
-}}template <typename T1, typename
-T2>static bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> mk_buckets(int64_t num){bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> buckets = {};
-auto f_impl = [&](auto& _self_f, unsigned int
-n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
-if (n <= 0) { return buckets; } else { unsigned int n_ = n - 1; stm::TVar<List<bsl::pair<T1, T2>>> b = stm::atomically([&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
-buckets.push_back(b);
-return _self_f(_self_f, n_); }
+  const variant_t &v() const { return d_v_; }
 };
-auto f = [&](unsigned int
-n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
-return f_impl(f_impl, n);
-};
-return f(static_cast<unsigned int>(num));}template <typename T1, typename T2,
-typename F0, typename
-F1>  requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
-      && bsl::is_invocable_r_v<int64_t, F1 &, T1 &>
-static CHT<T1, T2> new_hash(F0&& eqb, F1&& hash,
-int64_t requested){int64_t n = bsl::max<int64_t>(requested, 1);
-bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> bs = CHT<int, int>::template mk_buckets<T1,
-T2>(n);
-bool empt = bs.empty();
-if (empt) { stm::TVar<List<bsl::pair<T1, T2>>> fb = stm::atomically([&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
-bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> v = {};
-v.push_back(fb);
-return CHT<T1, T2>{eqb, hash, v, 1,
-fb}; } else { stm::TVar<List<bsl::pair<T1, T2>>> b = bs.at(0);
-return CHT<T1, T2>{eqb, hash, bs, n,
-b}; }}
+template <typename K, typename V> struct CHT {
+  bsl::function<bool(K, K)> cht_eqb;
+  bsl::function<int64_t(K)> cht_hash;
+  bsl::vector<stm::TVar<List<bsl::pair<K, V>>>> cht_buckets;
+  int64_t cht_nbuckets;
+  stm::TVar<List<bsl::pair<K, V>>> cht_fallback;
+  stm::TVar<List<bsl::pair<K, V>>> bucket_of(const K &k) const {
+    int64_t i =
+        (this->cht_nbuckets == 0 ? 0 : this->cht_hash(k) % this->cht_nbuckets);
+    return this->cht_buckets.at(i);
+  }
+  bsl::optional<V> stm_get(const K &k) const {
+    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+    List<bsl::pair<K, V>> xs = stm::readTVar(b);
+    return CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k, xs);
+  }
+  std::monostate stm_put(const K &k, const V &v) const {
+    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+    List<bsl::pair<K, V>> xs = stm::readTVar(b);
+    List<bsl::pair<K, V>> xs_ =
+        CHT<int, int>::template assoc_insert_or_replace<K, V>(this->cht_eqb, k,
+                                                              v, bsl::move(xs));
+    stm::writeTVar(b, xs_);
+    return std::monostate{};
+  }
+  bsl::optional<V> stm_delete(const K &k) const {
+    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+    List<bsl::pair<K, V>> xs = stm::readTVar(b);
+    bsl::pair<bsl::optional<V>, List<bsl::pair<K, V>>> p =
+        CHT<int, int>::template assoc_remove<K, V>(this->cht_eqb, k,
+                                                   bsl::move(xs));
+    auto _cs = p.first;
+    if (_cs.has_value()) {
+      V _x = *_cs;
+      stm::writeTVar(bsl::move(b), p.second);
+      return p.first;
+    } else {
+      return p.first;
+    }
+  }
+  template <typename F1>
+    requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
+  V stm_update(const K &k, F1 &&f) const {
+    stm::TVar<List<bsl::pair<K, V>>> b = this->bucket_of(k);
+    List<bsl::pair<K, V>> xs = stm::readTVar(b);
+    bsl::optional<V> ov =
+        CHT<int, int>::template assoc_lookup<K, V>(this->cht_eqb, k, xs);
+    V v = f(bsl::move(ov));
+    List<bsl::pair<K, V>> xs_ =
+        CHT<int, int>::template assoc_insert_or_replace<K, V>(this->cht_eqb, k,
+                                                              v, bsl::move(xs));
+    stm::writeTVar(b, xs_);
+    return v;
+  }
+  V stm_get_or(const K &k, const V &dflt) const {
+    bsl::optional<V> v = this->stm_get(k);
+    if (v.has_value()) {
+      V x = *v;
+      return x;
+    } else {
+      return dflt;
+    }
+  }
+  std::monostate put(const K &k, const V &v) const {
+    CHT<K, V> _self_val = *this;
+    return stm::atomically([&] {
+      return [=]() mutable {
+        _self_val.stm_put(k, v);
+        return std::monostate{};
+      }();
+    });
+  }
+  bsl::optional<V> get(const K &k) const {
+    return stm::atomically([&] { return this->stm_get(k); });
+  }
+  bsl::optional<V> hash_delete(const K &k) const {
+    return stm::atomically([&] { return this->stm_delete(k); });
+  }
+  template <typename F1>
+    requires bsl::is_invocable_r_v<V, F1 &, bsl::optional<V> &>
+  V hash_update(const K &k, F1 &&f) const {
+    return stm::atomically([&] { return this->stm_update(k, f); });
+  }
+  V get_or(const K &k, const V &dflt) const {
+    return stm::atomically([&] { return this->stm_get_or(k, dflt); });
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::optional<T2> assoc_lookup(F0 &&eqb, const T1 &k,
+                                        const List<bsl::pair<T1, T2>> &xs) {
+    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
+      return bsl::optional<T2>();
+    } else {
+      const auto &[d_a0, d_a1] =
+          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
+      auto [k_, v] = d_a0;
+      if (eqb(k, k_)) {
+        return bsl::make_optional<T2>(v);
+      } else {
+        return CHT<int, int>::template assoc_lookup<T1, T2>(eqb, k, *d_a1);
+      }
+    }
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static List<bsl::pair<T1, T2>>
+  assoc_insert_or_replace(F0 &&eqb, T1 k, T2 v,
+                          const List<bsl::pair<T1, T2>> &xs) {
+    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(xs.v())) {
+      return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v),
+                                           List<bsl::pair<T1, T2>>::nil());
+    } else {
+      const auto &[d_a0, d_a1] =
+          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v());
+      auto [k_, v_] = d_a0;
+      if (eqb(k, k_)) {
+        return List<bsl::pair<T1, T2>>::cons(bsl::make_pair(k, v), *d_a1);
+      } else {
+        return List<bsl::pair<T1, T2>>::cons(
+            bsl::make_pair(k_, v_),
+            CHT<int, int>::template assoc_insert_or_replace<T1, T2>(eqb, k, v,
+                                                                    *d_a1));
+      }
+    }
+  }
+  template <typename T1, typename T2, typename F0>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &>
+  static bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>>
+  assoc_remove(F0 &&eqb, const T1 &k, List<bsl::pair<T1, T2>> xs) {
+    if (bsl::holds_alternative<typename List<bsl::pair<T1, T2>>::Nil>(
+            xs.v_mut())) {
+      return bsl::make_pair(bsl::optional<T2>(), xs);
+    } else {
+      auto &[d_a0, d_a1] =
+          bsl::get<typename List<bsl::pair<T1, T2>>::Cons>(xs.v_mut());
+      auto [k_, v_] = bsl::move(d_a0);
+      if (eqb(k, k_)) {
+        return bsl::make_pair(bsl::make_optional<T2>(v_), *d_a1);
+      } else {
+        bsl::pair<bsl::optional<T2>, List<bsl::pair<T1, T2>>> q =
+            CHT<int, int>::template assoc_remove<T1, T2>(eqb, k, *d_a1);
+        return bsl::make_pair(q.first, List<bsl::pair<T1, T2>>::cons(
+                                           bsl::make_pair(k_, v_), q.second));
+      }
+    }
+  }
+  template <typename T1, typename T2>
+  static bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>>
+  mk_buckets(int64_t num) {
+    bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> buckets = {};
+    auto f_impl =
+        [&](auto &_self_f,
+            unsigned int n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
+      if (n <= 0) {
+        return buckets;
+      } else {
+        unsigned int n_ = n - 1;
+        stm::TVar<List<bsl::pair<T1, T2>>> b = stm::atomically(
+            [&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
+        buckets.push_back(b);
+        return _self_f(_self_f, n_);
+      }
+    };
+    auto f =
+        [&](unsigned int n) -> bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> {
+      return f_impl(f_impl, n);
+    };
+    return f(static_cast<unsigned int>(num));
+  }
+  template <typename T1, typename T2, typename F0, typename F1>
+    requires bsl::is_invocable_r_v<bool, F0 &, T1 &, T1 &> &&
+             bsl::is_invocable_r_v<int64_t, F1 &, T1 &>
+  static CHT<T1, T2> new_hash(F0 &&eqb, F1 &&hash, int64_t requested) {
+    int64_t n = bsl::max<int64_t>(requested, 1);
+    bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> bs =
+        CHT<int, int>::template mk_buckets<T1, T2>(n);
+    bool empt = bs.empty();
+    if (empt) {
+      stm::TVar<List<bsl::pair<T1, T2>>> fb = stm::atomically(
+          [&] { return stm::newTVar(List<bsl::pair<T1, T2>>::nil()); });
+      bsl::vector<stm::TVar<List<bsl::pair<T1, T2>>>> v = {};
+      v.push_back(fb);
+      return CHT<T1, T2>{eqb, hash, v, 1, fb};
+    } else {
+      stm::TVar<List<bsl::pair<T1, T2>>> b = bs.at(0);
+      return CHT<T1, T2>{eqb, hash, bs, n, b};
+    }
+  }
 };
 
 #endif // INCLUDED_STM_HASH_MAP_BDE

--- a/tests/monadic/stmonad/stmonad.h
+++ b/tests/monadic/stmonad/stmonad.h
@@ -325,6 +325,7 @@ struct STMonadTests {
   static_assert(STRefClass<nat_stref, uint64_t>);
 
   template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static uint64_t array_simp_fixed_init() {
     std::vector<uint64_t> *arr;
     arr = new std::remove_pointer_t<decltype(arr)>(
@@ -337,6 +338,7 @@ struct STMonadTests {
   }
 
   template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static std::pair<std::pair<uint64_t, uint64_t>, List<uint64_t>>
   array_simp_list() {
     std::vector<uint64_t> *arr;
@@ -375,7 +377,9 @@ struct STMonadTests {
     return std::make_pair(std::make_pair(elem, lst.length()), lst);
   }
 
-  template <typename _tcI0, typename _tcI1> static uint64_t fib_ST(uint64_t n) {
+  template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
+  static uint64_t fib_ST(uint64_t n) {
     if (n < UINT64_C(2)) {
       return n;
     } else {
@@ -416,6 +420,7 @@ struct STMonadTests {
   }
 
   template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static std::pair<bool, bool> new_and_read_both_bool() {
     bool r1;
     r1 = false;
@@ -427,6 +432,7 @@ struct STMonadTests {
   }
 
   template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static std::pair<uint64_t, uint64_t> new_and_read_both_nat() {
     uint64_t r1;
     r1 = UINT64_C(5);
@@ -438,6 +444,7 @@ struct STMonadTests {
   }
 
   template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static uint64_t tree_simp_another_nat() {
     uint64_t v;
     v = UINT64_C(5);
@@ -446,13 +453,17 @@ struct STMonadTests {
     return val;
   }
 
-  template <typename _tcI0, typename _tcI1> static bool tree_simp_bool() {
+  template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
+  static bool tree_simp_bool() {
     bool v;
     v = true;
     return std::move(v);
   }
 
-  template <typename _tcI0, typename _tcI1> static uint64_t tree_simp_nat() {
+  template <typename _tcI0, typename _tcI1>
+    requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
+  static uint64_t tree_simp_nat() {
     uint64_t v;
     v = UINT64_C(5);
     return std::move(v);

--- a/tests/monadic/stmonad/stmonad.t.cpp
+++ b/tests/monadic/stmonad/stmonad.t.cpp
@@ -32,7 +32,7 @@ void aSsErT(bool condition, const char *message, int line) {
 int main() {
   // Test 1: newAndReadBoth returns (5, 6)
   {
-    auto result = STMonadTests::new_and_read_both_nat<STMonadTests::nat_idx, STMonadTests::nat_stref>();
+    auto result = STMonadTests::new_and_read_both_nat<STMonadTests::nat_stref, STMonadTests::nat_idx>();
     ASSERT(result.first == 5);
     ASSERT(result.second == 6);
     std::cout << "Test 1 (new_and_read_both_nat): (" << result.first << ", "
@@ -41,7 +41,7 @@ int main() {
 
   // Test 2: tree_simp returns 5
   {
-    auto result = STMonadTests::tree_simp_nat<STMonadTests::nat_idx, STMonadTests::nat_stref>();
+    auto result = STMonadTests::tree_simp_nat<STMonadTests::nat_stref, STMonadTests::nat_idx>();
     ASSERT(result == 5);
     std::cout << "Test 2 (tree_simp_nat): " << result << " PASSED"
               << std::endl;
@@ -57,7 +57,7 @@ int main() {
 
   // Test 4: newAndReadBoth returns (false, true)
   {
-    auto result = STMonadTests::new_and_read_both_bool<STMonadTests::nat_idx, STMonadTests::nat_stref>();
+    auto result = STMonadTests::new_and_read_both_bool<STMonadTests::nat_stref, STMonadTests::nat_idx>();
     ASSERT(result.first == false);
     ASSERT(result.second == true);
     std::cout << "Test 4 (new_and_read_both_bool): (" << result.first << ", "
@@ -66,7 +66,7 @@ int main() {
 
   // Test 5: tree_simp_bool returns true
   {
-    auto result =  STMonadTests::tree_simp_bool<STMonadTests::nat_idx, STMonadTests::nat_stref>();
+    auto result =  STMonadTests::tree_simp_bool<STMonadTests::nat_stref, STMonadTests::nat_idx>();
     ASSERT(result == true);
     std::cout << "Test 5 (tree_simp_bool): " << result << " PASSED"
               << std::endl;

--- a/tests/regression/block_template_edge/block_template_edge.cpp
+++ b/tests/regression/block_template_edge/block_template_edge.cpp
@@ -17,8 +17,10 @@ std::string BlockTemplateEdge::block_in_if() {
 int64_t BlockTemplateEdge::block_in_arith() {
   std::string n;
   std::getline(std::cin, n);
-  return ((static_cast<int64_t>(n.length()) + INT64_C(1)) &
-          0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(static_cast<int64_t>(n.length())) +
+       static_cast<uint64_t>(INT64_C(1))) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 /// 3. Two block templates of same type back-to-back
@@ -42,5 +44,7 @@ int64_t BlockTemplateEdge::block_then_pure() {
   std::string s;
   std::getline(std::cin, s);
   int64_t n = static_cast<int64_t>(std::move(s).length());
-  return ((n + n) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(n) + static_cast<uint64_t>(n)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }

--- a/tests/regression/clock/clock.cpp
+++ b/tests/regression/clock/clock.cpp
@@ -30,5 +30,7 @@ int64_t Clock::elapsed() {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now().time_since_epoch())
           .count());
-  return ((t2 - t1) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(t2) - static_cast<uint64_t>(t1)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }

--- a/tests/regression/density_potential_trace/DensityPotentialTrace.v
+++ b/tests/regression/density_potential_trace/DensityPotentialTrace.v
@@ -84,6 +84,6 @@ Definition sample_massive_nonneg : bool :=
 End DensityPotentialTraceCase.
 
 Require Crane.Extraction.
-From Crane Require Mapping.NatIntStd Mapping.Real.
+From Crane Require Mapping.NatIntStd Mapping.ZInt Mapping.Real.
 
 Crane Extraction "density_potential_trace" DensityPotentialTraceCase.

--- a/tests/regression/deque_empty_ops/DequeEmptyOps.v
+++ b/tests/regression/deque_empty_ops/DequeEmptyOps.v
@@ -1,0 +1,26 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(**
+   Regression for the DequeList [map]/[flat_map]/[concat] mappings: their
+   result element type is inferred from the deque's [value_type], never from
+   [%aN.front()], so the operations are total on the empty deque (calling
+   [front()] on an empty deque would be undefined behaviour). Each operation is
+   wrapped in a function so it is exercised at runtime on both empty and
+   non-empty inputs supplied by the test driver (CWE-476 / CWE-125). *)
+From Crane Require Import Mapping.NatIntStd Mapping.DequeList.
+From Stdlib Require Import Nat List.
+Import ListNotations.
+Require Crane.Extraction.
+
+Module DequeEmptyOps.
+
+Definition double (n : nat) : nat := n * 2.
+Definition dup (n : nat) : list nat := [n; n].
+
+Definition run_map (l : list nat) : list nat := List.map double l.
+Definition run_flatmap (l : list nat) : list nat := List.flat_map dup l.
+Definition run_concat (l : list (list nat)) : list nat := List.concat l.
+
+End DequeEmptyOps.
+
+Crane Extraction "deque_empty_ops" DequeEmptyOps.

--- a/tests/regression/deque_empty_ops/deque_empty_ops.cpp
+++ b/tests/regression/deque_empty_ops/deque_empty_ops.cpp
@@ -1,0 +1,48 @@
+#include "deque_empty_ops.h"
+
+uint64_t DequeEmptyOps::double_(uint64_t n) { return (n * UINT64_C(2)); }
+
+std::deque<uint64_t> DequeEmptyOps::dup(uint64_t n) {
+  return [](auto _a0, auto _a1) {
+    _a1.push_front(_a0);
+    return _a1;
+  }(n, [](auto _a0, auto _a1) {
+    _a1.push_front(_a0);
+    return _a1;
+  }(n, std::deque<uint64_t>{}));
+}
+
+std::deque<uint64_t> DequeEmptyOps::run_map(const std::deque<uint64_t> &l) {
+  return [&]() {
+    std::deque<std::decay_t<decltype(double_(
+        std::declval<typename std::decay_t<decltype(l)>::value_type &>()))>>
+        _r;
+    for (const auto &_x : l)
+      _r.push_back(double_(_x));
+    return _r;
+  }();
+}
+
+std::deque<uint64_t> DequeEmptyOps::run_flatmap(const std::deque<uint64_t> &l) {
+  return [&]() {
+    std::deque<typename std::decay_t<decltype(dup(
+        std::declval<typename std::decay_t<decltype(l)>::value_type &>()))>::
+                   value_type>
+        _r;
+    for (const auto &_x : l) {
+      auto _s = dup(_x);
+      _r.insert(_r.end(), _s.begin(), _s.end());
+    }
+    return _r;
+  }();
+}
+
+std::deque<uint64_t>
+DequeEmptyOps::run_concat(const std::deque<std::deque<uint64_t>> &_x0) {
+  return [&]() {
+    std::deque<typename std::decay_t<decltype(_x0)>::value_type::value_type> _r;
+    for (const auto &_s : _x0)
+      _r.insert(_r.end(), _s.begin(), _s.end());
+    return _r;
+  }();
+}

--- a/tests/regression/deque_empty_ops/deque_empty_ops.h
+++ b/tests/regression/deque_empty_ops/deque_empty_ops.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDED_DEQUE_EMPTY_OPS
+#define INCLUDED_DEQUE_EMPTY_OPS
+
+#include <deque>
+#include <type_traits>
+#include <utility>
+
+struct DequeEmptyOps {
+  static uint64_t double_(uint64_t n);
+  static std::deque<uint64_t> dup(uint64_t n);
+  static std::deque<uint64_t> run_map(const std::deque<uint64_t> &l);
+  static std::deque<uint64_t> run_flatmap(const std::deque<uint64_t> &l);
+  static std::deque<uint64_t>
+  run_concat(const std::deque<std::deque<uint64_t>> &_x0);
+};
+
+#endif // INCLUDED_DEQUE_EMPTY_OPS

--- a/tests/regression/deque_empty_ops/deque_empty_ops.t.cpp
+++ b/tests/regression/deque_empty_ops/deque_empty_ops.t.cpp
@@ -1,0 +1,32 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+//
+// Regression: DequeList map/flat_map/concat must be total on empty deques.
+// Their result element type is inferred from value_type (not front()), so the
+// empty cases below construct and return an empty deque rather than reading
+// front() of an empty container.
+
+#include "deque_empty_ops.h"
+
+#include <cassert>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+
+int main() {
+  assert(DequeEmptyOps::run_map(std::deque<uint64_t>{}).empty());
+  assert((DequeEmptyOps::run_map(std::deque<uint64_t>{1, 2, 3}) ==
+          std::deque<uint64_t>{2, 4, 6}));
+
+  assert(DequeEmptyOps::run_flatmap(std::deque<uint64_t>{}).empty());
+  assert((DequeEmptyOps::run_flatmap(std::deque<uint64_t>{1, 2}) ==
+          std::deque<uint64_t>{1, 1, 2, 2}));
+
+  assert(DequeEmptyOps::run_concat(std::deque<std::deque<uint64_t>>{}).empty());
+  assert((DequeEmptyOps::run_concat(
+              std::deque<std::deque<uint64_t>>{{1, 2}, {3}}) ==
+          std::deque<uint64_t>{1, 2, 3}));
+
+  std::cout << "All deque_empty_ops tests passed!" << std::endl;
+  return 0;
+}

--- a/tests/regression/dir/dir.cpp
+++ b/tests/regression/dir/dir.cpp
@@ -1,20 +1,39 @@
 #include "dir.h"
 
 bool Dir::make_dir(std::string path) {
-  return std::filesystem::create_directories(std::filesystem::path(path));
+  return [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
 }
 
 bool Dir::remove_dir(std::string path) {
-  return std::filesystem::remove_all(std::filesystem::path(path));
+  return [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::remove_all(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
 }
 
-std::string Dir::get_cwd() { return std::filesystem::current_path().string(); }
+std::string Dir::get_cwd() {
+  return [&]() -> std::string {
+    std::error_code _ec;
+    auto _p = std::filesystem::current_path(_ec);
+    return _ec ? std::string{} : _p.string();
+  }();
+}
 
 List<std::string> Dir::list_dir(std::string path) {
   return [&]() -> List<std::string> {
     auto result = List<std::string>::nil();
-    for (const auto &entry : std::filesystem::directory_iterator(path)) {
-      result = List<std::string>::cons(entry.path().filename().string(),
+    std::error_code _ec;
+    std::size_t _count = 0;
+    std::filesystem::directory_iterator _it(std::filesystem::path(path), _ec),
+        _end;
+    for (; !_ec && _it != _end && _count < 65536;
+         _it.increment(_ec), ++_count) {
+      result = List<std::string>::cons(_it->path().filename().string(),
                                        std::move(result));
     }
     return result;

--- a/tests/regression/dir/dir.h
+++ b/tests/regression/dir/dir.h
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -290,6 +290,17 @@
   (deps record_defaults.t.exe)
   (action (run ./record_defaults.t.exe))))
 
+(subdir real_floor_guard
+ (rule
+  (targets real_floor_guard.t.exe)
+  (deps RealFloorGuard.vo real_floor_guard.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} real_floor_guard.t.exe real_floor_guard.cpp real_floor_guard.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps real_floor_guard.t.exe)
+  (action (run ./real_floor_guard.t.exe))))
+
 (subdir setoid_rw
  (rule
   (targets setoid_rw.t.exe)

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -5971,6 +5971,17 @@
   (deps deque_element_cast.t.exe)
   (action (run ./deque_element_cast.t.exe))))
 
+(subdir deque_empty_ops
+ (rule
+  (targets deque_empty_ops.t.exe)
+  (deps DequeEmptyOps.vo deque_empty_ops.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} deque_empty_ops.t.exe deque_empty_ops.cpp deque_empty_ops.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps deque_empty_ops.t.exe)
+  (action (run ./deque_empty_ops.t.exe))))
+
 (subdir deque_action_mismatch
  (rule
   (targets deque_action_mismatch.t.exe)

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -3604,6 +3604,17 @@
   (deps loopify_coind_stream.t.exe)
   (action (run ./loopify_coind_stream.t.exe))))
 
+(subdir itree_invariants
+ (rule
+  (targets itree_invariants.t.exe)
+  (deps ItreeInvariants.vo itree_invariants.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} itree_invariants.t.exe itree_invariants.cpp itree_invariants.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps itree_invariants.t.exe)
+  (action (run ./itree_invariants.t.exe))))
+
 (subdir loopify_itree_reified
  (rule
   (targets loopify_itree_reified.t.exe)

--- a/tests/regression/dune
+++ b/tests/regression/dune
@@ -34,6 +34,20 @@
   (deps benchmark_matrix.t.exe)
   (action (run ./benchmark_matrix.t.exe))))
 
+(subdir extraction_path_traversal
+ ; Security regression: the assertions run while the .vo is built (Fail commands
+ ; reject path-traversal extraction targets). The .t.cpp is a shim so the
+ ; standard test runner still sees and depends on the fixture.
+ (rule
+  (targets extraction_path_traversal.t.exe)
+  (deps ExtractionPathTraversal.vo extraction_path_traversal.t.cpp)
+  (action
+   (run clang++ -std=c++23 -o extraction_path_traversal.t.exe extraction_path_traversal.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps extraction_path_traversal.t.exe)
+  (action (run ./extraction_path_traversal.t.exe))))
+
 (subdir any_cast_nested
  (rule
   (targets any_cast_nested.t.exe)

--- a/tests/regression/effect_complex_return/effect_complex_return.cpp
+++ b/tests/regression/effect_complex_return/effect_complex_return.cpp
@@ -62,7 +62,9 @@ int64_t EffectComplexReturn::elapsed_ms() {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now().time_since_epoch())
           .count());
-  return ((t2 - t1) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(t2) - static_cast<uint64_t>(t1)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 /// 6. Effect result used to build a list

--- a/tests/regression/effect_deep_compose/effect_deep_compose.cpp
+++ b/tests/regression/effect_deep_compose/effect_deep_compose.cpp
@@ -12,7 +12,9 @@ int64_t EffectDeepCompose::timed_env_op(std::string name, std::string value) {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now().time_since_epoch())
           .count());
-  return ((t2 - t1) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(t2) - static_cast<uint64_t>(t1)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 /// 2. Function using only console from inside bigE

--- a/tests/regression/effect_dir_path/effect_dir_path.cpp
+++ b/tests/regression/effect_dir_path/effect_dir_path.cpp
@@ -4,8 +4,13 @@
 std::optional<std::string> EffectDirPath::first_file(std::string path) {
   List<std::string> files = [&]() -> List<std::string> {
     auto result = List<std::string>::nil();
-    for (const auto &entry : std::filesystem::directory_iterator(path)) {
-      result = List<std::string>::cons(entry.path().filename().string(),
+    std::error_code _ec;
+    std::size_t _count = 0;
+    std::filesystem::directory_iterator _it(std::filesystem::path(path), _ec),
+        _end;
+    for (; !_ec && _it != _end && _count < 65536;
+         _it.increment(_ec), ++_count) {
+      result = List<std::string>::cons(_it->path().filename().string(),
                                        std::move(result));
     }
     return result;
@@ -20,14 +25,21 @@ std::optional<std::string> EffectDirPath::first_file(std::string path) {
 
 /// 2. current_path (zero args) chained to env
 void EffectDirPath::save_cwd() {
-  std::string cwd = std::filesystem::current_path().string();
+  std::string cwd = [&]() -> std::string {
+    std::error_code _ec;
+    auto _p = std::filesystem::current_path(_ec);
+    return _ec ? std::string{} : _p.string();
+  }();
   setenv("CWD"s.c_str(), std::move(cwd).c_str(), 1);
   return;
 }
 
 /// 3. is_directory bool result used in conditional with effects in arms
 std::optional<std::string> EffectDirPath::check_and_list(std::string path) {
-  bool isdir = std::filesystem::is_directory(std::filesystem::path(path));
+  bool isdir = [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::is_directory(std::filesystem::path(path), _ec);
+  }();
   if (isdir) {
     return first_file(path);
   } else {
@@ -37,16 +49,25 @@ std::optional<std::string> EffectDirPath::check_and_list(std::string path) {
 
 /// 4. Path effect result chained to print
 void EffectDirPath::show_absolute(std::string path) {
-  std::string abs =
-      std::filesystem::absolute(std::filesystem::path(path)).string();
+  std::string abs = [&]() -> std::string {
+    std::error_code _ec;
+    auto _r = std::filesystem::absolute(std::filesystem::path(path), _ec);
+    return _ec ? std::string{} : _r.string();
+  }();
   std::cout << std::move(abs) << '\n';
   return;
 }
 
 /// 5. Multiple bool effects composed
 std::string EffectDirPath::classify_path(std::string path) {
-  bool isdir = std::filesystem::is_directory(std::filesystem::path(path));
-  bool isfile = std::filesystem::is_regular_file(std::filesystem::path(path));
+  bool isdir = [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::is_directory(std::filesystem::path(path), _ec);
+  }();
+  bool isfile = [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::is_regular_file(std::filesystem::path(path), _ec);
+  }();
   if (isdir) {
     return "directory";
   } else {
@@ -60,7 +81,11 @@ std::string EffectDirPath::classify_path(std::string path) {
 
 /// 6. create_directory bool result explicitly bound and used
 std::string EffectDirPath::create_and_report(std::string path) {
-  bool ok = std::filesystem::create_directories(std::filesystem::path(path));
+  bool ok = [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
   if (ok) {
     std::cout << "Created"s << '\n';
     return "created";
@@ -79,8 +104,13 @@ uint64_t EffectDirPath::count_entries(const List<std::string> &dirs,
     const auto &[a0, a1] = std::get<typename List<std::string>::Cons>(dirs.v());
     List<std::string> files = [&]() -> List<std::string> {
       auto result = List<std::string>::nil();
-      for (const auto &entry : std::filesystem::directory_iterator(a0)) {
-        result = List<std::string>::cons(entry.path().filename().string(),
+      std::error_code _ec;
+      std::size_t _count = 0;
+      std::filesystem::directory_iterator _it(std::filesystem::path(a0), _ec),
+          _end;
+      for (; !_ec && _it != _end && _count < 65536;
+           _it.increment(_ec), ++_count) {
+        result = List<std::string>::cons(_it->path().filename().string(),
                                          std::move(result));
       }
       return result;
@@ -92,7 +122,11 @@ uint64_t EffectDirPath::count_entries(const List<std::string> &dirs,
 
 /// 8. remove_directory (returns bool but treated as unit in bind)
 void EffectDirPath::cleanup(std::string path) {
-  bool _x = std::filesystem::remove_all(std::filesystem::path(path));
+  bool _x = [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::remove_all(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
   std::cout << "cleaned up"s << '\n';
   return;
 }

--- a/tests/regression/effect_dir_path/effect_dir_path.h
+++ b/tests/regression/effect_dir_path/effect_dir_path.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/tests/regression/effect_list_return/effect_list_return.cpp
+++ b/tests/regression/effect_list_return/effect_list_return.cpp
@@ -4,8 +4,13 @@
 List<std::string> EffectListReturn::list_files(std::string path) {
   return [&]() -> List<std::string> {
     auto result = List<std::string>::nil();
-    for (const auto &entry : std::filesystem::directory_iterator(path)) {
-      result = List<std::string>::cons(entry.path().filename().string(),
+    std::error_code _ec;
+    std::size_t _count = 0;
+    std::filesystem::directory_iterator _it(std::filesystem::path(path), _ec),
+        _end;
+    for (; !_ec && _it != _end && _count < 65536;
+         _it.increment(_ec), ++_count) {
+      result = List<std::string>::cons(_it->path().filename().string(),
                                        std::move(result));
     }
     return result;
@@ -14,7 +19,11 @@ List<std::string> EffectListReturn::list_files(std::string path) {
 
 /// 2. create dir and verify
 bool EffectListReturn::make_and_check(std::string path) {
-  return std::filesystem::create_directories(std::filesystem::path(path));
+  return [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
 }
 
 /// 3. get_time result used in pair
@@ -30,18 +39,31 @@ std::pair<int64_t, std::string> EffectListReturn::timestamped_line() {
 
 /// 4. current_path as a no-arg effect
 std::string EffectListReturn::get_cwd() {
-  return std::filesystem::current_path().string();
+  return [&]() -> std::string {
+    std::error_code _ec;
+    auto _p = std::filesystem::current_path(_ec);
+    return _ec ? std::string{} : _p.string();
+  }();
 }
 
 /// 5. Chain effects with different return types
 std::pair<bool, List<std::string>>
 EffectListReturn::create_and_list(std::string dir) {
-  bool ok = std::filesystem::create_directories(std::filesystem::path(dir));
+  bool ok = [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(dir), _ec);
+    return !_ec;
+  }();
   if (ok) {
     List<std::string> files = [&]() -> List<std::string> {
       auto result = List<std::string>::nil();
-      for (const auto &entry : std::filesystem::directory_iterator(dir)) {
-        result = List<std::string>::cons(entry.path().filename().string(),
+      std::error_code _ec;
+      std::size_t _count = 0;
+      std::filesystem::directory_iterator _it(std::filesystem::path(dir), _ec),
+          _end;
+      for (; !_ec && _it != _end && _count < 65536;
+           _it.increment(_ec), ++_count) {
+        result = List<std::string>::cons(_it->path().filename().string(),
                                          std::move(result));
       }
       return result;

--- a/tests/regression/effect_list_return/effect_list_return.h
+++ b/tests/regression/effect_list_return/effect_list_return.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/tests/regression/effect_unit_stress/effect_unit_stress.cpp
+++ b/tests/regression/effect_unit_stress/effect_unit_stress.cpp
@@ -74,7 +74,9 @@ int64_t EffectUnitStress::let_pure_in_monadic() {
   std::string s;
   std::getline(std::cin, s);
   int64_t n = static_cast<int64_t>(std::move(s).length());
-  int64_t m = ((n + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL);
+  int64_t m = static_cast<int64_t>(
+      (static_cast<uint64_t>(n) + static_cast<uint64_t>(INT64_C(1))) &
+      0x7FFFFFFFFFFFFFFFULL);
   return m;
 }
 

--- a/tests/regression/effect_workflow/effect_workflow.cpp
+++ b/tests/regression/effect_workflow/effect_workflow.cpp
@@ -10,19 +10,23 @@ std::string EffectWorkflow::full_workflow(std::string prefix) {
     std::string _n = std::filesystem::path(prefix).filename().string();
     if (_n.empty() || _n == "." || _n == "..")
       _n = "tmp";
-    std::filesystem::path _dir = std::filesystem::temp_directory_path();
+    std::filesystem::path _base = std::filesystem::temp_directory_path();
     std::random_device _rng;
     for (;;) {
-      std::string _p =
-          (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng())))
+      std::string _d =
+          (_base / (_n + std::to_string(_rng()) + std::to_string(_rng())))
               .string();
-      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-      if (_fd >= 0) {
-        ::close(_fd);
-        return _p;
+      if (::mkdir(_d.c_str(), 0700) != 0) {
+        if (errno == EEXIST)
+          continue;
+        throw std::runtime_error("crane: failed to create temporary directory");
       }
-      if (errno != EEXIST)
+      std::string _p = _d + "/" + _n;
+      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+      if (_fd < 0)
         throw std::runtime_error("crane: failed to create temporary file");
+      ::close(_fd);
+      return _p;
     }
   }();
   bool _x0 = std::filesystem::create_directories(std::filesystem::path(tmp));

--- a/tests/regression/effect_workflow/effect_workflow.cpp
+++ b/tests/regression/effect_workflow/effect_workflow.cpp
@@ -7,12 +7,23 @@ std::string EffectWorkflow::full_workflow(std::string prefix) {
           std::chrono::steady_clock::now().time_since_epoch())
           .count());
   std::string tmp = [&]() -> std::string {
-    auto p = std::filesystem::temp_directory_path() / (prefix + "XXXXXX");
-    std::string s = p.string();
-    int fd = mkstemp(s.data());
-    if (fd >= 0)
-      ::close(fd);
-    return s;
+    std::string _n = std::filesystem::path(prefix).filename().string();
+    if (_n.empty() || _n == "." || _n == "..")
+      _n = "tmp";
+    std::filesystem::path _dir = std::filesystem::temp_directory_path();
+    std::random_device _rng;
+    for (;;) {
+      std::string _p =
+          (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng())))
+              .string();
+      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+      if (_fd >= 0) {
+        ::close(_fd);
+        return _p;
+      }
+      if (errno != EEXIST)
+        throw std::runtime_error("crane: failed to create temporary file");
+    }
   }();
   bool _x0 = std::filesystem::create_directories(std::filesystem::path(tmp));
   setenv("LAST_TEMP"s.c_str(), tmp.c_str(), 1);

--- a/tests/regression/effect_workflow/effect_workflow.cpp
+++ b/tests/regression/effect_workflow/effect_workflow.cpp
@@ -29,7 +29,11 @@ std::string EffectWorkflow::full_workflow(std::string prefix) {
       return _p;
     }
   }();
-  bool _x0 = std::filesystem::create_directories(std::filesystem::path(tmp));
+  bool _x0 = [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(tmp), _ec);
+    return !_ec;
+  }();
   setenv("LAST_TEMP"s.c_str(), tmp.c_str(), 1);
   std::cout << tmp << '\n';
   int64_t _x3 = static_cast<int64_t>(
@@ -41,7 +45,11 @@ std::string EffectWorkflow::full_workflow(std::string prefix) {
 
 /// 2. Match on bool from create_directory inside a chain
 std::string EffectWorkflow::conditional_create(std::string path) {
-  bool ok = std::filesystem::create_directories(std::filesystem::path(path));
+  bool ok = [&]() -> bool {
+    std::error_code _ec;
+    std::filesystem::create_directories(std::filesystem::path(path), _ec);
+    return !_ec;
+  }();
   if (ok) {
     std::cout << "created"s << '\n';
     return path;
@@ -84,7 +92,11 @@ std::string EffectWorkflow::env_or_create(std::string name, std::string path) {
     const std::string &v = *r;
     return v;
   } else {
-    bool _x = std::filesystem::create_directories(std::filesystem::path(path));
+    bool _x = [&]() -> bool {
+      std::error_code _ec;
+      std::filesystem::create_directories(std::filesystem::path(path), _ec);
+      return !_ec;
+    }();
     setenv(name.c_str(), path.c_str(), 1);
     return path;
   }

--- a/tests/regression/effect_workflow/effect_workflow.h
+++ b/tests/regression/effect_workflow/effect_workflow.h
@@ -1,14 +1,19 @@
 #ifndef INCLUDED_EFFECT_WORKFLOW
 #define INCLUDED_EFFECT_WORKFLOW
 
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <fcntl.h>
 #include <filesystem>
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <random>
+#include <stdexcept>
 #include <string>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <utility>
 #include <variant>

--- a/tests/regression/effect_workflow/effect_workflow.h
+++ b/tests/regression/effect_workflow/effect_workflow.h
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <sys/stat.h>
+#include <system_error>
 #include <unistd.h>
 #include <utility>
 #include <variant>

--- a/tests/regression/extraction_path_traversal/ExtractionPathTraversal.v
+++ b/tests/regression/extraction_path_traversal/ExtractionPathTraversal.v
@@ -1,0 +1,22 @@
+(* Copyright 2025 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+
+(* Security regression: a Crane extraction target filename must stay within the
+   configured output directory. Absolute paths and parent-directory ('..')
+   traversal are rejected before any file is written (CWE-22 / CWE-73). The
+   substantive assertions run while ExtractionPathTraversal.vo is built. *)
+Require Crane.Extraction.
+
+Definition ok : bool := true.
+
+(* Absolute paths are rejected. *)
+Fail Crane Extraction "/tmp/crane_escape" ok.
+
+(* Parent-directory traversal is rejected, whether leading or hidden mid-path. *)
+Fail Crane Extraction ".." ok.
+Fail Crane Extraction "../crane_escape" ok.
+Fail Crane Extraction "sub/../../crane_escape" ok.
+
+(* The same guard protects the TestCompile variant, which shares the code path
+   that derives output paths from the target filename. *)
+Fail Crane Extraction TestCompile "../crane_escape" ok.

--- a/tests/regression/extraction_path_traversal/extraction_path_traversal.t.cpp
+++ b/tests/regression/extraction_path_traversal/extraction_path_traversal.t.cpp
@@ -1,0 +1,8 @@
+// Copyright 2025 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+
+// The security assertions run while ExtractionPathTraversal.vo is built: the
+// Fail commands reject path-traversal extraction targets before any file is
+// written. This executable makes the fixture visible to Crane's standard test
+// runner.
+int main() { return 0; }

--- a/tests/regression/fold_sequence_state_trace/FoldSequenceStateTrace.v
+++ b/tests/regression/fold_sequence_state_trace/FoldSequenceStateTrace.v
@@ -147,6 +147,6 @@ Definition sample_has_expected_lines : bool :=
 End FoldSequenceStateTraceCase.
 
 Require Crane.Extraction.
-From Crane Require Mapping.NatIntStd Mapping.Real.
+From Crane Require Mapping.NatIntStd Mapping.ZInt Mapping.Real.
 
 Crane Extraction "fold_sequence_state_trace" FoldSequenceStateTraceCase.

--- a/tests/regression/itree_invariants/ItreeInvariants.v
+++ b/tests/regression/itree_invariants/ItreeInvariants.v
@@ -1,0 +1,36 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(**
+   Regression harness for the reified ITree runtime invariants
+   ([theories/cpp/crane_itree.h]).  The Rocq side only needs to force the
+   generated header to include <crane_itree.h>; the actual invariant checks
+   (null continuations rejected, Ret re-runnable, run keeps its node alive)
+   live in [itree_invariants.t.cpp], which drives the C++ runtime type
+   directly. *)
+From Stdlib Require Import Nat.
+From Crane Require Import Mapping.Std Mapping.NatIntStd Monads.ITreeReified.
+Require Crane.Extraction.
+
+Module IO_axioms.
+  Axiom ioE : Type -> Type.
+End IO_axioms.
+Crane Extract Skip Module IO_axioms.
+Export IO_axioms.
+
+Module ItreeInvariants.
+
+(** Emitted so the generated header includes <crane_itree.h>. *)
+Fixpoint count_taus (fuel : nat) (t : itree ioE nat) : nat :=
+  match fuel with
+  | 0 => 0
+  | S fuel' =>
+    match observe t with
+    | RetF _ => 0
+    | TauF t' => S (count_taus fuel' t')
+    | VisF _ _ => 0
+    end
+  end.
+
+End ItreeInvariants.
+
+Crane Extraction "itree_invariants" ItreeInvariants.

--- a/tests/regression/itree_invariants/itree_invariants.cpp
+++ b/tests/regression/itree_invariants/itree_invariants.cpp
@@ -1,0 +1,27 @@
+#include "itree_invariants.h"
+
+/// Emitted so the generated header includes <crane_itree.h>.
+uint64_t
+ItreeInvariants::count_taus(uint64_t fuel,
+                            const std::shared_ptr<ITree<uint64_t>> &t) {
+  if (fuel <= 0) {
+    return UINT64_C(0);
+  } else {
+    uint64_t fuel_ = fuel - 1;
+    auto _cs = t->observe();
+    if (std::holds_alternative<typename ITree<uint64_t>::Ret>(_cs)) {
+      const auto &_itf = *std::get_if<typename ITree<uint64_t>::Ret>(&_cs);
+      auto _x = _itf.value;
+      return UINT64_C(0);
+    } else if (std::holds_alternative<typename ITree<uint64_t>::Tau>(_cs)) {
+      const auto &_itf = *std::get_if<typename ITree<uint64_t>::Tau>(&_cs);
+      auto t_ = _itf.next;
+      return (count_taus(fuel_, t_) + 1);
+    } else {
+      const auto &_itf = *std::get_if<typename ITree<uint64_t>::Vis>(&_cs);
+      auto _x = _itf.effect;
+      auto _x0 = _itf.cont;
+      return UINT64_C(0);
+    }
+  }
+}

--- a/tests/regression/itree_invariants/itree_invariants.h
+++ b/tests/regression/itree_invariants/itree_invariants.h
@@ -1,0 +1,12 @@
+#ifndef INCLUDED_ITREE_INVARIANTS
+#define INCLUDED_ITREE_INVARIANTS
+
+#include <crane_itree.h>
+
+struct ItreeInvariants {
+  /// Emitted so the generated header includes <crane_itree.h>.
+  static uint64_t count_taus(uint64_t fuel,
+                             const std::shared_ptr<ITree<uint64_t>> &t);
+};
+
+#endif // INCLUDED_ITREE_INVARIANTS

--- a/tests/regression/itree_invariants/itree_invariants.t.cpp
+++ b/tests/regression/itree_invariants/itree_invariants.t.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+//
+// Regression for the reified ITree runtime invariants (crane_itree.h):
+//   * factories reject null Tau next / null Vis effect+continuation (finding 132)
+//   * a Ret tree can be run more than once without corruption (finding 37)
+//   * ITree<void>::run keeps the node alive via shared ownership (finding 86):
+//     an effect that drops every other owner must not free the running node.
+
+#include "itree_invariants.h"
+
+#include <any>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+int main() {
+  // finding 132: null Tau next rejected.
+  {
+    bool threw = false;
+    try {
+      ITree<int>::tau(nullptr);
+    } catch (const std::invalid_argument &) {
+      threw = true;
+    }
+    assert(threw);
+  }
+
+  // finding 132: null Vis continuation rejected.
+  {
+    bool threw = false;
+    try {
+      ITree<int>::vis([]() -> std::any { return std::any{}; },
+                      std::function<std::shared_ptr<ITree<int>>(std::any)>());
+    } catch (const std::invalid_argument &) {
+      threw = true;
+    }
+    assert(threw);
+  }
+
+  // finding 37: a Ret tree is re-runnable (payload copied, not moved out).
+  {
+    auto t = ITree<int>::ret(7);
+    assert(t->run() == 7);
+    assert(t->run() == 7);
+  }
+
+  // finding 86: a void effect that drops the last external owner must not free
+  // the node out from under run().  The tree owns itself only through [holder]
+  // here; the effect clears [holder], leaving run()'s own shared_from_this
+  // reference as the sole keeper.
+  {
+    auto holder = std::make_shared<std::shared_ptr<ITree<void>>>();
+    *holder = ITree<void>::vis(
+        [holder]() -> std::any {
+          *holder = nullptr; // drop the external owner mid-run
+          return std::any{};
+        },
+        [](std::any) { return ITree<void>::ret(); });
+    (*holder)->run();
+  }
+
+  std::cout << "All itree_invariants tests passed!" << std::endl;
+  return 0;
+}

--- a/tests/regression/monadic_closure/monadic_closure.cpp
+++ b/tests/regression/monadic_closure/monadic_closure.cpp
@@ -4,9 +4,10 @@
 int64_t MonadicClosure::capture_bind() {
   std::string line;
   std::getline(std::cin, line);
-  return ((_capture_bind_f(UINT64_C(0), line) +
-           _capture_bind_f(UINT64_C(1), line)) &
-          0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(_capture_bind_f(UINT64_C(0), line)) +
+       static_cast<uint64_t>(_capture_bind_f(UINT64_C(1), line))) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 int64_t MonadicClosure::test_apply_after() {
@@ -29,8 +30,11 @@ std::function<std::string(std::string)> MonadicClosure::make_greeter() {
 }
 
 int64_t MonadicClosure::test_with_length() {
-  return with_length(
-      [](int64_t n) { return ((n + INT64_C(1)) & 0x7FFFFFFFFFFFFFFFLL); });
+  return with_length([](int64_t n) {
+    return static_cast<int64_t>(
+        (static_cast<uint64_t>(n) + static_cast<uint64_t>(INT64_C(1))) &
+        0x7FFFFFFFFFFFFFFFULL);
+  });
 }
 
 /// 5. Nested closures over bindings
@@ -41,7 +45,9 @@ int64_t MonadicClosure::nested_capture() {
   std::getline(std::cin, b);
   int64_t la = static_cast<int64_t>(std::move(a).length());
   int64_t lb = static_cast<int64_t>(std::move(b).length());
-  return ((la + lb) & 0x7FFFFFFFFFFFFFFFLL);
+  return static_cast<int64_t>(
+      (static_cast<uint64_t>(la) + static_cast<uint64_t>(lb)) &
+      0x7FFFFFFFFFFFFFFFULL);
 }
 
 uint64_t MonadicClosure::test_count() {

--- a/tests/regression/numeral_edge/numeral_edge.h
+++ b/tests/regression/numeral_edge/numeral_edge.h
@@ -640,8 +640,10 @@ struct NumeralEdge {
   static inline const int64_t z_pow2_30 = INT64_C(1073741824);
   /// 5. Numerals in arithmetic expressions
   static inline const uint64_t add_numerals = (UINT64_C(100) + UINT64_C(200));
-  static inline const int64_t mul_numerals = (INT64_C(10) * INT64_C(20));
-  static inline const int64_t sub_numerals = (INT64_C(100) - INT64_C(1));
+  static inline const int64_t mul_numerals = static_cast<int64_t>(
+      static_cast<uint64_t>(INT64_C(10)) * static_cast<uint64_t>(INT64_C(20)));
+  static inline const int64_t sub_numerals = static_cast<int64_t>(
+      static_cast<uint64_t>(INT64_C(100)) - static_cast<uint64_t>(INT64_C(1)));
   /// 6. Numeral as function argument
   static uint64_t take_nat(uint64_t n);
   static inline const uint64_t test_arg = take_nat(UINT64_C(42));
@@ -662,7 +664,10 @@ struct NumeralEdge {
   static bool is_big(uint64_t n);
   /// 12. Multiple Z values in one function
   static inline const int64_t z_arith =
-      (INT64_C(10) + (INT64_C(3) * INT64_C(7)));
+      static_cast<int64_t>(static_cast<uint64_t>(INT64_C(10)) +
+                           static_cast<uint64_t>(static_cast<int64_t>(
+                               static_cast<uint64_t>(INT64_C(3)) *
+                               static_cast<uint64_t>(INT64_C(7)))));
   /// 13. Negative Z in a pair
   static inline const std::pair<int64_t, int64_t> z_pair =
       std::make_pair(INT64_C(-42), INT64_C(42));

--- a/tests/regression/numeral_stress/numeral_stress.cpp
+++ b/tests/regression/numeral_stress/numeral_stress.cpp
@@ -21,5 +21,6 @@ bool NumeralStress::check_range(uint64_t n) {
 
 /// 10. Mixed nat and Z in one function
 int64_t NumeralStress::mixed_arith(uint64_t n) {
-  return (static_cast<int64_t>(n) + INT64_C(100));
+  return static_cast<int64_t>(static_cast<uint64_t>(static_cast<int64_t>(n)) +
+                              static_cast<uint64_t>(INT64_C(100)));
 }

--- a/tests/regression/numeral_stress/numeral_stress.h
+++ b/tests/regression/numeral_stress/numeral_stress.h
@@ -126,8 +126,13 @@ struct NumeralStress {
   static inline const uint64_t test_count =
       count_from(UINT64_C(100), UINT64_C(50));
   /// 7. Z arithmetic with literals
-  static inline const int64_t z_complex =
-      ((INT64_C(100) * INT64_C(200)) + (INT64_C(50) - INT64_C(25)));
+  static inline const int64_t z_complex = static_cast<int64_t>(
+      static_cast<uint64_t>(
+          static_cast<int64_t>(static_cast<uint64_t>(INT64_C(100)) *
+                               static_cast<uint64_t>(INT64_C(200)))) +
+      static_cast<uint64_t>(
+          static_cast<int64_t>(static_cast<uint64_t>(INT64_C(50)) -
+                               static_cast<uint64_t>(INT64_C(25)))));
 
   /// 8. Multiple numerals in one record
   struct point {

--- a/tests/regression/path/path.cpp
+++ b/tests/regression/path/path.cpp
@@ -1,21 +1,39 @@
 #include "path.h"
 
 std::string Path::abs_path(std::string p) {
-  return std::filesystem::absolute(std::filesystem::path(p)).string();
+  return [&]() -> std::string {
+    std::error_code _ec;
+    auto _r = std::filesystem::absolute(std::filesystem::path(p), _ec);
+    return _ec ? std::string{} : _r.string();
+  }();
 }
 
 std::string Path::canon_path(std::string p) {
-  return std::filesystem::canonical(std::filesystem::path(p)).string();
+  return [&]() -> std::string {
+    std::error_code _ec;
+    auto _r = std::filesystem::canonical(std::filesystem::path(p), _ec);
+    return _ec ? std::string{} : _r.string();
+  }();
 }
 
 std::string Path::rel_path(std::string p) {
-  return std::filesystem::relative(std::filesystem::path(p)).string();
+  return [&]() -> std::string {
+    std::error_code _ec;
+    auto _r = std::filesystem::relative(std::filesystem::path(p), _ec);
+    return _ec ? std::string{} : _r.string();
+  }();
 }
 
 bool Path::check_is_dir(std::string p) {
-  return std::filesystem::is_directory(std::filesystem::path(p));
+  return [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::is_directory(std::filesystem::path(p), _ec);
+  }();
 }
 
 bool Path::check_is_file(std::string p) {
-  return std::filesystem::is_regular_file(std::filesystem::path(p));
+  return [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::is_regular_file(std::filesystem::path(p), _ec);
+  }();
 }

--- a/tests/regression/path/path.h
+++ b/tests/regression/path/path.h
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <string>
+#include <system_error>
 
 struct Path {
   static std::string abs_path(std::string p);

--- a/tests/regression/ping_pong/ping_pong.cpp
+++ b/tests/regression/ping_pong/ping_pong.cpp
@@ -24,7 +24,8 @@ void PingPong::run_game(uint64_t round) {
                 << '\n';
       _loop_round = (_loop_round + 1);
     } else {
-      std::cout << "You said '"s + response + "' — game over!"s << '\n';
+      std::cout << "You said '"s + response + "' \342\200\224 game over!"s
+                << '\n';
       return;
     }
   }

--- a/tests/regression/polygon_winding_area_trace/PolygonWindingAreaTrace.v
+++ b/tests/regression/polygon_winding_area_trace/PolygonWindingAreaTrace.v
@@ -151,6 +151,6 @@ Definition sample_centroid_winding_gt_half : bool :=
 End PolygonWindingAreaTraceCase.
 
 Require Crane.Extraction.
-From Crane Require Mapping.NatIntStd Mapping.Real.
+From Crane Require Mapping.NatIntStd Mapping.ZInt Mapping.Real.
 
 Crane Extraction "polygon_winding_area_trace" PolygonWindingAreaTraceCase.

--- a/tests/regression/polygon_winding_area_trace/polygon_winding_area_trace.cpp
+++ b/tests/regression/polygon_winding_area_trace/polygon_winding_area_trace.cpp
@@ -2,8 +2,11 @@
 
 int64_t BinInt::pow_pos(int64_t z, unsigned int _x0) {
   return Pos::template iter<int64_t>(
-      [=](int64_t _x0) mutable -> int64_t { return (z * _x0); }, INT64_C(1),
-      _x0);
+      [=](int64_t _x0) mutable -> int64_t {
+        return static_cast<int64_t>(static_cast<uint64_t>(z) *
+                                    static_cast<uint64_t>(_x0));
+      },
+      INT64_C(1), _x0);
 }
 
 Real PolygonWindingAreaTraceCase::hav(Real theta) {

--- a/tests/regression/primitive_rec_typeclass/primitive_rec_typeclass.h
+++ b/tests/regression/primitive_rec_typeclass/primitive_rec_typeclass.h
@@ -34,6 +34,7 @@ struct PrimitiveRecTypeclass {
   static_assert(HasNorm<vec3Norm, vec3>);
 
   template <typename _tcI0, typename T1>
+    requires HasNorm<_tcI0, T1>
   static uint64_t double_norm(const T1 &x) {
     return (_tcI0::norm(x) + _tcI0::norm(x));
   }

--- a/tests/regression/read_variable_capture/read_variable_capture.cpp
+++ b/tests/regression/read_variable_capture/read_variable_capture.cpp
@@ -30,7 +30,10 @@ std::string ReadVariableCapture::read_variable(std::string path) {
 /// but that's a plain expression, not a lambda, so it works.
 /// This test is for read specifically.
 std::string ReadVariableCapture::read_and_check(std::string path) {
-  bool ok = std::filesystem::exists(std::filesystem::path(path));
+  bool ok = [&]() -> bool {
+    std::error_code _ec;
+    return std::filesystem::exists(std::filesystem::path(path), _ec);
+  }();
   if (ok) {
     return [&]() -> std::string {
       std::ifstream file(path);

--- a/tests/regression/read_variable_capture/read_variable_capture.h
+++ b/tests/regression/read_variable_capture/read_variable_capture.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <system_error>
 
 using namespace std::string_literals;
 

--- a/tests/regression/real_floor_guard/RealFloorGuard.v
+++ b/tests/regression/real_floor_guard/RealFloorGuard.v
@@ -1,0 +1,18 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+(**
+   Regression harness for the Real floor guard (theories/cpp/crane_real.h).
+   The Rocq side only forces the generated header to include <crane_real.h>;
+   the actual checks (NaN / infinity / out-of-range doubles do not invoke
+   undefined behaviour when floored to int64_t) live in
+   real_floor_guard.t.cpp, which drives the shipped [r_floor_z] helper
+   directly. *)
+From Crane Require Extraction.
+From Crane Require Import Mapping.Real.
+From Stdlib Require Import Reals.
+
+Module RealFloorGuard.
+Definition anchor : R := R0.
+End RealFloorGuard.
+
+Crane Extraction "real_floor_guard" RealFloorGuard.

--- a/tests/regression/real_floor_guard/real_floor_guard.cpp
+++ b/tests/regression/real_floor_guard/real_floor_guard.cpp
@@ -1,0 +1,1 @@
+#include "real_floor_guard.h"

--- a/tests/regression/real_floor_guard/real_floor_guard.h
+++ b/tests/regression/real_floor_guard/real_floor_guard.h
@@ -1,0 +1,10 @@
+#ifndef INCLUDED_REAL_FLOOR_GUARD
+#define INCLUDED_REAL_FLOOR_GUARD
+
+#include <crane_real.h>
+
+struct RealFloorGuard {
+  static inline const Real anchor = Real(0.0L);
+};
+
+#endif // INCLUDED_REAL_FLOOR_GUARD

--- a/tests/regression/real_floor_guard/real_floor_guard.t.cpp
+++ b/tests/regression/real_floor_guard/real_floor_guard.t.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+//
+// Regression for the Real floor guard (crane_real.h): flooring a NaN, an
+// infinity, or a value outside the int64_t range to int64_t must not invoke
+// undefined behaviour.  Rocq's floor is total, so r_floor_z stays total —
+// NaN maps to 0 and out-of-range magnitudes saturate to the int64_t bounds.
+
+#include "real_floor_guard.h"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+int main() {
+  // Ordinary values floor as usual.
+  assert(r_floor_z(Real(3.7L)) == 3);
+  assert(r_floor_z(Real(-2.5L)) == -3);
+  assert(r_floor_z(Real(0.0L)) == 0);
+  assert(r_floor_z(Real(-0.0L)) == 0);
+
+  // Non-finite and out-of-range inputs must be total, not UB.
+  const long double inf = std::numeric_limits<long double>::infinity();
+  const long double nan = std::numeric_limits<long double>::quiet_NaN();
+  assert(r_floor_z(Real(inf)) == INT64_MAX);
+  assert(r_floor_z(Real(-inf)) == INT64_MIN);
+  assert(r_floor_z(Real(nan)) == 0);
+  assert(r_floor_z(Real(1e30L)) == INT64_MAX);
+  assert(r_floor_z(Real(-1e30L)) == INT64_MIN);
+
+  // A value produced by division-by-zero (infinity) also stays safe.
+  assert(r_floor_z(Real(1.0L) / Real(0.0L)) == INT64_MAX);
+
+  std::cout << "All real_floor_guard tests passed!" << std::endl;
+  return 0;
+}

--- a/tests/regression/temp_file/temp_file.cpp
+++ b/tests/regression/temp_file/temp_file.cpp
@@ -2,19 +2,41 @@
 
 std::string TempFile::make_temp_file(std::string prefix) {
   return [&]() -> std::string {
-    auto p = std::filesystem::temp_directory_path() / (prefix + "XXXXXX");
-    std::string s = p.string();
-    int fd = mkstemp(s.data());
-    if (fd >= 0)
-      ::close(fd);
-    return s;
+    std::string _n = std::filesystem::path(prefix).filename().string();
+    if (_n.empty() || _n == "." || _n == "..")
+      _n = "tmp";
+    std::filesystem::path _dir = std::filesystem::temp_directory_path();
+    std::random_device _rng;
+    for (;;) {
+      std::string _p =
+          (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng())))
+              .string();
+      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+      if (_fd >= 0) {
+        ::close(_fd);
+        return _p;
+      }
+      if (errno != EEXIST)
+        throw std::runtime_error("crane: failed to create temporary file");
+    }
   }();
 }
 
 std::string TempFile::make_temp_dir(std::string prefix) {
   return [&]() -> std::string {
-    auto p = std::filesystem::temp_directory_path() / (prefix + "XXXXXX");
-    std::string s = p.string();
-    return std::string(mkdtemp(s.data()));
+    std::string _n = std::filesystem::path(prefix).filename().string();
+    if (_n.empty() || _n == "." || _n == "..")
+      _n = "tmp";
+    std::filesystem::path _dir = std::filesystem::temp_directory_path();
+    std::random_device _rng;
+    for (;;) {
+      std::string _p =
+          (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng())))
+              .string();
+      if (::mkdir(_p.c_str(), 0700) == 0)
+        return _p;
+      if (errno != EEXIST)
+        throw std::runtime_error("crane: failed to create temporary directory");
+    }
   }();
 }

--- a/tests/regression/temp_file/temp_file.cpp
+++ b/tests/regression/temp_file/temp_file.cpp
@@ -5,19 +5,23 @@ std::string TempFile::make_temp_file(std::string prefix) {
     std::string _n = std::filesystem::path(prefix).filename().string();
     if (_n.empty() || _n == "." || _n == "..")
       _n = "tmp";
-    std::filesystem::path _dir = std::filesystem::temp_directory_path();
+    std::filesystem::path _base = std::filesystem::temp_directory_path();
     std::random_device _rng;
     for (;;) {
-      std::string _p =
-          (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng())))
+      std::string _d =
+          (_base / (_n + std::to_string(_rng()) + std::to_string(_rng())))
               .string();
-      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-      if (_fd >= 0) {
-        ::close(_fd);
-        return _p;
+      if (::mkdir(_d.c_str(), 0700) != 0) {
+        if (errno == EEXIST)
+          continue;
+        throw std::runtime_error("crane: failed to create temporary directory");
       }
-      if (errno != EEXIST)
+      std::string _p = _d + "/" + _n;
+      int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+      if (_fd < 0)
         throw std::runtime_error("crane: failed to create temporary file");
+      ::close(_fd);
+      return _p;
     }
   }();
 }

--- a/tests/regression/temp_file/temp_file.h
+++ b/tests/regression/temp_file/temp_file.h
@@ -1,9 +1,13 @@
 #ifndef INCLUDED_TEMP_FILE
 #define INCLUDED_TEMP_FILE
 
-#include <cstdlib>
+#include <cerrno>
+#include <fcntl.h>
 #include <filesystem>
+#include <random>
+#include <stdexcept>
 #include <string>
+#include <sys/stat.h>
 #include <unistd.h>
 
 struct TempFile {

--- a/tests/regression/temp_file/temp_file.t.cpp
+++ b/tests/regression/temp_file/temp_file.t.cpp
@@ -47,9 +47,32 @@ void test_create_temp_dir() {
   std::cout << "PASS: create_temp_dir = " << path << "\n";
 }
 
+// A prefix containing directory separators, "..", or an absolute path must not
+// escape the system temporary directory: the created entry's parent directory
+// is always the temp directory itself.
+void test_prefix_traversal() {
+  namespace fs = std::filesystem;
+  const fs::path tmp = fs::weakly_canonical(fs::temp_directory_path());
+
+  for (const char *prefix :
+       {"../crane_escape_", "/etc/crane_escape_", "a/b/crane_escape_", "..",
+        "/"}) {
+    auto path = TempFile::make_temp_file(prefix);
+    ASSERT(!path.empty());
+    ASSERT(fs::exists(path));
+    // Resolve symlinks/./.. then confirm the parent is the temp directory.
+    ASSERT(fs::weakly_canonical(fs::path(path)).parent_path() == tmp);
+
+    fs::remove(path);
+    std::cout << "PASS: traversal-safe temp file for prefix '" << prefix
+              << "'\n";
+  }
+}
+
 int main() {
   test_create_temp_file();
   test_create_temp_dir();
+  test_prefix_traversal();
 
   std::cout << (testStatus ? "FAIL" : "PASS") << ": temp_file\n";
   return testStatus;

--- a/tests/regression/temp_file/temp_file.t.cpp
+++ b/tests/regression/temp_file/temp_file.t.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <filesystem>
 #include <iostream>
+#include <sys/stat.h>
 
 namespace {
 
@@ -23,6 +24,17 @@ void aSsErT(bool condition, const char *message, int line) {
   }
 }
 
+// A temp file is created inside a fresh owner-only (0700) directory so that no
+// other user can reach it; confirm that private parent directory really is
+// mode 0700.
+bool parent_is_private(const std::filesystem::path &file) {
+  struct stat st{};
+  if (::stat(file.parent_path().c_str(), &st) != 0) {
+    return false;
+  }
+  return (st.st_mode & 07777) == 0700;
+}
+
 } // namespace
 
 #define ASSERT(X) aSsErT(!(X), #X, __LINE__)
@@ -32,8 +44,9 @@ void test_create_temp_file() {
   ASSERT(!path.empty());
   ASSERT(std::filesystem::exists(path));
   ASSERT(std::filesystem::is_regular_file(path));
+  ASSERT(parent_is_private(path));
 
-  std::filesystem::remove(path);
+  std::filesystem::remove_all(std::filesystem::path(path).parent_path());
   std::cout << "PASS: create_temp_file = " << path << "\n";
 }
 
@@ -48,8 +61,8 @@ void test_create_temp_dir() {
 }
 
 // A prefix containing directory separators, "..", or an absolute path must not
-// escape the system temporary directory: the created entry's parent directory
-// is always the temp directory itself.
+// escape the system temporary directory. The file lives in a private per-file
+// directory, so its grandparent is the temp directory and its parent is 0700.
 void test_prefix_traversal() {
   namespace fs = std::filesystem;
   const fs::path tmp = fs::weakly_canonical(fs::temp_directory_path());
@@ -60,10 +73,13 @@ void test_prefix_traversal() {
     auto path = TempFile::make_temp_file(prefix);
     ASSERT(!path.empty());
     ASSERT(fs::exists(path));
-    // Resolve symlinks/./.. then confirm the parent is the temp directory.
-    ASSERT(fs::weakly_canonical(fs::path(path)).parent_path() == tmp);
+    // Resolve symlinks/./.. then confirm the private parent dir sits directly
+    // under the temp directory (i.e. the file could not escape it).
+    fs::path parent = fs::weakly_canonical(fs::path(path)).parent_path();
+    ASSERT(parent.parent_path() == tmp);
+    ASSERT(parent_is_private(path));
 
-    fs::remove(path);
+    fs::remove_all(fs::path(path).parent_path());
     std::cout << "PASS: traversal-safe temp file for prefix '" << prefix
               << "'\n";
   }

--- a/tests/regression/todo_erased_instance_param/todo_erased_instance_param.h
+++ b/tests/regression/todo_erased_instance_param/todo_erased_instance_param.h
@@ -15,7 +15,9 @@ struct TodoErasedInstanceParam {
 
   static_assert(Default<natDefault, uint64_t>);
 
-  template <typename _tcI0, typename T1> static T1 pick() {
+  template <typename _tcI0, typename T1>
+    requires Default<_tcI0, T1>
+  static T1 pick() {
     return _tcI0::def();
   }
 

--- a/tests/regression/todo_type_app_instance_alias/todo_type_app_instance_alias.h
+++ b/tests/regression/todo_type_app_instance_alias/todo_type_app_instance_alias.h
@@ -15,7 +15,9 @@ struct TodoTypeAppInstanceAlias {
 
   static_assert(Boxed<natBoxed, uint64_t>);
 
-  template <typename _tcI0, typename T1> static T1 pick() {
+  template <typename _tcI0, typename T1>
+    requires Boxed<_tcI0, T1>
+  static T1 pick() {
     return _tcI0::boxed_default();
   }
 

--- a/tests/regression/todo_typeclass_requires/todo_typeclass_requires.h
+++ b/tests/regression/todo_typeclass_requires/todo_typeclass_requires.h
@@ -17,6 +17,7 @@ struct TodoTypeclassRequires {
   static_assert(Numeric<NatNumeric, uint64_t>);
 
   template <typename _tcI0, typename T1>
+    requires Numeric<_tcI0, T1>
   static uint64_t double_val(const T1 &x) {
     return (_tcI0::to_nat_val(x) + _tcI0::to_nat_val(x));
   }

--- a/tests/regression/todo_with_type_constraint/todo_with_type_constraint.h
+++ b/tests/regression/todo_with_type_constraint/todo_with_type_constraint.h
@@ -16,7 +16,7 @@ concept BASE = requires {
   { M::bump(std::declval<typename M::t>()) } -> std::same_as<typename M::t>;
 };
 template <typename M>
-concept NAT_BASE = BASE<M>;
+concept NAT_BASE = BASE<M> && std::same_as<typename M::t, uint64_t>;
 
 struct TodoWithTypeConstraint {
   struct NatBase {

--- a/tests/regression/typeclass_function_field_probe/typeclass_function_field_probe.h
+++ b/tests/regression/typeclass_function_field_probe/typeclass_function_field_probe.h
@@ -22,7 +22,9 @@ struct TypeclassFunctionFieldProbe {
 
   static_assert(HasEndo<boolEndo, Bool0>);
 
-  template <typename _tcI0, typename T1> static T1 use(const T1 &x) {
+  template <typename _tcI0, typename T1>
+    requires HasEndo<_tcI0, T1>
+  static T1 use(const T1 &x) {
     return _tcI0::endo(_tcI0::endo(x));
   }
 

--- a/tests/wip/fibst_cofix_repro/fibst_cofix_repro.h
+++ b/tests/wip/fibst_cofix_repro/fibst_cofix_repro.h
@@ -248,6 +248,7 @@ struct STRefNat {
 };
 
 template <typename _tcI0, typename _tcI1, typename T1>
+  requires STRefClass<_tcI0, T1> && Ix<_tcI1, T1>
 uint64_t fibst_repro(uint64_t n) {
   auto go_impl = [&](auto &, uint64_t x, uint64_t y, const T1 &,
                      const T1 &) -> uint64_t {

--- a/tests/wip/z_abs_min/z_abs_min.cpp
+++ b/tests/wip/z_abs_min/z_abs_min.cpp
@@ -4,7 +4,12 @@
 /// ZInt maps Z.abs to std::abs(%a0) (from <cstdlib>).
 /// But std::abs(INT64_MIN) is undefined behavior in C++
 /// because -INT64_MIN cannot be represented as int64_t.
-int64_t ZAbsMin::my_abs(int64_t _x0) { return std::abs(_x0); }
+int64_t ZAbsMin::my_abs(int64_t _x0) {
+  return (_x0 < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(_x0)) : _x0);
+}
 
 /// Should always be true for Z.abs, but fails in C++.
-bool ZAbsMin::is_nonneg(int64_t x) { return INT64_C(0) <= std::abs(x); }
+bool ZAbsMin::is_nonneg(int64_t x) {
+  return INT64_C(0) <=
+         (x < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(x)) : x);
+}

--- a/tests/wip/z_abs_min/z_abs_min.h
+++ b/tests/wip/z_abs_min/z_abs_min.h
@@ -2,7 +2,6 @@
 #define INCLUDED_Z_ABS_MIN
 
 #include <cstdint>
-#include <cstdlib>
 
 struct ZAbsMin {
   /// In Rocq, Z.abs is total: Z.abs z is always non-negative.
@@ -11,11 +10,16 @@ struct ZAbsMin {
   /// because -INT64_MIN cannot be represented as int64_t.
   static int64_t my_abs(int64_t _x0);
   /// Construct INT64_MIN = -2^63 via INT64_MAX + 1 negated.
-  static inline const int64_t neg_max = (-INT64_C(9223372036854775807));
-  static inline const int64_t int64_min = (neg_max - 1);
+  static inline const int64_t neg_max = static_cast<int64_t>(
+      -static_cast<uint64_t>(INT64_C(9223372036854775807)));
+
+  static inline const int64_t int64_min =
+      static_cast<int64_t>(static_cast<uint64_t>(neg_max) - 1);
   /// In Rocq, this is 9223372036854775808 (positive).
   /// In C++, std::abs(INT64_MIN) is UB — typically returns INT64_MIN.
-  static inline const int64_t abs_of_min = std::abs(int64_min);
+  static inline const int64_t abs_of_min =
+      (int64_min < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(int64_min))
+                     : int64_min);
   /// Should always be true for Z.abs, but fails in C++.
   static bool is_nonneg(int64_t x);
 };

--- a/tests/wip/z_arith_overflow/z_arith_overflow.h
+++ b/tests/wip/z_arith_overflow/z_arith_overflow.h
@@ -532,19 +532,22 @@ struct ZArithOverflow {
   /// 3,100,000,000^2 = 9,610,000,000,000,000,000 > INT64_MAX.
   /// In Rocq: perfectly fine (Z is arbitrary precision).
   /// In C++: signed integer multiplication overflow — UB.
-  static inline const int64_t overflow_mul = (big_z * big_z);
+  static inline const int64_t overflow_mul = static_cast<int64_t>(
+      static_cast<uint64_t>(big_z) * static_cast<uint64_t>(big_z));
   /// The result should be positive (product of two positives).
   /// In C++ the overflowed result wraps to a negative value.
   static inline const bool is_positive = INT64_C(0) < overflow_mul;
   /// Addition near INT64_MAX
   static inline const int64_t near_max =
       static_cast<int64_t>(UINT64_C(4000000000));
-  static inline const int64_t near_max_sq = (near_max * near_max);
+  static inline const int64_t near_max_sq = static_cast<int64_t>(
+      static_cast<uint64_t>(near_max) * static_cast<uint64_t>(near_max));
   /// Negation of the most negative int64_t is also UB
-  static inline const int64_t neg_big =
-      (-static_cast<int64_t>(UINT64_C(4000000000)));
+  static inline const int64_t neg_big = static_cast<int64_t>(
+      -static_cast<uint64_t>(static_cast<int64_t>(UINT64_C(4000000000))));
 
-  static inline const int64_t neg_sq = (neg_big * neg_big);
+  static inline const int64_t neg_sq = static_cast<int64_t>(
+      static_cast<uint64_t>(neg_big) * static_cast<uint64_t>(neg_big));
 };
 
 #endif // INCLUDED_Z_ARITH_OVERFLOW

--- a/tests/wip/z_div_min/z_div_min.h
+++ b/tests/wip/z_div_min/z_div_min.h
@@ -6,8 +6,10 @@
 
 struct ZDivMin {
   /// Build INT64_MIN = -9223372036854775808 via Z.opp(Z.of_nat ...)
-  static inline const int64_t neg_max = (-INT64_C(9223372036854775807));
-  static inline const int64_t int64_min = (neg_max - 1);
+  static inline const int64_t neg_max = static_cast<int64_t>(
+      -static_cast<uint64_t>(INT64_C(9223372036854775807)));
+  static inline const int64_t int64_min =
+      static_cast<int64_t>(static_cast<uint64_t>(neg_max) - 1);
   /// INT64_MIN / -1 = 9223372036854775808, which doesn't fit in int64_t.
   /// In Rocq: perfectly fine, result is positive.
   /// In C++: signed division overflow → undefined behavior.
@@ -16,6 +18,8 @@ struct ZDivMin {
     int64_t _b = INT64_C(-1);
     if (_b == 0)
       return INT64_C(0);
+    if (_b == -1)
+      return static_cast<int64_t>(-static_cast<uint64_t>(_a));
     int64_t _q = _a / _b;
     int64_t _r = _a % _b;
     if (_r != 0 && ((_r < 0) != (_b < 0)))
@@ -31,6 +35,8 @@ struct ZDivMin {
     int64_t _b = INT64_C(-1);
     if (_b == 0)
       return _a;
+    if (_b == -1)
+      return INT64_C(0);
     int64_t _r = _a % _b;
     if (_r != 0 && ((_r < 0) != (_b < 0)))
       return _r + _b;
@@ -38,7 +44,9 @@ struct ZDivMin {
   }();
   /// Z.opp INT64_MIN is also UB: -(INT64_MIN) overflows int64_t.
   /// In Rocq: result is positive 9223372036854775808.
-  static inline const int64_t opp_min = (-int64_min);
+  static inline const int64_t opp_min =
+      static_cast<int64_t>(-static_cast<uint64_t>(int64_min));
+
   static inline const bool opp_is_positive = INT64_C(0) < opp_min;
 };
 

--- a/tests/wip/z_div_min/z_div_min.h
+++ b/tests/wip/z_div_min/z_div_min.h
@@ -11,14 +11,31 @@ struct ZDivMin {
   /// INT64_MIN / -1 = 9223372036854775808, which doesn't fit in int64_t.
   /// In Rocq: perfectly fine, result is positive.
   /// In C++: signed division overflow → undefined behavior.
-  static inline const int64_t div_min_neg1 =
-      (INT64_C(-1) == 0 ? INT64_C(0) : int64_min / INT64_C(-1));
+  static inline const int64_t div_min_neg1 = [&]() -> int64_t {
+    int64_t _a = int64_min;
+    int64_t _b = INT64_C(-1);
+    if (_b == 0)
+      return INT64_C(0);
+    int64_t _q = _a / _b;
+    int64_t _r = _a % _b;
+    if (_r != 0 && ((_r < 0) != (_b < 0)))
+      return _q - 1;
+    return _q;
+  }();
   /// The result should be positive (dividing negative by negative).
   static inline const bool div_is_positive = INT64_C(0) < div_min_neg1;
   /// INT64_MIN % -1 = 0 in Rocq.
   /// In C++: also UB (same overflow issue).
-  static inline const int64_t mod_min_neg1 =
-      (INT64_C(-1) == 0 ? INT64_C(0) : int64_min % INT64_C(-1));
+  static inline const int64_t mod_min_neg1 = [&]() -> int64_t {
+    int64_t _a = int64_min;
+    int64_t _b = INT64_C(-1);
+    if (_b == 0)
+      return _a;
+    int64_t _r = _a % _b;
+    if (_r != 0 && ((_r < 0) != (_b < 0)))
+      return _r + _b;
+    return _r;
+  }();
   /// Z.opp INT64_MIN is also UB: -(INT64_MIN) overflows int64_t.
   /// In Rocq: result is positive 9223372036854775808.
   static inline const int64_t opp_min = (-int64_min);

--- a/theories/External/StringViewBDE.v
+++ b/theories/External/StringViewBDE.v
@@ -11,6 +11,13 @@ Crane Extract Inlined Constant length => "%a0.length()" From "bsl_string_view.h"
 Crane Extract Inlined Constant substr => "%a0.substr(%a1, %a2)" From "bsl_string_view.h".
 Crane Extract Inlined Constant sv_of_string => "{%a0.data(), %a0.size()}" From "bsl_string_view.h".
 Crane Extract Inlined Constant contains => "%a0.contains(%a1)" From "bsl_string_view.h".
-Crane Extract Inlined Constant sv_get => "%a0[%a1]" From "bsl_string_view.h".
+(* The [sv_get] axioms (StringViewDefs.v) constrain only in-range indices, so
+   returning the null char for an out-of-range index is consistent with the
+   specification and makes the operation total. The bounds check prevents an
+   out-of-bounds read of a possibly non-owning [bsl::string_view] (CWE-125).
+   Use [sv_at] when a throwing, checked accessor is desired instead. *)
+Crane Extract Inlined Constant sv_get =>
+  "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
+  From "bsl_string_view.h".
 Crane Extract Inlined Constant sv_at => "%a0.at(%a1)" From "bsl_string_view.h".
 Crane Extract Inlined Constant empty_sv => "bsl::string_view(nullptr, 0)" From "bsl_string_view.h".

--- a/theories/External/StringViewBDE.v
+++ b/theories/External/StringViewBDE.v
@@ -8,7 +8,16 @@ Crane Extract Inlined Constant string_view => "bsl::basic_string_view<char>" Fro
 Crane Extract Inlined Constant empty => "%a0.empty()" From "bsl_string_view.h".
 Crane Extract Inlined Constant sv_eq => "%a0 == %a1" From "bsl_string_view.h".
 Crane Extract Inlined Constant length => "%a0.length()" From "bsl_string_view.h".
-Crane Extract Inlined Constant substr => "%a0.substr(%a1, %a2)" From "bsl_string_view.h".
+(* [length_substr]/[length_substr_prefix] (StringViewDefs.v) define [substr]
+   as total: a [start] at or past the view's length yields an empty view
+   rather than raising, and [len] is clamped to what remains.
+   [bsl::basic_string_view::substr] already clamps [count], but throws when
+   [pos > size()]. The guard reproduces the axiomatized clamp-to-empty
+   behavior instead of letting the exception escape and terminate the
+   generated program (CWE-248/CWE-755). *)
+Crane Extract Inlined Constant substr =>
+  "((%a1 >= 0 && %a1 <= static_cast<int64_t>(%a0.length())) ? %a0.substr(%a1, %a2) : bsl::basic_string_view<char>())"
+  From "bsl_string_view.h".
 Crane Extract Inlined Constant sv_of_string => "{%a0.data(), %a0.size()}" From "bsl_string_view.h".
 Crane Extract Inlined Constant contains => "%a0.contains(%a1)" From "bsl_string_view.h".
 (* The [sv_get] axioms (StringViewDefs.v) constrain only in-range indices, so

--- a/theories/External/StringViewDefs.v
+++ b/theories/External/StringViewDefs.v
@@ -21,6 +21,16 @@ Axiom length : string_view -> int.
 Axiom substr : string_view -> int -> int -> string_view.
 Axiom sv_get : string_view -> int -> char63.
 Axiom sv_at : string_view -> int -> char63.
+(* [sv_of_string] returns a NON-OWNING view: both the std and BDE mappings build
+   it from the source string's [data()]/[size()], so the returned view is only
+   valid while that source string is alive.  This is an inherent property of
+   [string_view] and cannot be enforced at the mapping level (a temporary and an
+   lvalue string share the same extraction template).  Callers MUST apply it to a
+   string that outlives the view -- never to a temporary such as the result of a
+   substring, concatenation, or function return -- or later reads through the
+   view are use-after-free (CWE-416).  When a temporary source is unavoidable,
+   bind it to a named [string] first, or keep the owning [string] and index into
+   it rather than converting to a view. *)
 Axiom sv_of_string : string -> string_view.
 Axiom contains : string_view -> char63 -> bool.
 
@@ -31,9 +41,16 @@ Axiom sv_eq_rel_equiv : equivalence string_view sv_eq_rel.
 Axiom empty_substr : forall sv i, empty (substr sv i 0) = true.
 Axiom empty_length : forall sv, empty sv = true <-> length sv = 0.
 Axiom length_of_string : forall s, length (sv_of_string s) = PrimString.length s.
+(* [i] and [j] are start/end indices: the slice is the half-open range
+   [[i, j)].  Both sides must therefore denote a slice of length [j - i].  The
+   view side already uses [sub j i]; [PrimString.sub] takes an (offset, length)
+   pair, so it must receive [sub j i] as its length -- passing [j] would make
+   the primitive side a length-[j] slice (e.g. "bcd" instead of "bc" for
+   s = "abcde", i = 1, j = 3), letting proofs about an end-index slice diverge
+   from the extracted code (CWE-682 / CWE-345). *)
 Axiom substr_of_string_comm : forall s i j, compare i j <> Gt
                               -> compare j (PrimString.length s) <> Gt
-                              -> substr (sv_of_string s) i (sub j i) = sv_of_string (PrimString.sub s i j).
+                              -> substr (sv_of_string s) i (sub j i) = sv_of_string (PrimString.sub s i (sub j i)).
 
 (* Axioms relating contains, sv_get, substr, and length *)
 

--- a/theories/External/StringViewStd.v
+++ b/theories/External/StringViewStd.v
@@ -11,6 +11,13 @@ Crane Extract Inlined Constant length => "%a0.length()" From "string_view".
 Crane Extract Inlined Constant substr => "%a0.substr(%a1, %a2)" From "string_view".
 Crane Extract Inlined Constant sv_of_string => "{%a0.data(), %a0.size()}" From "string_view".
 Crane Extract Inlined Constant contains => "%a0.contains(%a1)" From "string_view".
-Crane Extract Inlined Constant sv_get => "%a0[%a1]" From "string_view".
+(* The [sv_get] axioms (StringViewDefs.v) constrain only in-range indices, so
+   returning the null char for an out-of-range index is consistent with the
+   specification and makes the operation total. The bounds check prevents an
+   out-of-bounds read of a possibly non-owning [std::string_view] (CWE-125).
+   Use [sv_at] when a throwing, checked accessor is desired instead. *)
+Crane Extract Inlined Constant sv_get =>
+  "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
+  From "string_view".
 Crane Extract Inlined Constant sv_at => "%a0.at(%a1)" From "string_view".
 Crane Extract Inlined Constant empty_sv => "std::string_view(nullptr, 0)" From "string_view".

--- a/theories/External/StringViewStd.v
+++ b/theories/External/StringViewStd.v
@@ -8,7 +8,16 @@ Crane Extract Inlined Constant string_view => "std::basic_string_view<char>" Fro
 Crane Extract Inlined Constant empty => "%a0.empty()" From "string_view".
 Crane Extract Inlined Constant sv_eq => "%a0 == %a1" From "string_view".
 Crane Extract Inlined Constant length => "%a0.length()" From "string_view".
-Crane Extract Inlined Constant substr => "%a0.substr(%a1, %a2)" From "string_view".
+(* [length_substr]/[length_substr_prefix] (StringViewDefs.v) define [substr]
+   as total: a [start] at or past the view's length yields an empty view
+   rather than raising, and [len] is clamped to what remains.
+   [std::string_view::substr] already clamps [count], but throws
+   [std::out_of_range] when [pos > size()]. The guard reproduces the
+   axiomatized clamp-to-empty behavior instead of letting the exception
+   escape and terminate the generated program (CWE-248/CWE-755). *)
+Crane Extract Inlined Constant substr =>
+  "((%a1 >= 0 && %a1 <= static_cast<int64_t>(%a0.length())) ? %a0.substr(%a1, %a2) : std::basic_string_view<char>())"
+  From "string_view".
 Crane Extract Inlined Constant sv_of_string => "{%a0.data(), %a0.size()}" From "string_view".
 Crane Extract Inlined Constant contains => "%a0.contains(%a1)" From "string_view".
 (* The [sv_get] axioms (StringViewDefs.v) constrain only in-range indices, so

--- a/theories/Mapping/BDE.v
+++ b/theories/Mapping/BDE.v
@@ -34,7 +34,13 @@ From Corelib Require Import PrimString.
 Crane Extract Inlined Constant PrimString.char63 => "char".
 Crane Extract Inlined Constant PrimString.string => "bsl::string" From "bsl_string.h".
 Crane Extract Inlined Constant PrimString.cat => "%a0 + %a1" From "bsl_string.h".
-Crane Extract Inlined Constant PrimString.get => "%a0[%a1]" From "bsl_string.h".
+(* [get] is total in Rocq: [get_spec] defines [get s i = nth (to_nat i) s 0],
+   so an out-of-range index yields the null char rather than undefined behavior.
+   The bounds check reproduces that semantics exactly and prevents an
+   out-of-bounds read of [bsl::string] (CWE-125). *)
+Crane Extract Inlined Constant PrimString.get =>
+  "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
+  From "bsl_string.h".
 Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "bsl_string.h".
 Crane Extract Inlined Constant PrimString.length => "%a0.length()" From "bsl_string.h".
 

--- a/theories/Mapping/BDE.v
+++ b/theories/Mapping/BDE.v
@@ -44,12 +44,18 @@ Crane Extract Inlined Constant PrimString.get =>
 Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "bsl_string.h".
 Crane Extract Inlined Constant PrimString.length => "%a0.length()" From "bsl_string.h".
 
+(* int63 primitives - int64_t with 63-bit masking.
+   Arithmetic is performed in the unsigned (uint64_t) domain, where overflow is
+   defined as wraparound, then masked to [0, 2^63) to match Rocq semantics and
+   cast back to int64_t. Performing add/sub/mul/shl directly on signed int64_t
+   would be undefined behavior on overflow (CWE-190). div and mod guard against
+   division by zero. Bitwise ops preserve the invariant (inputs have bit 63 = 0). *)
 From Corelib Require Import PrimInt63.
 Crane Extract Inlined Constant PrimInt63.int => "int64_t" From "bsl_cstdint.h".
-Crane Extract Inlined Constant PrimInt63.add => "%a0 + %a1".
-Crane Extract Inlined Constant PrimInt63.sub => "%a0 - %a1".
-Crane Extract Inlined Constant PrimInt63.mul => "%a0 * %a1".
-Crane Extract Inlined Constant PrimInt63.mod => "%a0 % %a1".
+Crane Extract Inlined Constant PrimInt63.add => "static_cast<int64_t>((static_cast<uint64_t>(%a0) + static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
+Crane Extract Inlined Constant PrimInt63.sub => "static_cast<int64_t>((static_cast<uint64_t>(%a0) - static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
+Crane Extract Inlined Constant PrimInt63.mul => "static_cast<int64_t>((static_cast<uint64_t>(%a0) * static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
+Crane Extract Inlined Constant PrimInt63.mod => "(%a1 == 0 ? 0 : %a0 % %a1)".
 Crane Extract Inlined Constant PrimInt63.div => "(%a1 == 0 ? 0 : %a0 / %a1)".
 Crane Extract Inlined Constant PrimInt63.eqb => "%a0 == %a1".
 Crane Extract Inlined Constant PrimInt63.ltb => "%a0 < %a1".
@@ -57,8 +63,8 @@ Crane Extract Inlined Constant PrimInt63.leb => "%a0 <= %a1".
 Crane Extract Inlined Constant PrimInt63.land => "(%a0 & %a1)".
 Crane Extract Inlined Constant PrimInt63.lor => "(%a0 | %a1)".
 Crane Extract Inlined Constant PrimInt63.lxor => "(%a0 ^ %a1)".
-Crane Extract Inlined Constant PrimInt63.lsl => "(%a1 >= 63 ? 0 : (%a0 << %a1))".
-Crane Extract Inlined Constant PrimInt63.lsr => "(%a1 >= 63 ? 0 : (%a0 >> %a1))".
+Crane Extract Inlined Constant PrimInt63.lsl => "(%a1 >= 63 ? 0 : static_cast<int64_t>((static_cast<uint64_t>(%a0) << %a1) & 0x7FFFFFFFFFFFFFFFULL))".
+Crane Extract Inlined Constant PrimInt63.lsr => "(%a1 >= 63 ? 0 : static_cast<int64_t>(static_cast<uint64_t>(%a0) >> %a1))".
 
 (* PrimFloat - IEEE 754 binary64 (C++ double). *)
 From Corelib Require Import PrimFloat.

--- a/theories/Mapping/BDE.v
+++ b/theories/Mapping/BDE.v
@@ -41,7 +41,15 @@ Crane Extract Inlined Constant PrimString.cat => "%a0 + %a1" From "bsl_string.h"
 Crane Extract Inlined Constant PrimString.get =>
   "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
   From "bsl_string.h".
-Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "bsl_string.h".
+(* [sub] is total in Rocq (Pstring.sub): an [off] at or past the string's
+   length yields the empty string rather than raising, and [len] is clamped
+   to what remains. [bsl::string::substr] already clamps [count], but throws
+   when [pos > size()]. The guard reproduces Rocq's clamp-to-empty behavior
+   instead of letting the exception escape and terminate the generated
+   program (CWE-248/CWE-755). *)
+Crane Extract Inlined Constant PrimString.sub =>
+  "((%a1 >= 0 && %a1 <= static_cast<int64_t>(%a0.length())) ? %a0.substr(%a1, %a2) : bsl::string())"
+  From "bsl_string.h".
 Crane Extract Inlined Constant PrimString.length => "%a0.length()" From "bsl_string.h".
 
 (* int63 primitives - int64_t with 63-bit masking.

--- a/theories/Mapping/DequeList.v
+++ b/theories/Mapping/DequeList.v
@@ -28,8 +28,13 @@ Crane Extract Inlined Constant Datatypes.app =>
   "[&]() { auto _r = %a0; auto _s = %a1; _r.insert(_r.end(), _s.begin(), _s.end()); return _r; }()" From "deque".
 
 (** Higher-order list functions from the [List] module. *)
+(* Result element types are derived from the deque's [value_type] and a
+   [std::declval] of it, never from [%a1.front()]: on an empty deque [front()]
+   is undefined behaviour, and deriving a type from it (even in an unevaluated
+   [decltype]) reads as unsafe.  Using [value_type] keeps the inference total
+   regardless of whether the input deque is empty (CWE-476 / CWE-125). *)
 Crane Extract Inlined Constant List.map =>
-  "[&]() { std::deque<std::decay_t<decltype(%a0(%a1.front()))>> _r; for (const auto& _x : %a1) _r.push_back(%a0(_x)); return _r; }()" From "deque".
+  "[&]() { std::deque<std::decay_t<decltype(%a0(std::declval<typename std::decay_t<decltype(%a1)>::value_type&>()))>> _r; for (const auto& _x : %a1) _r.push_back(%a0(_x)); return _r; }()" From "deque" "utility" "type_traits".
 
 Crane Extract Inlined Constant List.rev =>
   "[&]() { auto _r = %a0; std::reverse(_r.begin(), _r.end()); return _r; }()" From "algorithm".
@@ -47,10 +52,10 @@ Crane Extract Inlined Constant List.forallb =>
   "[&]() { for (const auto& _x : %a1) if (!%a0(_x)) return false; return true; }()" From "deque".
 
 Crane Extract Inlined Constant List.flat_map =>
-  "[&]() { std::deque<typename std::decay_t<decltype(%a0(%a1.front()))>::value_type> _r; for (const auto& _x : %a1) { auto _s = %a0(_x); _r.insert(_r.end(), _s.begin(), _s.end()); } return _r; }()" From "deque".
+  "[&]() { std::deque<typename std::decay_t<decltype(%a0(std::declval<typename std::decay_t<decltype(%a1)>::value_type&>()))>::value_type> _r; for (const auto& _x : %a1) { auto _s = %a0(_x); _r.insert(_r.end(), _s.begin(), _s.end()); } return _r; }()" From "deque" "utility" "type_traits".
 
 Crane Extract Inlined Constant List.concat =>
-  "[&]() { std::deque<typename std::decay_t<decltype(%a0.front())>::value_type> _r; for (const auto& _s : %a0) _r.insert(_r.end(), _s.begin(), _s.end()); return _r; }()" From "deque".
+  "[&]() { std::deque<typename std::decay_t<decltype(%a0)>::value_type::value_type> _r; for (const auto& _s : %a0) _r.insert(_r.end(), _s.begin(), _s.end()); return _r; }()" From "deque" "type_traits".
 
 (** String <-> list conversions. *)
 Crane Extract Inlined Constant String.list_ascii_of_string =>

--- a/theories/Mapping/NGMP.v
+++ b/theories/Mapping/NGMP.v
@@ -30,10 +30,14 @@ Crane Extract Numeral N => "mpz_class(%n)".
 
 (* Pos operations *)
 Crane Extract Inlined Constant Pos.add => "(%a0 + %a1)".
-Crane Extract Inlined Constant Pos.sub => "(%a0 - %a1)".
+(* [positive] is strictly >= 1. Rocq's [Pos.sub] truncates at 1 (it returns 1
+   when a <= b) and [Pos.pred 1 = 1], keeping the result inside the positive
+   domain. Raw subtraction would produce 0 or negative values that violate the
+   invariant (CWE-682). *)
+Crane Extract Inlined Constant Pos.sub => "(%a0 > %a1 ? %a0 - %a1 : mpz_class(1))".
 Crane Extract Inlined Constant Pos.mul => "(%a0 * %a1)".
 Crane Extract Inlined Constant Pos.succ => "(%a0 + 1)".
-Crane Extract Inlined Constant Pos.pred => "(%a0 - 1)".
+Crane Extract Inlined Constant Pos.pred => "(%a0 > 1 ? %a0 - 1 : mpz_class(1))".
 Crane Extract Inlined Constant Pos.eqb => "%a0 == %a1".
 Crane Extract Inlined Constant Pos.ltb => "%a0 < %a1".
 Crane Extract Inlined Constant Pos.leb => "%a0 <= %a1".
@@ -58,6 +62,15 @@ Crane Extract Inlined Constant N.succ_double => "(%a0 * 2 + 1)".
 
 (* Conversions *)
 Crane Extract Inlined Constant N.of_nat => "mpz_class(%a0)".
-Crane Extract Inlined Constant N.to_nat => "static_cast<unsigned int>(%a0.get_ui())".
+(* [mpz_class::get_ui] returns only the low word of an arbitrary-precision
+   value, and Rocq's [N.to_nat]/[Pos.to_nat] are total, unbounded-domain
+   functions. Silently truncating a value that exceeds [UINT_MAX] would
+   produce a wrapped, wrong result rather than surfacing the loss of
+   precision (CWE-190/CWE-681), so we saturate at [UINT_MAX] instead. *)
+Crane Extract Inlined Constant N.to_nat =>
+  "(%a0 > mpz_class(UINT_MAX) ? UINT_MAX : static_cast<unsigned int>(%a0.get_ui()))"
+  From "climits".
 Crane Extract Inlined Constant Pos.of_nat => "mpz_class(%a0 == 0 ? 1 : %a0)".
-Crane Extract Inlined Constant Pos.to_nat => "static_cast<unsigned int>(%a0.get_ui())".
+Crane Extract Inlined Constant Pos.to_nat =>
+  "(%a0 > mpz_class(UINT_MAX) ? UINT_MAX : static_cast<unsigned int>(%a0.get_ui()))"
+  From "climits".

--- a/theories/Mapping/NInt.v
+++ b/theories/Mapping/NInt.v
@@ -8,6 +8,15 @@ From Stdlib Require Import BinNat BinPos.
 
     Maps [positive] to [unsigned int] and [N] to [unsigned int].
     All [N] and [Pos] operations become native C++ arithmetic.
+
+    WARNING (prototyping only): [unsigned int] is fixed-width, whereas Rocq's
+    [positive] and [N] are unbounded. Addition, multiplication, successor,
+    doubling, and numeral extraction wrap modulo 2^32 once a value exceeds
+    [UINT_MAX], and conversions truncate — silently diverging from the proof
+    model (CWE-190/CWE-681). Use this mapping only for testing/prototyping where
+    values are provably in range; for security-sensitive or unbounded arithmetic
+    use the arbitrary-precision GMP mappings ([Mapping.NGMP], [Mapping.ZGMP])
+    instead.
 *)
 
 (* positive: strictly positive binary integers *)

--- a/theories/Mapping/NIntBDE.v
+++ b/theories/Mapping/NIntBDE.v
@@ -8,6 +8,15 @@ From Stdlib Require Import BinNat BinPos.
 
     Maps [positive] to [unsigned int] and [N] to [unsigned int].
     All [N] and [Pos] operations become native C++ arithmetic.
+
+    WARNING (prototyping only): [unsigned int] is fixed-width, whereas Rocq's
+    [positive] and [N] are unbounded. Addition, multiplication, successor,
+    doubling, and numeral extraction wrap modulo 2^32 once a value exceeds
+    [UINT_MAX], and conversions truncate — silently diverging from the proof
+    model (CWE-190/CWE-681). Use this mapping only for testing/prototyping where
+    values are provably in range; for security-sensitive or unbounded arithmetic
+    use the arbitrary-precision GMP mappings ([Mapping.NGMP], [Mapping.ZGMP])
+    instead.
 *)
 
 (* positive: strictly positive binary integers *)

--- a/theories/Mapping/Real.v
+++ b/theories/Mapping/Real.v
@@ -1,20 +1,30 @@
 (* Copyright 2026 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the GNU LGPL v2.1 license. *)
 From Crane Require Extraction.
-From Crane Require Export Mapping.ZInt.
+From Crane Require Export Mapping.Std.
 From Stdlib Require Import Reals Rtrigo Ratan Rsqrt_def.
 
 (** Extraction of [R] (axiomatized reals) to a C++ [Real] class
     wrapping [long double].
 
-    Imports [Mapping.ZInt] which transitively provides:
-    - [positive] / [N] -> [unsigned int]   (via [NInt.v])
-    - [Z] -> [int64_t]                     (via [ZInt.v])
-    - Standard mappings (option, pair, etc.) (via [Std.v])
+    This mapping is deliberately *integer-flavor-agnostic*: it does not choose a
+    representation for [Z] / [N] / [positive].  Only the four integer -> real
+    coercions ([INR], [IZR], [IPR], [IPR_2]) touch those types, and they map to
+    the templated [Real::from_nat] / [from_z] / [from_pos] helpers, which accept
+    whatever C++ type the imported integer mapping uses (int64_t, unsigned int,
+    or GMP [mpz_class]).  A program that uses those coercions must therefore
+    import an integer flavor as well, e.g.:
 
-    This short-circuits the constructive real infrastructure
-    (ConstructiveCauchyReals, ClassicalDedekindReals, etc.)
-    by mapping R and its operations directly to concrete C++. *)
+    - [From Crane Require Import Mapping.ZInt Mapping.Real.]   (Z -> int64_t)
+    - [From Crane Require Import Mapping.ZGMP Mapping.Real.]   (Z -> mpz_class)
+
+    Keeping the choice out of [Real.v] means importing reals no longer silently
+    pins [Z] to int64_t (which used to collide with an explicit GMP import).
+
+    Only [Std] (option, pair, string, ...) is exported here, since it carries no
+    integer-inductive mapping.  This short-circuits the constructive real
+    infrastructure (ConstructiveCauchyReals, ClassicalDedekindReals, etc.) by
+    mapping R and its operations directly to concrete C++. *)
 
 (* --- R type --- *)
 Crane Extract Inlined Constant R => "Real" From "crane_real.h".
@@ -57,7 +67,10 @@ Crane Extract Inlined Constant Req_EM_T => "(%a0 == %a1)".
 Crane Extract Inlined Constant INR => "Real::from_nat(%a0)".
 Crane Extract Inlined Constant IZR => "Real::from_z(%a0)".
 Crane Extract Inlined Constant IPR => "Real::from_pos(%a0)".
-Crane Extract Inlined Constant IPR_2 => "Real::from_pos(2u * %a0)".
+(* [IPR_2 p = 2 * IPR p]; double in real arithmetic rather than doing [2 * p] in
+   the integer domain, so this stays independent of the integer representation
+   (e.g. avoids relying on [unsigned]-typed multiplication). *)
+Crane Extract Inlined Constant IPR_2 => "(Real::from_pos(%a0) + Real::from_pos(%a0))".
 
 (* --- Short-circuit constructive real infrastructure --- *)
 Crane Extract Inlined Constant Rabst => "%a0".

--- a/theories/Mapping/Std.v
+++ b/theories/Mapping/Std.v
@@ -32,7 +32,13 @@ From Corelib Require Import PrimString.
 Crane Extract Inlined Constant PrimString.char63 => "char".
 Crane Extract Inlined Constant PrimString.string => "std::string" From "string".
 Crane Extract Inlined Constant PrimString.cat => "%a0 + %a1" From "string".
-Crane Extract Inlined Constant PrimString.get => "%a0[%a1]" From "string".
+(* [get] is total in Rocq: [get_spec] defines [get s i = nth (to_nat i) s 0],
+   so an out-of-range index yields the null char rather than undefined behavior.
+   The bounds check reproduces that semantics exactly and prevents an
+   out-of-bounds read of [std::string] (CWE-125). *)
+Crane Extract Inlined Constant PrimString.get =>
+  "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
+  From "string".
 Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "string".
 Crane Extract Inlined Constant PrimString.length => "static_cast<int64_t>(%a0.length())" From "string".
 

--- a/theories/Mapping/Std.v
+++ b/theories/Mapping/Std.v
@@ -39,7 +39,15 @@ Crane Extract Inlined Constant PrimString.cat => "%a0 + %a1" From "string".
 Crane Extract Inlined Constant PrimString.get =>
   "((%a1 >= 0 && %a1 < static_cast<int64_t>(%a0.length())) ? %a0[%a1] : static_cast<char>(0))"
   From "string".
-Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "string".
+(* [sub] is total in Rocq (Pstring.sub): an [off] at or past the string's
+   length yields the empty string rather than raising, and [len] is clamped
+   to what remains. [std::string::substr] already clamps [count], but throws
+   [std::out_of_range] when [pos > size()]. The guard reproduces Rocq's
+   clamp-to-empty behavior instead of letting the exception escape and
+   terminate the generated program (CWE-248/CWE-755). *)
+Crane Extract Inlined Constant PrimString.sub =>
+  "((%a1 >= 0 && %a1 <= static_cast<int64_t>(%a0.length())) ? %a0.substr(%a1, %a2) : std::string())"
+  From "string".
 Crane Extract Inlined Constant PrimString.length => "static_cast<int64_t>(%a0.length())" From "string".
 
 (* int63 primitives - int64_t with 63-bit masking.

--- a/theories/Mapping/Std.v
+++ b/theories/Mapping/Std.v
@@ -43,14 +43,18 @@ Crane Extract Inlined Constant PrimString.sub => "%a0.substr(%a1, %a2)" From "st
 Crane Extract Inlined Constant PrimString.length => "static_cast<int64_t>(%a0.length())" From "string".
 
 (* int63 primitives - int64_t with 63-bit masking.
-   All arithmetic results are masked to [0, 2^63) to match Rocq semantics.
-   Bitwise ops preserve the invariant (inputs have bit 63 = 0).
-   Shifts guard against UB when shift amount >= 63. *)
+   Arithmetic is performed in the unsigned (uint64_t) domain, where overflow is
+   defined as wraparound, then masked to [0, 2^63) to match Rocq semantics and
+   cast back to int64_t. Performing add/sub/mul directly on signed int64_t would
+   be undefined behavior on overflow (CWE-190), even though the result is later
+   masked. Bitwise ops preserve the invariant (inputs have bit 63 = 0).
+   Shifts guard against UB when shift amount >= 63 and shift in the unsigned
+   domain. *)
 From Corelib Require Import PrimInt63.
 Crane Extract Inlined Constant PrimInt63.int => "int64_t" From "cstdint".
-Crane Extract Inlined Constant PrimInt63.add => "((%a0 + %a1) & 0x7FFFFFFFFFFFFFFFLL)".
-Crane Extract Inlined Constant PrimInt63.sub => "((%a0 - %a1) & 0x7FFFFFFFFFFFFFFFLL)".
-Crane Extract Inlined Constant PrimInt63.mul => "((%a0 * %a1) & 0x7FFFFFFFFFFFFFFFLL)".
+Crane Extract Inlined Constant PrimInt63.add => "static_cast<int64_t>((static_cast<uint64_t>(%a0) + static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
+Crane Extract Inlined Constant PrimInt63.sub => "static_cast<int64_t>((static_cast<uint64_t>(%a0) - static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
+Crane Extract Inlined Constant PrimInt63.mul => "static_cast<int64_t>((static_cast<uint64_t>(%a0) * static_cast<uint64_t>(%a1)) & 0x7FFFFFFFFFFFFFFFULL)".
 Crane Extract Inlined Constant PrimInt63.div => "(%a1 == 0 ? 0 : %a0 / %a1)".
 Crane Extract Inlined Constant PrimInt63.mod => "(%a1 == 0 ? 0 : %a0 % %a1)".
 Crane Extract Inlined Constant PrimInt63.eqb => "%a0 == %a1".
@@ -59,8 +63,8 @@ Crane Extract Inlined Constant PrimInt63.leb => "%a0 <= %a1".
 Crane Extract Inlined Constant PrimInt63.land => "(%a0 & %a1)".
 Crane Extract Inlined Constant PrimInt63.lor => "(%a0 | %a1)".
 Crane Extract Inlined Constant PrimInt63.lxor => "(%a0 ^ %a1)".
-Crane Extract Inlined Constant PrimInt63.lsl => "(%a1 >= 63 ? 0 : ((%a0 << %a1) & 0x7FFFFFFFFFFFFFFFLL))".
-Crane Extract Inlined Constant PrimInt63.lsr => "(%a1 >= 63 ? 0 : (%a0 >> %a1))".
+Crane Extract Inlined Constant PrimInt63.lsl => "(%a1 >= 63 ? 0 : static_cast<int64_t>((static_cast<uint64_t>(%a0) << %a1) & 0x7FFFFFFFFFFFFFFFULL))".
+Crane Extract Inlined Constant PrimInt63.lsr => "(%a1 >= 63 ? 0 : static_cast<int64_t>(static_cast<uint64_t>(%a0) >> %a1))".
 
 (* PrimFloat - IEEE 754 binary64 (C++ double).
    Import PrimFloat AFTER PrimInt63 so the qualified names below resolve

--- a/theories/Mapping/ZGMP.v
+++ b/theories/Mapping/ZGMP.v
@@ -25,8 +25,30 @@ Crane Extract Numeral Z => "mpz_class(%n)".
 Crane Extract Inlined Constant Z.add => "(%a0 + %a1)".
 Crane Extract Inlined Constant Z.sub => "(%a0 - %a1)".
 Crane Extract Inlined Constant Z.mul => "(%a0 * %a1)".
-Crane Extract Inlined Constant Z.div => "(%a1 == 0 ? mpz_class(0) : %a0 / %a1)".
-Crane Extract Inlined Constant Z.modulo => "(%a1 == 0 ? mpz_class(0) : %a0 % %a1)".
+(* Rocq's Z.div / Z.modulo use *floored* division (the remainder takes the sign
+   of the divisor). GMP's mpz_class / and % truncate toward zero (remainder
+   takes the sign of the dividend), so we apply the flooring correction to match
+   Rocq for negative operands, following Rocq's a/0 = 0 and a mod 0 = a
+   conventions for a zero divisor (CWE-682). *)
+Crane Extract Inlined Constant Z.div =>
+"[&]() -> mpz_class {
+  mpz_class _a = %a0;
+  mpz_class _b = %a1;
+  if (_b == 0) return mpz_class(0);
+  mpz_class _q = _a / _b;
+  mpz_class _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _q - 1;
+  return _q;
+}()".
+Crane Extract Inlined Constant Z.modulo =>
+"[&]() -> mpz_class {
+  mpz_class _a = %a0;
+  mpz_class _b = %a1;
+  if (_b == 0) return _a;
+  mpz_class _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _r + _b;
+  return _r;
+}()".
 Crane Extract Inlined Constant Z.opp => "(-%a0)".
 Crane Extract Inlined Constant Z.abs => "abs(%a0)".
 Crane Extract Inlined Constant Z.succ => "(%a0 + 1)".
@@ -41,7 +63,14 @@ Crane Extract Inlined Constant Z.max => "(%a0 >= %a1 ? %a0 : %a1)".
 
 (* Conversions *)
 Crane Extract Inlined Constant Z.of_nat => "mpz_class(%a0)".
-Crane Extract Inlined Constant Z.to_nat => "static_cast<unsigned int>(%a0 < 0 ? 0 : %a0.get_ui())".
+(* [mpz_class::get_ui] only returns the low word of an arbitrary-precision
+   value. Rocq's [Z.to_nat] is total (negatives map to 0) but places no upper
+   bound on the result, so silently truncating a large positive value would
+   produce a wrapped, wrong result instead of surfacing the loss of precision
+   (CWE-190/CWE-681); we saturate at [UINT_MAX] instead. *)
+Crane Extract Inlined Constant Z.to_nat =>
+  "(%a0 < 0 ? 0 : (%a0 > mpz_class(UINT_MAX) ? UINT_MAX : static_cast<unsigned int>(%a0.get_ui())))"
+  From "climits".
 Crane Extract Inlined Constant Z.of_N => "mpz_class(%a0)".
 Crane Extract Inlined Constant Z.to_N => "(%a0 < 0 ? mpz_class(0) : %a0)".
 Crane Extract Inlined Constant Z.abs_N => "abs(%a0)".

--- a/theories/Mapping/ZInt.v
+++ b/theories/Mapping/ZInt.v
@@ -22,8 +22,30 @@ Crane Extract Numeral Z => "INT64_C(%n)".
 Crane Extract Inlined Constant Z.add => "(%a0 + %a1)".
 Crane Extract Inlined Constant Z.sub => "(%a0 - %a1)".
 Crane Extract Inlined Constant Z.mul => "(%a0 * %a1)".
-Crane Extract Inlined Constant Z.div => "(%a1 == 0 ? INT64_C(0) : %a0 / %a1)".
-Crane Extract Inlined Constant Z.modulo => "(%a1 == 0 ? INT64_C(0) : %a0 % %a1)".
+(* Rocq's Z.div / Z.modulo use *floored* division (the remainder takes the sign
+   of the divisor), whereas C++ / and % truncate toward zero. We compute the
+   truncated quotient/remainder once and apply the flooring correction so the
+   results match Rocq for negative operands, and follow Rocq's a/0 = 0 and
+   a mod 0 = a conventions for a zero divisor (CWE-682). *)
+Crane Extract Inlined Constant Z.div =>
+"[&]() -> int64_t {
+  int64_t _a = %a0;
+  int64_t _b = %a1;
+  if (_b == 0) return INT64_C(0);
+  int64_t _q = _a / _b;
+  int64_t _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _q - 1;
+  return _q;
+}()".
+Crane Extract Inlined Constant Z.modulo =>
+"[&]() -> int64_t {
+  int64_t _a = %a0;
+  int64_t _b = %a1;
+  if (_b == 0) return _a;
+  int64_t _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _r + _b;
+  return _r;
+}()".
 Crane Extract Inlined Constant Z.opp => "(-%a0)".
 Crane Extract Inlined Constant Z.abs => "std::abs(%a0)" From "cstdlib".
 Crane Extract Inlined Constant Z.succ => "(%a0 + 1)".

--- a/theories/Mapping/ZInt.v
+++ b/theories/Mapping/ZInt.v
@@ -18,20 +18,37 @@ Crane Extract Inductive Z =>
 
 Crane Extract Numeral Z => "INT64_C(%n)".
 
-(* Z operations *)
-Crane Extract Inlined Constant Z.add => "(%a0 + %a1)".
-Crane Extract Inlined Constant Z.sub => "(%a0 - %a1)".
-Crane Extract Inlined Constant Z.mul => "(%a0 * %a1)".
+(* Z operations.
+
+   [Z] is unbounded in Rocq but represented as [int64_t] here, so operations
+   that exceed the 64-bit range cannot match Rocq exactly. What we can and do
+   guarantee is that they never execute C++ *undefined behavior*: signed
+   overflow, negation/abs of INT64_MIN, and INT64_MIN / -1 are all UB, which an
+   optimizer may miscompile in ways that silently invalidate the verified
+   source's assumptions (CWE-190 / CWE-682). Each arithmetic op is therefore
+   computed in the unsigned domain, where wraparound is well-defined, and cast
+   back (C++20 mandates two's-complement, so the round-trip is defined). For
+   inputs whose true result fits in int64_t this is identical to native signed
+   arithmetic; only the out-of-range cases differ, and there they wrap
+   deterministically instead of being UB. *)
+Crane Extract Inlined Constant Z.add =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) + static_cast<uint64_t>(%a1))".
+Crane Extract Inlined Constant Z.sub =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) - static_cast<uint64_t>(%a1))".
+Crane Extract Inlined Constant Z.mul =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) * static_cast<uint64_t>(%a1))".
 (* Rocq's Z.div / Z.modulo use *floored* division (the remainder takes the sign
    of the divisor), whereas C++ / and % truncate toward zero. We compute the
    truncated quotient/remainder once and apply the flooring correction so the
    results match Rocq for negative operands, and follow Rocq's a/0 = 0 and
-   a mod 0 = a conventions for a zero divisor (CWE-682). *)
+   a mod 0 = a conventions for a zero divisor (CWE-682). The [_b == -1] case is
+   handled separately because INT64_MIN / -1 and INT64_MIN % -1 are UB. *)
 Crane Extract Inlined Constant Z.div =>
 "[&]() -> int64_t {
   int64_t _a = %a0;
   int64_t _b = %a1;
   if (_b == 0) return INT64_C(0);
+  if (_b == -1) return static_cast<int64_t>(-static_cast<uint64_t>(_a));
   int64_t _q = _a / _b;
   int64_t _r = _a % _b;
   if (_r != 0 && ((_r < 0) != (_b < 0))) return _q - 1;
@@ -42,14 +59,16 @@ Crane Extract Inlined Constant Z.modulo =>
   int64_t _a = %a0;
   int64_t _b = %a1;
   if (_b == 0) return _a;
+  if (_b == -1) return INT64_C(0);
   int64_t _r = _a % _b;
   if (_r != 0 && ((_r < 0) != (_b < 0))) return _r + _b;
   return _r;
 }()".
-Crane Extract Inlined Constant Z.opp => "(-%a0)".
-Crane Extract Inlined Constant Z.abs => "std::abs(%a0)" From "cstdlib".
-Crane Extract Inlined Constant Z.succ => "(%a0 + 1)".
-Crane Extract Inlined Constant Z.pred => "(%a0 - 1)".
+Crane Extract Inlined Constant Z.opp => "static_cast<int64_t>(-static_cast<uint64_t>(%a0))".
+Crane Extract Inlined Constant Z.abs =>
+  "(%a0 < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(%a0)) : %a0)".
+Crane Extract Inlined Constant Z.succ => "static_cast<int64_t>(static_cast<uint64_t>(%a0) + 1)".
+Crane Extract Inlined Constant Z.pred => "static_cast<int64_t>(static_cast<uint64_t>(%a0) - 1)".
 Crane Extract Inlined Constant Z.eqb => "%a0 == %a1".
 Crane Extract Inlined Constant Z.ltb => "%a0 < %a1".
 Crane Extract Inlined Constant Z.leb => "%a0 <= %a1".
@@ -63,4 +82,5 @@ Crane Extract Inlined Constant Z.of_nat => "static_cast<int64_t>(%a0)".
 Crane Extract Inlined Constant Z.to_nat => "static_cast<uint64_t>(%a0 < 0 ? 0 : %a0)".
 Crane Extract Inlined Constant Z.of_N => "static_cast<int64_t>(%a0)".
 Crane Extract Inlined Constant Z.to_N => "static_cast<unsigned int>(%a0 < 0 ? 0 : %a0)".
-Crane Extract Inlined Constant Z.abs_N => "static_cast<unsigned int>(std::abs(%a0))" From "cstdlib".
+Crane Extract Inlined Constant Z.abs_N =>
+  "static_cast<unsigned int>(%a0 < 0 ? -static_cast<uint64_t>(%a0) : static_cast<uint64_t>(%a0))".

--- a/theories/Mapping/ZIntBDE.v
+++ b/theories/Mapping/ZIntBDE.v
@@ -18,20 +18,37 @@ Crane Extract Inductive Z =>
 
 Crane Extract Numeral Z => "INT64_C(%n)".
 
-(* Z operations *)
-Crane Extract Inlined Constant Z.add => "(%a0 + %a1)".
-Crane Extract Inlined Constant Z.sub => "(%a0 - %a1)".
-Crane Extract Inlined Constant Z.mul => "(%a0 * %a1)".
+(* Z operations.
+
+   [Z] is unbounded in Rocq but represented as [int64_t] here, so operations
+   that exceed the 64-bit range cannot match Rocq exactly. What we can and do
+   guarantee is that they never execute C++ *undefined behavior*: signed
+   overflow, negation/abs of INT64_MIN, and INT64_MIN / -1 are all UB, which an
+   optimizer may miscompile in ways that silently invalidate the verified
+   source's assumptions (CWE-190 / CWE-682). Each arithmetic op is therefore
+   computed in the unsigned domain, where wraparound is well-defined, and cast
+   back (C++20 mandates two's-complement, so the round-trip is defined). For
+   inputs whose true result fits in int64_t this is identical to native signed
+   arithmetic; only the out-of-range cases differ, and there they wrap
+   deterministically instead of being UB. *)
+Crane Extract Inlined Constant Z.add =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) + static_cast<uint64_t>(%a1))".
+Crane Extract Inlined Constant Z.sub =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) - static_cast<uint64_t>(%a1))".
+Crane Extract Inlined Constant Z.mul =>
+  "static_cast<int64_t>(static_cast<uint64_t>(%a0) * static_cast<uint64_t>(%a1))".
 (* Rocq's Z.div / Z.modulo use *floored* division (the remainder takes the sign
    of the divisor), whereas C++ / and % truncate toward zero. We compute the
    truncated quotient/remainder once and apply the flooring correction so the
    results match Rocq for negative operands, and follow Rocq's a/0 = 0 and
-   a mod 0 = a conventions for a zero divisor (CWE-682). *)
+   a mod 0 = a conventions for a zero divisor (CWE-682). The [_b == -1] case is
+   handled separately because INT64_MIN / -1 and INT64_MIN % -1 are UB. *)
 Crane Extract Inlined Constant Z.div =>
 "[&]() -> int64_t {
   int64_t _a = %a0;
   int64_t _b = %a1;
   if (_b == 0) return INT64_C(0);
+  if (_b == -1) return static_cast<int64_t>(-static_cast<uint64_t>(_a));
   int64_t _q = _a / _b;
   int64_t _r = _a % _b;
   if (_r != 0 && ((_r < 0) != (_b < 0))) return _q - 1;
@@ -42,14 +59,16 @@ Crane Extract Inlined Constant Z.modulo =>
   int64_t _a = %a0;
   int64_t _b = %a1;
   if (_b == 0) return _a;
+  if (_b == -1) return INT64_C(0);
   int64_t _r = _a % _b;
   if (_r != 0 && ((_r < 0) != (_b < 0))) return _r + _b;
   return _r;
 }()".
-Crane Extract Inlined Constant Z.opp => "(-%a0)".
-Crane Extract Inlined Constant Z.abs => "bsl::abs(%a0)" From "bsl_cstdlib.h".
-Crane Extract Inlined Constant Z.succ => "(%a0 + 1)".
-Crane Extract Inlined Constant Z.pred => "(%a0 - 1)".
+Crane Extract Inlined Constant Z.opp => "static_cast<int64_t>(-static_cast<uint64_t>(%a0))".
+Crane Extract Inlined Constant Z.abs =>
+  "(%a0 < 0 ? static_cast<int64_t>(-static_cast<uint64_t>(%a0)) : %a0)".
+Crane Extract Inlined Constant Z.succ => "static_cast<int64_t>(static_cast<uint64_t>(%a0) + 1)".
+Crane Extract Inlined Constant Z.pred => "static_cast<int64_t>(static_cast<uint64_t>(%a0) - 1)".
 Crane Extract Inlined Constant Z.eqb => "%a0 == %a1".
 Crane Extract Inlined Constant Z.ltb => "%a0 < %a1".
 Crane Extract Inlined Constant Z.leb => "%a0 <= %a1".
@@ -63,4 +82,5 @@ Crane Extract Inlined Constant Z.of_nat => "static_cast<int64_t>(%a0)".
 Crane Extract Inlined Constant Z.to_nat => "static_cast<unsigned int>(%a0 < 0 ? 0 : %a0)".
 Crane Extract Inlined Constant Z.of_N => "static_cast<int64_t>(%a0)".
 Crane Extract Inlined Constant Z.to_N => "static_cast<unsigned int>(%a0 < 0 ? 0 : %a0)".
-Crane Extract Inlined Constant Z.abs_N => "static_cast<unsigned int>(bsl::abs(%a0))" From "bsl_cstdlib.h".
+Crane Extract Inlined Constant Z.abs_N =>
+  "static_cast<unsigned int>(%a0 < 0 ? -static_cast<uint64_t>(%a0) : static_cast<uint64_t>(%a0))".

--- a/theories/Mapping/ZIntBDE.v
+++ b/theories/Mapping/ZIntBDE.v
@@ -22,8 +22,30 @@ Crane Extract Numeral Z => "INT64_C(%n)".
 Crane Extract Inlined Constant Z.add => "(%a0 + %a1)".
 Crane Extract Inlined Constant Z.sub => "(%a0 - %a1)".
 Crane Extract Inlined Constant Z.mul => "(%a0 * %a1)".
-Crane Extract Inlined Constant Z.div => "(%a1 == 0 ? INT64_C(0) : %a0 / %a1)".
-Crane Extract Inlined Constant Z.modulo => "(%a1 == 0 ? INT64_C(0) : %a0 % %a1)".
+(* Rocq's Z.div / Z.modulo use *floored* division (the remainder takes the sign
+   of the divisor), whereas C++ / and % truncate toward zero. We compute the
+   truncated quotient/remainder once and apply the flooring correction so the
+   results match Rocq for negative operands, and follow Rocq's a/0 = 0 and
+   a mod 0 = a conventions for a zero divisor (CWE-682). *)
+Crane Extract Inlined Constant Z.div =>
+"[&]() -> int64_t {
+  int64_t _a = %a0;
+  int64_t _b = %a1;
+  if (_b == 0) return INT64_C(0);
+  int64_t _q = _a / _b;
+  int64_t _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _q - 1;
+  return _q;
+}()".
+Crane Extract Inlined Constant Z.modulo =>
+"[&]() -> int64_t {
+  int64_t _a = %a0;
+  int64_t _b = %a1;
+  if (_b == 0) return _a;
+  int64_t _r = _a % _b;
+  if (_r != 0 && ((_r < 0) != (_b < 0))) return _r + _b;
+  return _r;
+}()".
 Crane Extract Inlined Constant Z.opp => "(-%a0)".
 Crane Extract Inlined Constant Z.abs => "bsl::abs(%a0)" From "bsl_cstdlib.h".
 Crane Extract Inlined Constant Z.succ => "(%a0 + 1)".

--- a/theories/Monads/Dir.v
+++ b/theories/Monads/Dir.v
@@ -10,35 +10,52 @@ From Crane Require Extraction.
 From Crane Require Import Mapping.Std.
 From Crane Require Export Monads.DirDefs.
 
+(**
+   Safety: every mapping uses the non-throwing [std::error_code] overload so an
+   invalid, inaccessible, or raced path degrades to the neutral result
+   ([false] / empty list / empty string) instead of raising a
+   [std::filesystem_error] that terminates the generated process (CWE-248 /
+   CWE-755). [list_directory] additionally caps the number of
+   entries it accumulates so a huge or adversarial directory cannot exhaust
+   memory (CWE-400); on the cap or on any iteration error it
+   returns the entries gathered so far.
+*)
 Crane Extract Inductive dirE => ""
-  [ "std::filesystem::create_directories(std::filesystem::path(%a0))"
-    "std::filesystem::remove_all(std::filesystem::path(%a0))"
+  [ "[&]() -> bool { std::error_code _ec; std::filesystem::create_directories(std::filesystem::path(%a0), _ec); return !_ec; }()"
+    "[&]() -> bool { std::error_code _ec; std::filesystem::remove_all(std::filesystem::path(%a0), _ec); return !_ec; }()"
     "[&]() -> List<std::string> {
   auto result = List<std::string>::nil();
-  for (const auto& entry : std::filesystem::directory_iterator(%a0)) {
-    result = List<std::string>::cons(entry.path().filename().string(), std::move(result));
+  std::error_code _ec;
+  std::size_t _count = 0;
+  std::filesystem::directory_iterator _it(std::filesystem::path(%a0), _ec), _end;
+  for (; !_ec && _it != _end && _count < 65536; _it.increment(_ec), ++_count) {
+    result = List<std::string>::cons(_it->path().filename().string(), std::move(result));
   }
   return result;
 }()"
-    "std::filesystem::current_path().string()" ]
-  From "filesystem".
+    "[&]() -> std::string { std::error_code _ec; auto _p = std::filesystem::current_path(_ec); return _ec ? std::string{} : _p.string(); }()" ]
+  From "filesystem" "system_error".
 
 Crane Extract Inlined Constant create_directory =>
-  "std::filesystem::create_directories(std::filesystem::path(%a0))"
-  From "filesystem".
+  "[&]() -> bool { std::error_code _ec; std::filesystem::create_directories(std::filesystem::path(%a0), _ec); return !_ec; }()"
+  From "filesystem" "system_error".
 
 Crane Extract Inlined Constant remove_directory =>
-  "std::filesystem::remove_all(std::filesystem::path(%a0))"
-  From "filesystem".
+  "[&]() -> bool { std::error_code _ec; std::filesystem::remove_all(std::filesystem::path(%a0), _ec); return !_ec; }()"
+  From "filesystem" "system_error".
 
 Crane Extract Inlined Constant list_directory =>
 "[&]() -> List<std::string> {
   auto result = List<std::string>::nil();
-  for (const auto& entry : std::filesystem::directory_iterator(%a0)) {
-    result = List<std::string>::cons(entry.path().filename().string(), std::move(result));
+  std::error_code _ec;
+  std::size_t _count = 0;
+  std::filesystem::directory_iterator _it(std::filesystem::path(%a0), _ec), _end;
+  for (; !_ec && _it != _end && _count < 65536; _it.increment(_ec), ++_count) {
+    result = List<std::string>::cons(_it->path().filename().string(), std::move(result));
   }
   return result;
-}()" From "filesystem".
+}()" From "filesystem" "system_error".
 
 Crane Extract Inlined Constant current_path =>
-  "std::filesystem::current_path().string()" From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _p = std::filesystem::current_path(_ec); return _ec ? std::string{} : _p.string(); }()"
+  From "filesystem" "system_error".

--- a/theories/Monads/DirBDE.v
+++ b/theories/Monads/DirBDE.v
@@ -10,18 +10,30 @@ From Crane Require Extraction.
 From Crane Require Import Mapping.BDE.
 From Crane Require Export Monads.DirDefs.
 
+(**
+   Safety: the BDE create/remove/getWorkingDirectory mappings already report
+   failure by return value rather than throwing. [list_directory] uses the
+   non-throwing [std::error_code] overload of [directory_iterator] so an
+   invalid or raced path degrades to an empty list instead of terminating the
+   process (CWE-248 / CWE-755), and caps the number of entries it
+   accumulates so a huge or adversarial directory cannot exhaust memory
+   (CWE-400).
+*)
 Crane Extract Inductive dirE => ""
   [ "(bdls::FilesystemUtil::createDirectories(%a0.c_str(), true) == 0)"
     "(bdls::FilesystemUtil::remove(%a0.c_str(), true) == 0)"
     "[&]() -> List<bsl::string> {
   auto result = List<bsl::string>::nil();
-  for (const auto& entry : std::filesystem::directory_iterator(%a0)) {
-    result = List<bsl::string>::cons(entry.path().filename().string(), std::move(result));
+  std::error_code _ec;
+  std::size_t _count = 0;
+  std::filesystem::directory_iterator _it(std::filesystem::path(%a0), _ec), _end;
+  for (; !_ec && _it != _end && _count < 65536; _it.increment(_ec), ++_count) {
+    result = List<bsl::string>::cons(_it->path().filename().string(), std::move(result));
   }
   return result;
 }()"
     "[&]() -> bsl::string { bsl::string s; bdls::FilesystemUtil::getWorkingDirectory(&s); return s; }()" ]
-  From "bdls_filesystemutil.h" "filesystem".
+  From "bdls_filesystemutil.h" "filesystem" "system_error".
 
 Crane Extract Inlined Constant create_directory =>
   "(bdls::FilesystemUtil::createDirectories(%a0.c_str(), true) == 0)"
@@ -34,11 +46,14 @@ Crane Extract Inlined Constant remove_directory =>
 Crane Extract Inlined Constant list_directory =>
 "[&]() -> List<bsl::string> {
   auto result = List<bsl::string>::nil();
-  for (const auto& entry : std::filesystem::directory_iterator(%a0)) {
-    result = List<bsl::string>::cons(entry.path().filename().string(), std::move(result));
+  std::error_code _ec;
+  std::size_t _count = 0;
+  std::filesystem::directory_iterator _it(std::filesystem::path(%a0), _ec), _end;
+  for (; !_ec && _it != _end && _count < 65536; _it.increment(_ec), ++_count) {
+    result = List<bsl::string>::cons(_it->path().filename().string(), std::move(result));
   }
   return result;
-}()" From "bdls_filesystemutil.h" "filesystem".
+}()" From "bdls_filesystemutil.h" "filesystem" "system_error".
 
 Crane Extract Inlined Constant current_path =>
   "[&]() -> bsl::string { bsl::string s; bdls::FilesystemUtil::getWorkingDirectory(&s); return s; }()"

--- a/theories/Monads/DirDefs.v
+++ b/theories/Monads/DirDefs.v
@@ -11,6 +11,27 @@ From Corelib Require Import PrimString.
 From Crane Require Extraction.
 From Crane Require Import Monads.ITree.
 
+(**
+   Security note (CWE-22 / CWE-73).
+
+   [dirE] grants raw host filesystem authority: the path argument of
+   [CreateDirectory], [RemoveDirectory], and [ListDirectory] is passed to the
+   underlying C++ filesystem call verbatim, so an absolute path or a [..]
+   traversal reaches whatever the generated process can access. In particular
+   [RemoveDirectory] maps to a *recursive* delete, so an attacker-influenced
+   path can remove an arbitrary directory tree. This is intentional -- these
+   are general-purpose directory effects with no single containment root, so
+   path confinement is a policy only the *embedding application* can define.
+
+   A program that exposes these effects to untrusted input MUST confine the
+   path before calling the effect (canonicalize and check containment under an
+   approved root, reject absolute paths and [..] where unsafe) and should treat
+   [RemoveDirectory] as an opt-in destructive operation. The mappings
+   themselves only guarantee that a failed or malformed path degrades to a
+   neutral result rather than crashing the process, and that [ListDirectory]
+   caps the number of entries it materializes (see [Dir.v]); they do NOT
+   restrict which paths are reachable.
+*)
 Inductive dirE : Type -> Type :=
 | CreateDirectory : string -> dirE bool
 | RemoveDirectory : string -> dirE bool

--- a/theories/Monads/IO.v
+++ b/theories/Monads/IO.v
@@ -35,9 +35,9 @@ Crane Extract Inductive fileE => ""
   std::ofstream file(%a0, std::ios::app);
   file << %a1;
 }()"
-    "std::filesystem::exists(std::filesystem::path(%a0))"
-    "std::filesystem::remove(std::filesystem::path(%a0))" ]
-  From "fstream" "filesystem".
+    "[&]() -> bool { std::error_code _ec; return std::filesystem::exists(std::filesystem::path(%a0), _ec); }()"
+    "[&]() { std::error_code _ec; std::filesystem::remove(std::filesystem::path(%a0), _ec); }()" ]
+  From "fstream" "filesystem" "system_error".
 
 Crane Extract Inlined Constant print => "std::cout << %a0" From "iostream".
 Crane Extract Inlined Constant print_endline => "std::cout << %a0 << '\n'" From "iostream".
@@ -68,7 +68,13 @@ Crane Extract Inlined Constant append_file =>
   file << %a1;
 }()" From "fstream".
 
+(* [file_exists]/[remove_file] use the non-throwing [std::error_code] overload:
+   the Rocq effects return plain [bool]/[unit] with no error channel, so an
+   invalid, inaccessible, or raced path must not raise a [std::filesystem_error]
+   that terminates the generated process (CWE-248 / CWE-755). *)
 Crane Extract Inlined Constant file_exists =>
-  "std::filesystem::exists(std::filesystem::path(%a0))" From "filesystem".
+  "[&]() -> bool { std::error_code _ec; return std::filesystem::exists(std::filesystem::path(%a0), _ec); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant remove_file =>
-  "std::filesystem::remove(std::filesystem::path(%a0))" From "filesystem".
+  "[&]() { std::error_code _ec; std::filesystem::remove(std::filesystem::path(%a0), _ec); }()"
+  From "filesystem" "system_error".

--- a/theories/Monads/IODefs.v
+++ b/theories/Monads/IODefs.v
@@ -17,6 +17,27 @@ Inductive consoleE : Type -> Type :=
 | PrintEndline : string -> consoleE unit
 | GetLine : consoleE string.
 
+(**
+   Security note (CWE-22 / CWE-73).
+
+   [fileE] grants raw host filesystem authority: the path argument of
+   [ReadFile], [WriteFile], [AppendFile], [FileExists], and [RemoveFile] is
+   passed through to the underlying C++ filesystem call verbatim, so an
+   absolute path or a [..] traversal reaches whatever the generated process
+   can access. This is intentional -- these are general-purpose filesystem
+   effects with no single containment root, so path confinement is a policy
+   only the *embedding application* can define.
+
+   A program that exposes these effects to untrusted input MUST confine the
+   path before calling the effect (canonicalize and check containment under an
+   approved root, reject absolute paths and [..] where unsafe, and gate
+   destructive operations). The mappings themselves only guarantee that a
+   failed or malformed path degrades to a neutral result rather than crashing
+   the process (see [IO.v]); they do NOT restrict which paths are reachable.
+   For containment guarantees, use [tempFileE] (see [TempFileDefs.v]), whose
+   mappings reduce the caller prefix to a single filename component under the
+   system temporary directory.
+*)
 Inductive fileE : Type -> Type :=
 | ReadFile : string -> fileE string
 | WriteFile : string -> string -> fileE unit

--- a/theories/Monads/Path.v
+++ b/theories/Monads/Path.v
@@ -10,26 +10,34 @@ From Crane Require Extraction.
 From Crane Require Import Mapping.Std.
 From Crane Require Export Monads.PathDefs.
 
+(**
+   Safety: every mapping uses the non-throwing [std::error_code] overload so
+   that an ordinary invalid, inaccessible, or raced path cannot raise a
+   [std::filesystem_error] that terminates the generated process. The Rocq
+   effects return a plain [string]/[bool] with no error channel, so a failed
+   query degrades to the neutral result (empty string / [false]) instead of
+   crashing (CWE-248 / CWE-755).
+*)
 Crane Extract Inductive pathE => ""
-  [ "std::filesystem::canonical(std::filesystem::path(%a0)).string()"
-    "std::filesystem::relative(std::filesystem::path(%a0)).string()"
-    "std::filesystem::absolute(std::filesystem::path(%a0)).string()"
-    "std::filesystem::is_directory(std::filesystem::path(%a0))"
-    "std::filesystem::is_regular_file(std::filesystem::path(%a0))" ]
-  From "filesystem".
+  [ "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::canonical(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+    "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::relative(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+    "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::absolute(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+    "[&]() -> bool { std::error_code _ec; return std::filesystem::is_directory(std::filesystem::path(%a0), _ec); }()"
+    "[&]() -> bool { std::error_code _ec; return std::filesystem::is_regular_file(std::filesystem::path(%a0), _ec); }()" ]
+  From "filesystem" "system_error".
 
 Crane Extract Inlined Constant canonical =>
-  "std::filesystem::canonical(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::canonical(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant relative =>
-  "std::filesystem::relative(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::relative(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant absolute =>
-  "std::filesystem::absolute(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::absolute(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant is_directory =>
-  "std::filesystem::is_directory(std::filesystem::path(%a0))"
-  From "filesystem".
+  "[&]() -> bool { std::error_code _ec; return std::filesystem::is_directory(std::filesystem::path(%a0), _ec); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant is_regular_file =>
-  "std::filesystem::is_regular_file(std::filesystem::path(%a0))"
-  From "filesystem".
+  "[&]() -> bool { std::error_code _ec; return std::filesystem::is_regular_file(std::filesystem::path(%a0), _ec); }()"
+  From "filesystem" "system_error".

--- a/theories/Monads/PathBDE.v
+++ b/theories/Monads/PathBDE.v
@@ -11,23 +11,31 @@ From Crane Require Extraction.
 From Crane Require Import Mapping.BDE.
 From Crane Require Export Monads.PathDefs.
 
+(**
+   Safety: the [std::filesystem] path-normalization mappings use the
+   non-throwing [std::error_code] overload so an invalid or inaccessible path
+   degrades to the empty string rather than raising a [std::filesystem_error]
+   that terminates the generated process. The Rocq effects carry no error
+   channel (CWE-248 / CWE-755). The BDE predicate mappings
+   ([isDirectory]/[isRegularFile]) already report failure by return value.
+*)
 Crane Extract Inductive pathE => ""
-  [ "std::filesystem::canonical(std::filesystem::path(%a0)).string()"
-    "std::filesystem::relative(std::filesystem::path(%a0)).string()"
-    "std::filesystem::absolute(std::filesystem::path(%a0)).string()"
+  [ "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::canonical(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+    "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::relative(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+    "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::absolute(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
     "bdls::FilesystemUtil::isDirectory(%a0)"
     "bdls::FilesystemUtil::isRegularFile(%a0)" ]
-  From "filesystem" "bdls_filesystemutil.h".
+  From "filesystem" "system_error" "bdls_filesystemutil.h".
 
 Crane Extract Inlined Constant canonical =>
-  "std::filesystem::canonical(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::canonical(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant relative =>
-  "std::filesystem::relative(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::relative(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant absolute =>
-  "std::filesystem::absolute(std::filesystem::path(%a0)).string()"
-  From "filesystem".
+  "[&]() -> std::string { std::error_code _ec; auto _r = std::filesystem::absolute(std::filesystem::path(%a0), _ec); return _ec ? std::string{} : _r.string(); }()"
+  From "filesystem" "system_error".
 Crane Extract Inlined Constant is_directory =>
   "bdls::FilesystemUtil::isDirectory(%a0)"
   From "bdls_filesystemutil.h".

--- a/theories/Monads/TempFile.v
+++ b/theories/Monads/TempFile.v
@@ -6,14 +6,19 @@
    Re-exports shared definitions from [TempFileDefs.v] and adds C++
    extraction mappings targeting the standard library ([std::]).
 
-   Safety: the caller-supplied prefix is reduced to a single filename
-   component ([std::filesystem::path::filename]) so directory separators,
-   [..], or an absolute path cannot place the entry outside the system
-   temporary directory (CWE-22). Entries are created with an unpredictable
-   name and O_EXCL / mkdir, which fail atomically if the path already exists
-   (so a pre-created file or symlink is never followed), and with owner-only
-   permissions. Failure is reported by exception rather than returning an
-   invalid path.
+   Safety:
+   - The caller-supplied prefix is reduced to a single filename component
+     ([std::filesystem::path::filename]) so directory separators, [..], or an
+     absolute path cannot escape the system temporary directory (CWE-22).
+   - Entries are created with an unpredictable name and O_EXCL / mkdir, which
+     fail atomically if the path already exists (so a pre-created file or
+     symlink is never followed), and with owner-only permissions.
+   - A temporary *file* is created inside a fresh owner-only (0700) directory.
+     Because no other user can traverse that directory, the returned path
+     cannot be swapped or symlink-raced by a local attacker before the caller
+     reopens it -- the effect returns a path rather than the secure descriptor,
+     so this containment is what keeps later opens safe (CWE-367 / CWE-377).
+   - Failures are reported by exception rather than returning an invalid path.
 *)
 From Crane Require Extraction.
 From Crane Require Import Mapping.Std.
@@ -23,15 +28,21 @@ Crane Extract Inductive tempFileE => ""
   [ "[&]() -> std::string {
   std::string _n = std::filesystem::path(%a0).filename().string();
   if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
-  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::filesystem::path _base = std::filesystem::temp_directory_path();
   std::random_device _rng;
   for (;;) {
-    std::string _p =
-      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    std::string _d =
+      (_base / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    if (::mkdir(_d.c_str(), 0700) != 0) {
+      if (errno == EEXIST) continue;
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+    }
+    std::string _p = _d + ""/"" + _n;
     int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-    if (_fd >= 0) { ::close(_fd); return _p; }
-    if (errno != EEXIST)
+    if (_fd < 0)
       throw std::runtime_error(""crane: failed to create temporary file"");
+    ::close(_fd);
+    return _p;
   }
 }()"
     "[&]() -> std::string {
@@ -54,18 +65,24 @@ Crane Extract Inlined Constant create_temp_file =>
 "[&]() -> std::string {
   std::string _n = std::filesystem::path(%a0).filename().string();
   if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
-  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::filesystem::path _base = std::filesystem::temp_directory_path();
   std::random_device _rng;
   for (;;) {
-    std::string _p =
-      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    std::string _d =
+      (_base / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    if (::mkdir(_d.c_str(), 0700) != 0) {
+      if (errno == EEXIST) continue;
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+    }
+    std::string _p = _d + ""/"" + _n;
     int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-    if (_fd >= 0) { ::close(_fd); return _p; }
-    if (errno != EEXIST)
+    if (_fd < 0)
       throw std::runtime_error(""crane: failed to create temporary file"");
+    ::close(_fd);
+    return _p;
   }
-}()" From "filesystem" "random" "string" "fcntl.h" "unistd.h" "cerrno"
-       "stdexcept".
+}()" From "filesystem" "random" "string" "fcntl.h" "sys/stat.h" "unistd.h"
+       "cerrno" "stdexcept".
 
 Crane Extract Inlined Constant create_temp_dir =>
 "[&]() -> std::string {

--- a/theories/Monads/TempFile.v
+++ b/theories/Monads/TempFile.v
@@ -5,6 +5,15 @@
 
    Re-exports shared definitions from [TempFileDefs.v] and adds C++
    extraction mappings targeting the standard library ([std::]).
+
+   Safety: the caller-supplied prefix is reduced to a single filename
+   component ([std::filesystem::path::filename]) so directory separators,
+   [..], or an absolute path cannot place the entry outside the system
+   temporary directory (CWE-22). Entries are created with an unpredictable
+   name and O_EXCL / mkdir, which fail atomically if the path already exists
+   (so a pre-created file or symlink is never followed), and with owner-only
+   permissions. Failure is reported by exception rather than returning an
+   invalid path.
 *)
 From Crane Require Extraction.
 From Crane Require Import Mapping.Std.
@@ -12,31 +21,63 @@ From Crane Require Export Monads.TempFileDefs.
 
 Crane Extract Inductive tempFileE => ""
   [ "[&]() -> std::string {
-  auto p = std::filesystem::temp_directory_path() / (%a0 + ""XXXXXX"");
-  std::string s = p.string();
-  int fd = mkstemp(s.data());
-  if (fd >= 0) ::close(fd);
-  return s;
+  std::string _n = std::filesystem::path(%a0).filename().string();
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::random_device _rng;
+  for (;;) {
+    std::string _p =
+      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (_fd >= 0) { ::close(_fd); return _p; }
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary file"");
+  }
 }()"
     "[&]() -> std::string {
-  auto p = std::filesystem::temp_directory_path() / (%a0 + ""XXXXXX"");
-  std::string s = p.string();
-  return std::string(mkdtemp(s.data()));
+  std::string _n = std::filesystem::path(%a0).filename().string();
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::random_device _rng;
+  for (;;) {
+    std::string _p =
+      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    if (::mkdir(_p.c_str(), 0700) == 0) return _p;
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+  }
 }()" ]
-  From "filesystem" "cstdlib" "unistd.h".
+  From "filesystem" "random" "string" "fcntl.h" "sys/stat.h" "unistd.h"
+       "cerrno" "stdexcept".
 
 Crane Extract Inlined Constant create_temp_file =>
 "[&]() -> std::string {
-  auto p = std::filesystem::temp_directory_path() / (%a0 + ""XXXXXX"");
-  std::string s = p.string();
-  int fd = mkstemp(s.data());
-  if (fd >= 0) ::close(fd);
-  return s;
-}()" From "filesystem" "cstdlib" "unistd.h".
+  std::string _n = std::filesystem::path(%a0).filename().string();
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::random_device _rng;
+  for (;;) {
+    std::string _p =
+      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (_fd >= 0) { ::close(_fd); return _p; }
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary file"");
+  }
+}()" From "filesystem" "random" "string" "fcntl.h" "unistd.h" "cerrno"
+       "stdexcept".
 
 Crane Extract Inlined Constant create_temp_dir =>
 "[&]() -> std::string {
-  auto p = std::filesystem::temp_directory_path() / (%a0 + ""XXXXXX"");
-  std::string s = p.string();
-  return std::string(mkdtemp(s.data()));
-}()" From "filesystem" "cstdlib".
+  std::string _n = std::filesystem::path(%a0).filename().string();
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::filesystem::path _dir = std::filesystem::temp_directory_path();
+  std::random_device _rng;
+  for (;;) {
+    std::string _p =
+      (_dir / (_n + std::to_string(_rng()) + std::to_string(_rng()))).string();
+    if (::mkdir(_p.c_str(), 0700) == 0) return _p;
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+  }
+}()" From "filesystem" "random" "string" "sys/stat.h" "cerrno" "stdexcept".

--- a/theories/Monads/TempFileBDE.v
+++ b/theories/Monads/TempFileBDE.v
@@ -6,14 +6,19 @@
    Re-exports shared definitions from [TempFileDefs.v] and adds C++
    extraction mappings targeting BDE ([bsl::]).
 
-   Safety: the caller-supplied prefix is reduced to a single filename
-   component (everything after the last ['/']) so directory separators, [..],
-   or an absolute path cannot place the entry outside the system temporary
-   directory (CWE-22). Entries are created with an unpredictable name and
-   O_EXCL / mkdir, which fail atomically if the path already exists (so a
-   pre-created file or symlink is never followed), and with owner-only
-   permissions. Failure is reported by exception rather than returning an
-   invalid path.
+   Safety:
+   - The caller-supplied prefix is reduced to a single filename component
+     (everything after the last ['/']) so directory separators, [..], or an
+     absolute path cannot escape the system temporary directory (CWE-22).
+   - Entries are created with an unpredictable name and O_EXCL / mkdir, which
+     fail atomically if the path already exists (so a pre-created file or
+     symlink is never followed), and with owner-only permissions.
+   - A temporary *file* is created inside a fresh owner-only (0700) directory.
+     Because no other user can traverse that directory, the returned path
+     cannot be swapped or symlink-raced by a local attacker before the caller
+     reopens it -- the effect returns a path rather than the secure descriptor,
+     so this containment is what keeps later opens safe (CWE-367 / CWE-377).
+   - Failures are reported by exception rather than returning an invalid path.
 *)
 From Crane Require Extraction.
 From Crane Require Import Mapping.BDE.
@@ -21,25 +26,31 @@ From Crane Require Export Monads.TempFileDefs.
 
 Crane Extract Inductive tempFileE => ""
   [ "[&]() -> bsl::string {
-  bsl::string _dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _base;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_base);
   bsl::string _n = %a0;
   bsl::string::size_type _sl = _n.find_last_of('/');
   if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
   if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
   std::random_device _rng;
   for (;;) {
-    bsl::string _p =
-      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    bsl::string _d =
+      _base + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    if (::mkdir(_d.c_str(), 0700) != 0) {
+      if (errno == EEXIST) continue;
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+    }
+    bsl::string _p = _d + ""/"" + _n;
     int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-    if (_fd >= 0) { ::close(_fd); return _p; }
-    if (errno != EEXIST)
+    if (_fd < 0)
       throw std::runtime_error(""crane: failed to create temporary file"");
+    ::close(_fd);
+    return _p;
   }
 }()"
     "[&]() -> bsl::string {
-  bsl::string _dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _base;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_base);
   bsl::string _n = %a0;
   bsl::string::size_type _sl = _n.find_last_of('/');
   if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
@@ -47,7 +58,7 @@ Crane Extract Inductive tempFileE => ""
   std::random_device _rng;
   for (;;) {
     bsl::string _p =
-      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+      _base + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
     if (::mkdir(_p.c_str(), 0700) == 0) return _p;
     if (errno != EEXIST)
       throw std::runtime_error(""crane: failed to create temporary directory"");
@@ -58,28 +69,34 @@ Crane Extract Inductive tempFileE => ""
 
 Crane Extract Inlined Constant create_temp_file =>
 "[&]() -> bsl::string {
-  bsl::string _dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _base;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_base);
   bsl::string _n = %a0;
   bsl::string::size_type _sl = _n.find_last_of('/');
   if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
   if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
   std::random_device _rng;
   for (;;) {
-    bsl::string _p =
-      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    bsl::string _d =
+      _base + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    if (::mkdir(_d.c_str(), 0700) != 0) {
+      if (errno == EEXIST) continue;
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+    }
+    bsl::string _p = _d + ""/"" + _n;
     int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-    if (_fd >= 0) { ::close(_fd); return _p; }
-    if (errno != EEXIST)
+    if (_fd < 0)
       throw std::runtime_error(""crane: failed to create temporary file"");
+    ::close(_fd);
+    return _p;
   }
 }()" From "bdls_filesystemutil.h" "bsl_string.h" "random" "fcntl.h"
-       "unistd.h" "cerrno" "stdexcept".
+       "sys/stat.h" "unistd.h" "cerrno" "stdexcept".
 
 Crane Extract Inlined Constant create_temp_dir =>
 "[&]() -> bsl::string {
-  bsl::string _dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _base;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_base);
   bsl::string _n = %a0;
   bsl::string::size_type _sl = _n.find_last_of('/');
   if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
@@ -87,7 +104,7 @@ Crane Extract Inlined Constant create_temp_dir =>
   std::random_device _rng;
   for (;;) {
     bsl::string _p =
-      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+      _base + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
     if (::mkdir(_p.c_str(), 0700) == 0) return _p;
     if (errno != EEXIST)
       throw std::runtime_error(""crane: failed to create temporary directory"");

--- a/theories/Monads/TempFileBDE.v
+++ b/theories/Monads/TempFileBDE.v
@@ -5,6 +5,15 @@
 
    Re-exports shared definitions from [TempFileDefs.v] and adds C++
    extraction mappings targeting BDE ([bsl::]).
+
+   Safety: the caller-supplied prefix is reduced to a single filename
+   component (everything after the last ['/']) so directory separators, [..],
+   or an absolute path cannot place the entry outside the system temporary
+   directory (CWE-22). Entries are created with an unpredictable name and
+   O_EXCL / mkdir, which fail atomically if the path already exists (so a
+   pre-created file or symlink is never followed), and with owner-only
+   permissions. Failure is reported by exception rather than returning an
+   invalid path.
 *)
 From Crane Require Extraction.
 From Crane Require Import Mapping.BDE.
@@ -12,35 +21,76 @@ From Crane Require Export Monads.TempFileDefs.
 
 Crane Extract Inductive tempFileE => ""
   [ "[&]() -> bsl::string {
-  bsl::string dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&dir);
-  bsl::string s = dir + ""/"" + %a0 + ""XXXXXX"";
-  int fd = mkstemp(s.data());
-  if (fd >= 0) ::close(fd);
-  return s;
+  bsl::string _dir;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _n = %a0;
+  bsl::string::size_type _sl = _n.find_last_of('/');
+  if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::random_device _rng;
+  for (;;) {
+    bsl::string _p =
+      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (_fd >= 0) { ::close(_fd); return _p; }
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary file"");
+  }
 }()"
     "[&]() -> bsl::string {
-  bsl::string dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&dir);
-  bsl::string s = dir + ""/"" + %a0 + ""XXXXXX"";
-  return bsl::string(mkdtemp(s.data()));
+  bsl::string _dir;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _n = %a0;
+  bsl::string::size_type _sl = _n.find_last_of('/');
+  if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::random_device _rng;
+  for (;;) {
+    bsl::string _p =
+      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    if (::mkdir(_p.c_str(), 0700) == 0) return _p;
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+  }
 }()" ]
-  From "bdls_filesystemutil.h" "cstdlib" "unistd.h".
+  From "bdls_filesystemutil.h" "bsl_string.h" "random" "fcntl.h" "sys/stat.h"
+       "unistd.h" "cerrno" "stdexcept".
 
 Crane Extract Inlined Constant create_temp_file =>
 "[&]() -> bsl::string {
-  bsl::string dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&dir);
-  bsl::string s = dir + ""/"" + %a0 + ""XXXXXX"";
-  int fd = mkstemp(s.data());
-  if (fd >= 0) ::close(fd);
-  return s;
-}()" From "bdls_filesystemutil.h" "cstdlib" "unistd.h".
+  bsl::string _dir;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _n = %a0;
+  bsl::string::size_type _sl = _n.find_last_of('/');
+  if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::random_device _rng;
+  for (;;) {
+    bsl::string _p =
+      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    int _fd = ::open(_p.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (_fd >= 0) { ::close(_fd); return _p; }
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary file"");
+  }
+}()" From "bdls_filesystemutil.h" "bsl_string.h" "random" "fcntl.h"
+       "unistd.h" "cerrno" "stdexcept".
 
 Crane Extract Inlined Constant create_temp_dir =>
 "[&]() -> bsl::string {
-  bsl::string dir;
-  bdls::FilesystemUtil::getSystemTemporaryDirectory(&dir);
-  bsl::string s = dir + ""/"" + %a0 + ""XXXXXX"";
-  return bsl::string(mkdtemp(s.data()));
-}()" From "bdls_filesystemutil.h" "cstdlib".
+  bsl::string _dir;
+  bdls::FilesystemUtil::getSystemTemporaryDirectory(&_dir);
+  bsl::string _n = %a0;
+  bsl::string::size_type _sl = _n.find_last_of('/');
+  if (_sl != bsl::string::npos) _n = _n.substr(_sl + 1);
+  if (_n.empty() || _n == ""."" || _n == "".."") _n = ""tmp"";
+  std::random_device _rng;
+  for (;;) {
+    bsl::string _p =
+      _dir + ""/"" + _n + bsl::to_string(_rng()) + bsl::to_string(_rng());
+    if (::mkdir(_p.c_str(), 0700) == 0) return _p;
+    if (errno != EEXIST)
+      throw std::runtime_error(""crane: failed to create temporary directory"");
+  }
+}()" From "bdls_filesystemutil.h" "bsl_string.h" "random" "sys/stat.h"
+       "cerrno" "stdexcept".

--- a/theories/cpp/crane_itree.h
+++ b/theories/cpp/crane_itree.h
@@ -43,8 +43,12 @@ struct ITree : public std::enable_shared_from_this<ITree<R>> {
     R run() {
         auto cur = this->shared_from_this();
         while (true) {
+            // Copy (not move) the payload: cur is reached via shared_ptr and
+            // observe() lets callers hold onto and re-run the same tree, so
+            // moving out of a shared node would corrupt it for later runs
+            // (finding 37, CWE-664).
             if (auto *r = std::get_if<Ret>(&cur->node))
-                return std::move(r->value);
+                return r->value;
             if (auto *t = std::get_if<Tau>(&cur->node)) {
                 cur = t->next;
                 continue;

--- a/theories/cpp/crane_itree.h
+++ b/theories/cpp/crane_itree.h
@@ -5,6 +5,26 @@
 // inspected.  R is the result type (use void for effectful computations
 // that produce no value).  Tau is intentionally omitted -- it is a
 // coinductive guardedness marker with no runtime meaning.
+//
+// Invariants (enforced here so host/generated code cannot forge invalid
+// nodes):
+//   * Nodes are only constructible through the ret/tau/vis factories, which
+//     return a std::shared_ptr.  The constructor takes a private passkey, so
+//     external code cannot build a node from a hand-crafted variant or stack
+//     allocate one (a stack ITree would make shared_from_this throw)
+//     (CWE-665 / CWE-476, finding 132).
+//   * A Tau's next pointer and a Vis continuation's result are never null:
+//     the factories reject a null argument up front and run() rechecks the
+//     continuation result before dereferencing it (finding 132).
+//   * run() keeps the current node alive for the whole loop via
+//     shared_from_this -- including the void specialization, which must not
+//     fabricate a non-owning alias of [this] that an effect could outlive
+//     (CWE-416, finding 86).
+//
+// run() intentionally has no step budget: an itree is coinductive and may be
+// legitimately infinite, so bounding it here would be wrong.  A caller that
+// needs to stop a divergent computation controls that at its own effect
+// boundary.
 
 #ifndef INCLUDED_CRANE_ITREE
 #define INCLUDED_CRANE_ITREE
@@ -12,6 +32,7 @@
 #include <any>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 #include <variant>
 
@@ -26,21 +47,34 @@ struct ITree : public std::enable_shared_from_this<ITree<R>> {
     using variant_t = std::variant<Ret, Tau, Vis>;
     variant_t node;
 
-    explicit ITree(variant_t n) : node(std::move(n)) {}
+  private:
+    // Passkey: only ITree's own factories can name it, so the public
+    // constructor cannot be called from outside despite make_shared needing it.
+    struct Private { explicit Private() = default; };
+
+  public:
+    ITree(Private, variant_t n) : node(std::move(n)) {}
 
     static std::shared_ptr<ITree<R>> ret(R value) {
-        return std::make_shared<ITree<R>>(Ret{std::move(value)});
+        return std::make_shared<ITree<R>>(Private{}, Ret{std::move(value)});
     }
     static std::shared_ptr<ITree<R>> tau(std::shared_ptr<ITree<R>> next) {
-        return std::make_shared<ITree<R>>(Tau{std::move(next)});
+        if (!next)
+            throw std::invalid_argument("crane: ITree::tau given a null next");
+        return std::make_shared<ITree<R>>(Private{}, Tau{std::move(next)});
     }
     static std::shared_ptr<ITree<R>> vis(
         std::function<std::any()> effect,
         std::function<std::shared_ptr<ITree<R>>(std::any)> cont) {
-        return std::make_shared<ITree<R>>(Vis{std::move(effect), std::move(cont)});
+        if (!effect || !cont)
+            throw std::invalid_argument("crane: ITree::vis given a null effect or continuation");
+        return std::make_shared<ITree<R>>(Private{}, Vis{std::move(effect), std::move(cont)});
     }
 
     R run() {
+        // Hold an owning reference to the current node for the whole loop:
+        // effects and continuations may drop every other owner, so a
+        // non-owning alias would dangle (finding 86).
         auto cur = this->shared_from_this();
         while (true) {
             // Copy (not move) the payload: cur is reached via shared_ptr and
@@ -50,12 +84,17 @@ struct ITree : public std::enable_shared_from_this<ITree<R>> {
             if (auto *r = std::get_if<Ret>(&cur->node))
                 return r->value;
             if (auto *t = std::get_if<Tau>(&cur->node)) {
+                if (!t->next)
+                    throw std::runtime_error("crane: ITree Tau has a null next");
                 cur = t->next;
                 continue;
             }
             auto &v = std::get<Vis>(cur->node);
             std::any response = v.effect();
-            cur = v.cont(std::move(response));
+            auto next = v.cont(std::move(response));
+            if (!next)
+                throw std::runtime_error("crane: ITree Vis continuation returned null");
+            cur = std::move(next);
         }
     }
     const variant_t &observe() const { return node; }
@@ -63,7 +102,7 @@ struct ITree : public std::enable_shared_from_this<ITree<R>> {
 
 // Void specialization (Ret holds nothing).
 template <>
-struct ITree<void> {
+struct ITree<void> : public std::enable_shared_from_this<ITree<void>> {
     struct Ret { std::monostate value = {}; };
     struct Tau { std::shared_ptr<ITree<void>> next; };
     struct Vis {
@@ -73,37 +112,50 @@ struct ITree<void> {
     using variant_t = std::variant<Ret, Tau, Vis>;
     variant_t node;
 
-    explicit ITree(variant_t n) : node(std::move(n)) {}
+  private:
+    struct Private { explicit Private() = default; };
+
+  public:
+    ITree(Private, variant_t n) : node(std::move(n)) {}
 
     static std::shared_ptr<ITree<void>> ret() {
-        return std::make_shared<ITree<void>>(Ret{});
+        return std::make_shared<ITree<void>>(Private{}, Ret{});
     }
     static std::shared_ptr<ITree<void>> ret(std::monostate) {
-        return std::make_shared<ITree<void>>(Ret{});
+        return std::make_shared<ITree<void>>(Private{}, Ret{});
     }
     static std::shared_ptr<ITree<void>> tau(std::shared_ptr<ITree<void>> next) {
-        return std::make_shared<ITree<void>>(Tau{std::move(next)});
+        if (!next)
+            throw std::invalid_argument("crane: ITree::tau given a null next");
+        return std::make_shared<ITree<void>>(Private{}, Tau{std::move(next)});
     }
     static std::shared_ptr<ITree<void>> vis(
         std::function<std::any()> effect,
         std::function<std::shared_ptr<ITree<void>>(std::any)> cont) {
-        return std::make_shared<ITree<void>>(Vis{std::move(effect), std::move(cont)});
+        if (!effect || !cont)
+            throw std::invalid_argument("crane: ITree::vis given a null effect or continuation");
+        return std::make_shared<ITree<void>>(Private{}, Vis{std::move(effect), std::move(cont)});
     }
 
     void run() {
-        // Non-owning shared_ptr: safe because we stay in scope for the
-        // duration of the loop.
-        auto cur = std::shared_ptr<ITree<void>>(this, [](auto *) {});
+        // Owning reference (not a non-owning alias of [this]): an effect or
+        // continuation may release the last other owner mid-run (finding 86).
+        auto cur = this->shared_from_this();
         while (true) {
             if (std::holds_alternative<Ret>(cur->node))
                 return;
             if (auto *t = std::get_if<Tau>(&cur->node)) {
+                if (!t->next)
+                    throw std::runtime_error("crane: ITree Tau has a null next");
                 cur = t->next;
                 continue;
             }
             auto &v = std::get<Vis>(cur->node);
             std::any response = v.effect();
-            cur = v.cont(std::move(response));
+            auto next = v.cont(std::move(response));
+            if (!next)
+                throw std::runtime_error("crane: ITree Vis continuation returned null");
+            cur = std::move(next);
         }
     }
     const variant_t &observe() const { return node; }

--- a/theories/cpp/crane_real.h
+++ b/theories/cpp/crane_real.h
@@ -4,7 +4,9 @@
 #define CRANE_REAL_H
 #include <cmath>
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
+#include <type_traits>
 
 class Real {
   long double v_;
@@ -46,7 +48,21 @@ public:
 
   // Exponential & floor
   friend Real r_exp(Real x) { return Real(std::exp(x.v_)); }
-  friend int64_t r_floor_z(Real x) { return static_cast<int64_t>(std::floor(x.v_)); }
+  friend int64_t r_floor_z(Real x) {
+    // Guard the floating-point -> int64_t conversion: casting NaN, an infinity,
+    // or a value outside the int64_t range is undefined behaviour
+    // (CWE-681 / CWE-682 / CWE-190).  Division and r_inv can produce
+    // infinities, and sqrt/asin/acos can produce NaN from out-of-domain
+    // inputs, either of which then reaches this cast.  Rocq's floor is total
+    // over an idealized unbounded real, so keep the extracted version total
+    // too: NaN maps to 0, and out-of-range magnitudes saturate to the int64_t
+    // bounds rather than wrapping or trapping.
+    long double f = std::floor(x.v_);
+    if (std::isnan(f)) return 0;
+    if (f >= 0x1p63L) return INT64_MAX;   // f >= 2^63
+    if (f < -0x1p63L) return INT64_MIN;   // f < -2^63
+    return static_cast<int64_t>(f);
+  }
   friend std::string real_to_string(Real x) {
     std::ostringstream oss;
     oss << x.v_;
@@ -55,8 +71,23 @@ public:
 
   // Constants & conversions
   static Real pi() { return Real(std::acos(-1.0L)); }
-  static Real from_nat(unsigned int n) { return Real(static_cast<long double>(n)); }
-  static Real from_z(int64_t z) { return Real(static_cast<long double>(z)); }
-  static Real from_pos(unsigned int p) { return Real(static_cast<long double>(p)); }
+
+  // Integer -> Real coercions (INR / IZR / IPR).  Templated so the *same*
+  // mapping works with whatever integer representation the user imports for
+  // nat / Z / positive -- int64_t and unsigned int (the Int flavors) or GMP's
+  // mpz_class (the GMP flavor) -- without Real.v committing to one.  Arithmetic
+  // types convert directly; a bignum is narrowed through its get_d() member
+  // (only instantiated when T is such a type, so <gmpxx.h> is not required
+  // here).  Real is finite precision, so this coercion is inherently lossy for
+  // integers beyond the long double mantissa, regardless of the source type.
+  template <class T> static long double to_long_double(const T &z) {
+    if constexpr (std::is_arithmetic_v<T>)
+      return static_cast<long double>(z);
+    else
+      return static_cast<long double>(z.get_d());
+  }
+  template <class T> static Real from_nat(const T &n) { return Real(to_long_double(n)); }
+  template <class T> static Real from_z(const T &z) { return Real(to_long_double(z)); }
+  template <class T> static Real from_pos(const T &p) { return Real(to_long_double(p)); }
 };
 #endif


### PR DESCRIPTION
Systematic hardening pass over Crane driven by the 2026-06-16 security scan. The changes close undefined behavior, injection, memory-safety, and interface-fidelity gaps in three places: the extraction driver/build tooling, the C++ runtime mappings that extracted programs rely on, and the generated code itself. Valid extracted programs are unaffected — only invalid, malicious, or out-of-range inputs change behavior (from UB/crash to a defined result, bounds check, or clear error).

## What's included

**Extraction-time injection & path safety**
- Route all process execution through an argv-based `Subprocess` API (no shell); validate extraction output targets against traversal/absolute escape; harden the build/test shell scripts. (CWE-78, CWE-88, CWE-94, CWE-22, CWE-73)
- Sanitize Rocqdoc text before emitting it as C++ line comments. (CWE-94/CWE-116)

**Runtime mapping safety (affects extracted programs directly)**
- Bounds-check `string`/`string_view` indexing and make `substr`/`PrimString.sub` total instead of throwing. (CWE-125, CWE-248/CWE-755)
- Remove signed-arithmetic UB from the `Z` mappings (unsigned-domain ops, guarded `INT64_MIN / -1` and `abs`), guard `Real`'s floor-to-`int64_t` conversion against NaN/Inf/overflow, and keep integer div/mod zero-guarded. (CWE-190, CWE-681, CWE-682)
- Make filesystem effect mappings exception-safe via `std::error_code` and bound directory listing; contain temp-file creation in a private directory and drop the `mkstemp`/`mkdtemp` template. (CWE-248/CWE-755, CWE-400, CWE-377, CWE-367) - Infer `DequeList` element types from `value_type` instead of `front()` on a possibly-empty deque. (CWE-476)

**Reified ITree runtime**
- Fix `run()` payload corruption and an `any_cast` crash; enforce node invariants — factory-only construction, non-null Tau/Vis, owning traversal in the `void` specialization. (CWE-416, CWE-476, CWE-665, CWE-664)

**Generated interface fidelity**
- Emit real `requires` clauses for multi-parameter concepts and enforce `with Definition` type refinements, instead of degrading to unconstrained `typename`. (CWE-693, CWE-345, CWE-807)

**Mapping hygiene**
- Make `Real.v` integer-flavor-agnostic (no longer silently pins `Z` to int64_t) and warn on overlapping extraction mappings so a later import can't silently override an earlier one.

## Testing

`make test` → **612 passed, 6 failed**. The 6 failures are pre-existing and unrelated: `benchmark_matrix` and `extraction_path_traversal` fail only on this machine's Homebrew LLVM/macOS SDK `mbstate_t` toolchain issue (CI's clang-19 is authoritative), and `rocq_bug_3287`, `z_abs_min`, `z_arith_overflow`, `z_div_min` are known wip cases (the `z_*` ones assert unbounded-`Z` results that `int64_t` cannot represent — use the GMP mapping for exactness). New regression tests were added for the ITree invariants, the Real floor guard, and empty-deque operations.

## Notes

- Fixes are scoped to be behavior-preserving for in-range/valid inputs; the numeric mappings now wrap or saturate deterministically at the `int64_t` boundary rather than executing UB.
- A few findings were documented rather than code-changed where a complete fix needs a larger redesign (e.g. capability-confined filesystem effects, non-owning `string_view` lifetimes, allocation-in-destructor for deep deque-backed trees).
