### PR TITLE
WIP Test for requiring functions with dropped type parameters from another file

### DIFF
--- a/tests/wip/template_param_redef/Lib.v
+++ b/tests/wip/template_param_redef/Lib.v
@@ -1,0 +1,9 @@
+From Crane Require Extraction.
+
+Variant ex (A : Type) : Type := mk_box.
+
+Crane Extract Inductive ex => "std::monostate"
+  [ "std::monostate{}" ]
+From "variant".
+
+Definition f {A : Type} (b : ex A) : unit := tt.

--- a/tests/wip/template_param_redef/Use.v
+++ b/tests/wip/template_param_redef/Use.v
@@ -1,0 +1,8 @@
+From Crane Require Extraction.
+From CraneTestsWIP Require Import template_param_redef.Lib.
+
+Module M.
+  Definition use {A : Type} (b : ex A) : unit := f b.
+End M.
+
+Crane Extraction "template_param_redef" M.

--- a/tests/wip/template_param_redef/template_param_redef.cpp
+++ b/tests/wip/template_param_redef/template_param_redef.cpp
@@ -1,0 +1,1 @@
+#include "template_param_redef.h"

--- a/tests/wip/template_param_redef/template_param_redef.h
+++ b/tests/wip/template_param_redef/template_param_redef.h
@@ -1,0 +1,21 @@
+#ifndef INCLUDED_TEMPLATE_PARAM_REDEF
+#define INCLUDED_TEMPLATE_PARAM_REDEF
+
+#include <variant>
+
+enum class Unit { TT };
+
+struct Lib {
+  template <typename T1 = void> static void f(const std::monostate &_x);
+};
+
+struct M {
+  template <typename T1 = void> static void use(const std::monostate &_x0) {
+    Lib::template f<T1>(_x0);
+    return;
+  }
+};
+
+template <typename T1 = void> void Lib::f(const std::monostate &) { return; }
+
+#endif // INCLUDED_TEMPLATE_PARAM_REDEF


### PR DESCRIPTION
This bug requires two components:
1. A dependent type with an extraction that drops one of its type arguments, causing it to be given a default value of `void`
2. A function on this type being used by another file.

When definitions are required by another file the extraction creates an interface for those definitions and separate declarations for their bodies.  Crane gives the template parameters for the body declaration a default assignment to `void` as well, which is not allowed by C++.