### PR TITLE
Adds class examples and extracts STMonad references to shared pointers

### DIFF
--- a/tests/monadic/dune
+++ b/tests/monadic/dune
@@ -239,6 +239,17 @@
   (deps stmonad.t.exe)
   (action (run ./stmonad.t.exe))))
 
+(subdir object_model
+ (rule
+  (targets object_model.t.exe)
+  (deps ObjectModelExtractionTests.vo object_model.t.cpp (source_tree .))
+  (action
+   (run %{project_root}/scripts/compile-std.sh %{project_root} object_model.t.exe object_model.cpp object_model.t.cpp)))
+ (rule
+  (alias runtest)
+  (deps object_model.t.exe)
+  (action (run ./object_model.t.exe))))
+
 (subdir global_state
  (rule
   (targets global_state.t.exe)

--- a/tests/monadic/dune
+++ b/tests/monadic/dune
@@ -260,7 +260,8 @@
   (alias runtest)
   (deps global_state.t.exe)
   (action (run ./global_state.t.exe))))
- 
+
+
 (subdir thread
  (rule
   (targets thread.t.exe)

--- a/tests/monadic/object_model/ObjectModelExtractionTests.v
+++ b/tests/monadic/object_model/ObjectModelExtractionTests.v
@@ -1,0 +1,162 @@
+(* Copyright 2026 Bloomberg Finance L.P. *)
+(* Distributed under the terms of the GNU LGPL v2.1 license. *)
+
+(* An object model using STRefs for mutable state *)
+
+From Crane Require Import
+  Monads.ITree
+  Monads.Error
+  Monads.Indices
+  Monads.STMonad
+  Utils.HMap
+  Utils.HAList
+  Extraction.
+
+
+From Stdlib Require Import
+  Arith.PeanoNat
+  Arith.Peano_dec
+  Init.Peano
+  Lia
+  List
+  Morphisms
+  RelationClasses
+  Relation_Definitions
+  Setoid
+  Strings.String
+  Classes.EquivDec
+  Basics
+  ZArith
+.
+
+From ExtLib Require Import
+  CmpDec
+  Data.Bool
+  Data.List
+  Data.Map.FMapAList
+  Data.Monads.EitherMonad
+  Data.Pair
+  Data.String
+  Structures.Functor
+  Structures.Maps
+  Structures.Traversable
+  Structures.Reducible
+.
+
+
+From ITree Require Import
+  Events.Exception
+  Events.FailFacts
+  Events.MapDefault
+  Events.MapDefaultFacts
+  Events.State
+  Events.StateFacts
+  ITree
+  ITreeFacts
+.
+            
+
+
+
+Section PointDef.
+
+
+  Context (S : Type).
+  Let T := nat.
+  Let ltu := Nat.le.
+  Let V : T -> Type := fun _ => Z.
+  Let E0 := (STEvent T S V) +' exceptE Err.
+  
+
+  Record Point := mkPoint {
+      getX : itree E0 Z;
+      moveD : Z -> itree E0 unit;
+      offsetX : itree E0 Z;
+    }.
+
+
+  
+  (* NOTE: might wanna enforce unique indices with a global effect
+           draw indices from a index generator. *)
+  (* Modeling off of examples in OOHaskell,
+   starting from https://github.com/nkaretnikov/OOHaskell/blob/master/samples/SimpleST.hs#L69 *)
+  Definition class_pointST {idx : T} (init : Z) : itree E0 Point :=
+    ref <- newSTRef 0 init ;;
+    let moveD :=
+      fun move_amt =>
+        i <- readSTRef ref;;
+        writeSTRef ref (i + move_amt)%Z in
+    let offsetX :=
+      i <- readSTRef ref;;
+      Ret (i - init)%Z in
+    Ret (mkPoint (readSTRef ref) moveD offsetX).
+
+
+  Definition testtoST1 : itree E0 (Z * Z * Z) :=
+    p <- @class_pointST 0 1;;
+    a <- getX p;;
+    moveD p 2;;
+    b <- getX p;;
+    c <- offsetX p;;
+    Ret (a,b,c).
+
+
+  Definition testtoST2 : itree E0 (Z * Z * Z * Z) :=
+      p1 <- @class_pointST 0 1;;
+      p2 <- @class_pointST 1 10;;
+      a <- getX p1;;
+      b <- getX p2;;
+	    (* reading from one and putting into the other *)
+      v1 <- getX p1;; moveD p2 v1;;
+      c <- getX p1;;
+      d <- getX p2;;
+      Ret (a,b,c,d)
+  .
+      
+    
+    
+
+End PointDef.
+
+
+Transparent HAList.halist_lookup HAList.halist_add
+            HAList.HMap_halist HAList.HMapOk_halist.
+Existing Instance nat_ix_correct.
+Existing Instance nat_ix_stref.
+
+Definition run_test1 : itree (exceptE Err) (Z * Z * Z) :=
+  runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testtoST1.
+
+Lemma point_run_burn1 : burn 100 run_test1 = Ret (1, 3, 2)%Z.
+Proof. lazy. reflexivity. Qed.
+
+Definition run_test2 : itree (exceptE Err) (Z * Z * Z * Z) :=
+  runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testtoST2.
+
+Lemma point_run_burn2 : burn 100 run_test2 = Ret (1, 10, 1, 11)%Z.
+Proof. lazy. reflexivity. Qed.
+
+
+
+From Crane Require Import Mapping.ZInt.
+
+Definition testtoST1_ext :=
+  Eval unfold testtoST1, class_pointST in (testtoST1 unit).
+Definition testtoST2_ext :=
+  Eval unfold testtoST2, class_pointST in (testtoST2 unit).
+
+Crane Extraction "object_model" testtoST1_ext testtoST2_ext.
+
+
+
+
+
+
+
+
+
+  
+
+
+
+  

--- a/tests/monadic/object_model/ObjectModelExtractionTests.v
+++ b/tests/monadic/object_model/ObjectModelExtractionTests.v
@@ -3,14 +3,6 @@
 
 (* An object model using STRefs for mutable state *)
 
-From Crane Require Import
-  Monads.ITree
-  Monads.Error
-  Monads.Indices
-  Monads.STMonad
-  Utils.HMap
-  Utils.HAList
-  Extraction.
 
 
 From Stdlib Require Import
@@ -56,7 +48,16 @@ From ITree Require Import
 .
             
 
-
+From Crane Require Import
+  Monads.ITree
+  Monads.Error
+  Monads.Indices
+  Monads.STMonad
+  Monads.STMonadFacts
+  Monads.MonadFacts
+  Utils.HMap
+  Utils.HAList
+  Extraction.
 
 Section PointDef.
 
@@ -66,20 +67,23 @@ Section PointDef.
   Let ltu := Nat.le.
   Let V : T -> Type := fun _ => Z.
   Let E0 := (STEvent T S V) +' exceptE Err.
+
+  Local Notation ref := (newSTRef).
+  Local Notation "x :== y" := (writeSTRef x y) (at level 0).
+  Local Notation "! x" := (readSTRef x) (at level 50).
   
 
   Record Point := mkPoint {
-      getX : itree E0 Z;
+      getX : unit -> itree E0 Z;
       moveD : Z -> itree E0 unit;
-      offsetX : itree E0 Z;
+      offsetX : unit -> itree E0 Z;
     }.
 
 
   
   (* NOTE: might wanna enforce unique indices with a global effect
            draw indices from a index generator. *)
-  (* Modeling off of examples in OOHaskell,
-   starting from https://github.com/nkaretnikov/OOHaskell/blob/master/samples/SimpleST.hs#L69 *)
+  (* Modeling off of examples in OOHaskell, starting from https://github.com/nkaretnikov/OOHaskell/blob/master/samples/SimpleST.hs#L69 *)
   Definition class_pointST {idx : T} (init : Z) : itree E0 Point :=
     ref <- newSTRef 0 init ;;
     let moveD :=
@@ -89,32 +93,306 @@ Section PointDef.
     let offsetX :=
       i <- readSTRef ref;;
       Ret (i - init)%Z in
-    Ret (mkPoint (readSTRef ref) moveD offsetX).
+    Ret (mkPoint (fun _ => readSTRef ref) moveD (fun _ => offsetX)).
 
 
   Definition testtoST1 : itree E0 (Z * Z * Z) :=
     p <- @class_pointST 0 1;;
-    a <- getX p;;
+    a <- getX p tt;;
     moveD p 2;;
-    b <- getX p;;
-    c <- offsetX p;;
+    b <- getX p tt;;
+    c <- offsetX p tt;;
     Ret (a,b,c).
 
 
   Definition testtoST2 : itree E0 (Z * Z * Z * Z) :=
       p1 <- @class_pointST 0 1;;
       p2 <- @class_pointST 1 10;;
-      a <- getX p1;;
-      b <- getX p2;;
+      a <- getX p1 tt;;
+      b <- getX p2 tt;;
 	    (* reading from one and putting into the other *)
-      v1 <- getX p1;; moveD p2 v1;;
-      c <- getX p1;;
-      d <- getX p2;;
+      v1 <- getX p1 tt;; moveD p2 v1;;
+      c <- getX p1 tt;;
+      d <- getX p2 tt;;
       Ret (a,b,c,d)
   .
+
+  
+  Record Account := mkAccount {
+      getBalance : unit -> itree E0 Z;
+      deposit : Z -> itree E0 Z;
+      withdraw : Z -> itree E0 (option Z);
+    }.
+
+  Definition getBalance_imp (idx : T) (ref : STRef S Z) : unit -> itree E0 Z :=
+    fun _ => readSTRef (idx := idx) ref.
+
+  Definition deposit_imp (idx : T) (ref : STRef S Z) : Z -> itree E0 Z :=
+    fun amt : Z =>
+      bal <- readSTRef (idx := idx) ref;;
+      let new_bal := (bal + amt)%Z in
+      writeSTRef (idx := idx) ref new_bal;;
+      Ret new_bal.
+
+  Definition withdraw_imp (idx : T) (ref : STRef S Z) : Z -> itree E0 (option Z) :=
+      fun amt : Z =>
+        bal <- readSTRef (idx := idx) ref;;
+        let new_bal := (bal - amt)%Z in
+        if (new_bal <? 0)%Z then
+          Ret None
+        else
+          writeSTRef (idx := idx) ref new_bal;; 
+          Ret (Some new_bal).
+
+
+  Definition class_Account (idx : T) (init : Z) : itree E0 Account :=
+    bal_ref <- ref idx init ;;
+    Ret
+      {| getBalance _ := !bal_ref;
+         deposit amt := 
+            bal <- !bal_ref;;
+            let new_bal := (bal + amt)%Z in
+             bal_ref :== new_bal;;
+             Ret new_bal;
+        withdraw amt := 
+            bal <- !bal_ref;;
+            let new_bal := (bal - amt)%Z in
+            if (new_bal <? 0)%Z then
+              Ret None
+            else
+              bal_ref :== new_bal;; 
+              Ret (Some new_bal);
+      |}.
+
+
+  Definition testAccount1 : itree E0 (Z * Z * bool * Z) :=
+    acc <- @class_Account 0%nat 100;;
+    a <- getBalance acc tt;;
+    b <- deposit acc 50;; (* deposit 50 *)
+    c <- withdraw acc 160;; (* attempt to withdraw more than we can *)
+    d <- getBalance acc tt;; (* read final value *)
+    let c_is_Some :=
+      match c with
+      | Some _ => true
+      | None => false
+      end in
+    Ret (a,b,c_is_Some,d).
+
+  (* Fully transfer amounts between two accounts *)
+  Definition testAccount2 : itree E0 (Z * bool * Z * Z) :=
+    acc1 <- @class_Account 0%nat 100;;
+    acc2 <- @class_Account 0%nat 150;;
+    a <- getBalance acc1 tt;;
+    result <- withdraw acc1 a;;
+    match result with
+    | Some 0%Z => (* withdrawal succeeds, transfer money*)
+        b <- deposit acc2 a;;
+        c <- getBalance acc1 tt;;
+        Ret (a,true,b,c)
+    | _ => (* withdrawal failed, do nothing, return balance of a,b *)
+        b <- getBalance acc2 tt;;
+        c <- getBalance acc1 tt;;
+        Ret (a,false,b,c)
+    end.
+
+  #[export] Instance hmap_nat_v : HMap (@idx_key T T) (idx_key_type V) mem :=
+    HMap_halist (idx_key T) (idx_key_type V).
+
+
+  (* TODO: make this a structure instead of `and` *)
+
+
+  Definition backed_by (acc : Account) (idx : T) (ref : STRef S Z) : Prop :=
+    getBalance acc = getBalance_imp idx ref /\
+    withdraw acc = withdraw_imp idx ref /\
+    deposit acc = deposit_imp idx ref.
+
+
+  Definition account_wf (acc : Account) (idx : T) (ref : STRef S Z)
+    (m : @mem T V)  : Prop :=
+    backed_by acc idx ref /\
+    exists v, HMap.lookup (STRefToIx S Z ref, idx) m = Some v /\ (v >= 0)%Z.
+
+  Definition max_idx (m : @mem T V) :=
+    Datatypes.S (fold (fun '(existT _ (n, _) _) (acc : nat) => Nat.max n acc) 0%nat m).
+
+  Opaque HAList.halist_lookup HAList.halist_add
+        HAList.HMap_halist HAList.HMapOk_halist.
+
+  Lemma interp_st_class_account : forall
+    (init : Z)
+    (idx : T)
+    (l : @mem T V),
+      interp_st ltu (Account) (@class_Account idx init) l
+        ≈
+    ITreeDefinition.Ret
+    (HMap.add (max_idx l, idx)
+         init l,
+     {|
+       getBalance := getBalance_imp idx (MkSTRef S (V 0%nat) (max_idx l));
+       deposit := deposit_imp idx (MkSTRef S (V 0%nat) (max_idx l));
+       withdraw := withdraw_imp idx (MkSTRef S (V 0%nat) (max_idx l))
+     |}).
+    Proof using Type.
+      intros init idx l.
+      unfold class_Account.
+      change T with nat in *.
+      unfold E0.
+      rewrite interp_st_bind.
+      unfold newSTRef. rewrite interp_st_trigger. cbn.
+      change_to_monad.
+      change (V _) with Z in *.
+      monad_simpl_inner.
+      change_to_monad.
+      rewrite interp_st_ret.
+      unfold max_idx.
+      unfold getBalance_imp,deposit_imp,withdraw_imp.
+      change_to_monad.
+      reflexivity.
+    Qed.
+
+
+    
+
+  Lemma class_account_is_wf : forall (acc : Account) (idx : T) (mem mem2 : @mem T V ) (init : Z),
+      (init >= 0)%Z ->
+      interp_st ltu _ (@class_Account idx init) mem ≈ Ret (mem2, acc) ->
+      exists ref, account_wf acc idx ref mem2. 
+    Proof using Type.
+      intros.
+      unfold account_wf.
+      rewrite interp_st_class_account in H0.
+      eapply eutt_inv_Ret in H0.
+      inversion H0.
+      unfold getBalance. unfold getBalance_imp in *.
+      unfold readSTRef.
+      exists (MkSTRef S (V 0) (max_idx mem)).
+      split. 
+      - econstructor.
+        + econstructor.
+        + split; reflexivity.
+      - exists init. 
+        split.
+        + eapply st_lookup_add_eq. 
+        + assumption.
+    Qed.
       
-    
-    
+    Local Ltac unfold_instances :=
+      change T with nat in *;
+      unfold E0 in *;
+      unfold V in *.
+
+  Lemma withdraw_cannot_return_negative :
+    forall (acc : Account) (idx : T) (ref : STRef S Z) (amt new_bal : Z) (m0 m1 : @mem T V) (o : option Z),
+      account_wf acc idx ref m0 ->
+      interp_st ltu _ (withdraw acc amt) m0 ≈ Ret (m1 , o) ->
+      account_wf acc idx ref m1.
+    Proof using Type. 
+      intros acc idx ref amt b m0 m1 o Hwdrw Hintrp.
+      unfold account_wf in *. destruct Hwdrw as [Hback Hlookup].
+      split. try assumption.
+      unfold backed_by in Hback. destruct Hback as [Hgetb [Hwdrw Hdepos]].
+      rewrite Hwdrw in Hintrp.
+      unfold withdraw_imp in Hintrp. unfold_instances.
+      rewrite interp_st_bind in Hintrp.
+      unfold readSTRef in Hintrp.
+      rewrite interp_st_trigger in Hintrp. cbn in Hintrp.
+      destruct Hlookup as [v [Hlookup Hvnz]].
+      change (lookup (STRefToIxNat S Z ref, idx) m0) with (lookup (STRefToIx S Z ref, idx) m0) in Hintrp. 
+      replace (lookup (STRefToIx S Z ref, idx) m0) with
+              (Some v) in Hintrp.
+      change (@ITree.bind ?E) with (@Monad.bind (itree E) _) in Hintrp.
+      setoid_rewrite Ret_is_ret in Hintrp.
+      repeat (repeat setoid_rewrite Monad.bind_bind in Hintrp;
+          repeat setoid_rewrite bind_Ret_l in Hintrp;
+          repeat setoid_rewrite bind_Ret_r in Hintrp).
+      destruct (v - amt <? 0)%Z eqn:Hv.
+      setoid_rewrite Ret_is_ret in Hintrp.
+      rewrite interp_st_ret in Hintrp.
+      eapply eutt_inv_Ret in Hintrp. inversion Hintrp. subst.
+      exists v. split; assumption.
+      exists (v - amt)%Z.
+      unfold_instances.
+      change (@Monad.bind (itree ?E) _) with (@ITree.bind E) in Hintrp.
+      rewrite interp_st_bind_eutt in Hintrp.
+      unfold writeSTRef in Hintrp.
+      rewrite interp_st_trigger in Hintrp. cbn in Hintrp.
+      change (@ITree.bind ?E) with (@Monad.bind (itree E) _) in Hintrp.
+      setoid_rewrite bind_Ret_l in Hintrp.
+      cbv beta iota in Hintrp.
+      unfold Ret in Hintrp.
+      rewrite interp_st_Ret in Hintrp.
+      eapply eutt_inv_Ret in Hintrp.
+      inversion Hintrp. subst. split.
+      - eapply st_lookup_add_eq.
+      - lia.  
+     Qed.
+
+
+  Lemma deposit_preserves_wf :
+    forall (acc : Account) (idx : T) (ref : STRef S Z) (amt new_bal : Z) (m0 m1 : @mem T V) (out_val : Z),
+      (amt >= 0)%Z ->
+      account_wf acc idx ref m0 ->
+      interp_st ltu _ (deposit acc amt) m0 ≈ Ret (m1 , out_val) ->
+      account_wf acc idx ref m1.
+    Proof using Type.
+      intros acc idx ref amt b m0 m1 o Hamt Hwdrw Hintrp.
+      unfold account_wf in *. destruct Hwdrw as [Hback Hlookup].
+      split; try assumption.
+      unfold backed_by in Hback. destruct Hback as [Hgetb [Hwdrw Hdepos]].
+      rewrite Hdepos in Hintrp. unfold deposit_imp in Hintrp. unfold_instances.
+      rewrite interp_st_bind in Hintrp. unfold readSTRef in *. rewrite interp_st_trigger in Hintrp. cbn in Hintrp.  
+      destruct Hlookup as [v [Hlookup Hvnz]].
+      change (lookup (STRefToIxNat S Z ref, idx) m0) with (lookup (STRefToIx S Z ref, idx) m0) in Hintrp. 
+      replace (lookup (STRefToIx S Z ref, idx) m0) with
+              (Some v) in Hintrp.
+      change (@ITree.bind ?E) with (@Monad.bind (itree E) _) in Hintrp.
+      setoid_rewrite Ret_is_ret in Hintrp.
+      repeat (repeat setoid_rewrite Monad.bind_bind in Hintrp;
+          repeat setoid_rewrite bind_Ret_l in Hintrp;
+          repeat setoid_rewrite bind_Ret_r in Hintrp).
+      exists (v + amt)%Z. unfold_instances.
+      change (@Monad.bind (itree ?E) _) with (@ITree.bind E) in Hintrp.
+      rewrite interp_st_bind_eutt in Hintrp.
+      unfold writeSTRef in Hintrp.
+      rewrite interp_st_trigger in Hintrp. cbn in Hintrp.
+      change (@ITree.bind ?E) with (@Monad.bind (itree E) _) in Hintrp.
+      setoid_rewrite bind_Ret_l in Hintrp.
+      cbv beta iota in Hintrp.
+      unfold Ret in Hintrp.
+      rewrite interp_st_Ret in Hintrp.
+      eapply eutt_inv_Ret in Hintrp. inversion Hintrp. subst.
+      split.
+      - apply st_lookup_add_eq. 
+      - lia.
+    Qed.
+
+
+
+  Lemma getBalance_preserves_wf :
+    forall (acc : Account) (idx : T) (ref : STRef S Z) (out_val : Z) (m0 m1 : @mem T V),
+      account_wf acc idx ref m0 ->
+      interp_st ltu _ (getBalance acc tt) m0 ≈ Ret (m1 , out_val) ->
+      account_wf acc idx ref m1.
+    Proof.
+      intros acc idx ref out_val m0 m1 Hwf Hintrp.
+      destruct Hwf as [[Hgetbal [Hwth Hdep]] Hlookup]; rewrite Hgetbal in Hintrp.
+      unfold getBalance_imp in Hintrp.
+      unfold readSTRef in Hintrp.
+      unfold_instances.
+      rewrite interp_st_trigger in Hintrp; cbn in Hintrp.
+      destruct Hlookup as [v [Hlookup Hv]].
+      change (STRefToIxNat S Z ref, idx) with (STRefToIx S Z ref, idx) in Hintrp.
+      rewrite Hlookup in Hintrp.
+      eapply eutt_inv_Ret in Hintrp. inversion Hintrp. subst.
+      split; try (repeat split; assumption). 
+      exists out_val. split; try (repeat split; assumption).
+    Qed.
+
+
+
+
+                                            
 
 End PointDef.
 
@@ -136,6 +414,21 @@ Definition run_test2 : itree (exceptE Err) (Z * Z * Z * Z) :=
 Lemma point_run_burn2 : burn 100 run_test2 = Ret (1, 10, 1, 11)%Z.
 Proof. lazy. reflexivity. Qed.
 
+Definition run_acc1 : itree (exceptE Err) (Z * Z * bool * Z) :=
+  runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testAccount1.
+
+Lemma acc_run_burn1 : burn 100 run_acc1 = Ret (100, 150, false, 150)%Z.
+Proof. lazy. reflexivity. Qed.
+
+Definition run_acc2 : itree (exceptE Err) (Z * bool * Z * Z) :=
+  runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testAccount2.
+
+Lemma acc_run_burn2 : burn 100 run_acc2 = Ret (100, true, 250, 0)%Z.
+Proof. lazy. reflexivity. Qed.
+
+
+
+
 
 
 From Crane Require Import Mapping.ZInt.
@@ -145,7 +438,13 @@ Definition testtoST1_ext :=
 Definition testtoST2_ext :=
   Eval unfold testtoST2, class_pointST in (testtoST2 unit).
 
-Crane Extraction "object_model" testtoST1_ext testtoST2_ext.
+Definition acc_test1_ext :=
+  Eval unfold testAccount1, class_Account  in (testAccount1 unit).
+
+Definition acc_test2_ext :=
+  Eval unfold testAccount2, class_Account in (testAccount2 unit).
+
+Crane Extraction "object_model" testtoST1_ext testtoST2_ext acc_test1_ext acc_test2_ext.
 
 
 

--- a/tests/monadic/object_model/object_model.cpp
+++ b/tests/monadic/object_model/object_model.cpp
@@ -1,0 +1,71 @@
+#include "object_model.h"
+
+std::pair<std::pair<int64_t, int64_t>, int64_t> testtoST1_ext() {
+  Point<std::monostate> p = []() {
+    int64_t ref;
+    ref = INT64_C(1);
+    return Point<std::monostate>{
+        ref,
+        [=](int64_t move_amt) mutable {
+          int64_t i = ref;
+          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                     static_cast<uint64_t>(move_amt));
+          return std::monostate{};
+        },
+        [&]() {
+          int64_t i = ref;
+          return static_cast<int64_t>(static_cast<uint64_t>(i) -
+                                      static_cast<uint64_t>(INT64_C(1)));
+        }()};
+  }();
+  int64_t a = p.getX;
+  p.moveD(INT64_C(2));
+  int64_t b = p.getX;
+  int64_t c = p.offsetX;
+  return std::make_pair(std::make_pair(a, b), c);
+}
+
+std::pair<std::pair<std::pair<int64_t, int64_t>, int64_t>, int64_t>
+testtoST2_ext() {
+  Point<std::monostate> p1 = []() {
+    int64_t ref;
+    ref = INT64_C(1);
+    return Point<std::monostate>{
+        ref,
+        [=](int64_t move_amt) mutable {
+          int64_t i = ref;
+          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                     static_cast<uint64_t>(move_amt));
+          return std::monostate{};
+        },
+        [&]() {
+          int64_t i = ref;
+          return static_cast<int64_t>(static_cast<uint64_t>(i) -
+                                      static_cast<uint64_t>(INT64_C(1)));
+        }()};
+  }();
+  Point<std::monostate> p2 = []() {
+    int64_t ref;
+    ref = INT64_C(10);
+    return Point<std::monostate>{
+        ref,
+        [=](int64_t move_amt) mutable {
+          int64_t i = ref;
+          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                     static_cast<uint64_t>(move_amt));
+          return std::monostate{};
+        },
+        [&]() {
+          int64_t i = ref;
+          return static_cast<int64_t>(static_cast<uint64_t>(i) -
+                                      static_cast<uint64_t>(INT64_C(10)));
+        }()};
+  }();
+  int64_t a = p1.getX;
+  int64_t b = p2.getX;
+  int64_t v1 = p1.getX;
+  p2.moveD(v1);
+  int64_t c = p1.getX;
+  int64_t d = p2.getX;
+  return std::make_pair(std::make_pair(std::make_pair(a, b), c), d);
+}

--- a/tests/monadic/object_model/object_model.cpp
+++ b/tests/monadic/object_model/object_model.cpp
@@ -2,70 +2,191 @@
 
 std::pair<std::pair<int64_t, int64_t>, int64_t> testtoST1_ext() {
   Point<std::monostate> p = []() {
-    int64_t ref;
-    ref = INT64_C(1);
+    std::shared_ptr<int64_t> ref;
+    ref = std::make_shared<decltype(INT64_C(1))>(INT64_C(1));
     return Point<std::monostate>{
-        ref,
+        [=](std::monostate) mutable { return *ref; },
         [=](int64_t move_amt) mutable {
-          int64_t i = ref;
-          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
-                                     static_cast<uint64_t>(move_amt));
+          int64_t i = *ref;
+          *ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                      static_cast<uint64_t>(move_amt));
           return std::monostate{};
         },
-        [&]() {
-          int64_t i = ref;
+        [=](std::monostate) mutable {
+          int64_t i = *ref;
           return static_cast<int64_t>(static_cast<uint64_t>(i) -
                                       static_cast<uint64_t>(INT64_C(1)));
-        }()};
+        }};
   }();
-  int64_t a = p.getX;
+  int64_t a = p.getX(std::monostate{});
   p.moveD(INT64_C(2));
-  int64_t b = p.getX;
-  int64_t c = p.offsetX;
+  int64_t b = p.getX(std::monostate{});
+  int64_t c = p.offsetX(std::monostate{});
   return std::make_pair(std::make_pair(a, b), c);
 }
 
 std::pair<std::pair<std::pair<int64_t, int64_t>, int64_t>, int64_t>
 testtoST2_ext() {
   Point<std::monostate> p1 = []() {
-    int64_t ref;
-    ref = INT64_C(1);
+    std::shared_ptr<int64_t> ref;
+    ref = std::make_shared<decltype(INT64_C(1))>(INT64_C(1));
     return Point<std::monostate>{
-        ref,
+        [=](std::monostate) mutable { return *ref; },
         [=](int64_t move_amt) mutable {
-          int64_t i = ref;
-          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
-                                     static_cast<uint64_t>(move_amt));
+          int64_t i = *ref;
+          *ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                      static_cast<uint64_t>(move_amt));
           return std::monostate{};
         },
-        [&]() {
-          int64_t i = ref;
+        [=](std::monostate) mutable {
+          int64_t i = *ref;
           return static_cast<int64_t>(static_cast<uint64_t>(i) -
                                       static_cast<uint64_t>(INT64_C(1)));
-        }()};
+        }};
   }();
   Point<std::monostate> p2 = []() {
-    int64_t ref;
-    ref = INT64_C(10);
+    std::shared_ptr<int64_t> ref;
+    ref = std::make_shared<decltype(INT64_C(10))>(INT64_C(10));
     return Point<std::monostate>{
-        ref,
+        [=](std::monostate) mutable { return *ref; },
         [=](int64_t move_amt) mutable {
-          int64_t i = ref;
-          ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
-                                     static_cast<uint64_t>(move_amt));
+          int64_t i = *ref;
+          *ref = static_cast<int64_t>(static_cast<uint64_t>(i) +
+                                      static_cast<uint64_t>(move_amt));
           return std::monostate{};
         },
-        [&]() {
-          int64_t i = ref;
+        [=](std::monostate) mutable {
+          int64_t i = *ref;
           return static_cast<int64_t>(static_cast<uint64_t>(i) -
                                       static_cast<uint64_t>(INT64_C(10)));
-        }()};
+        }};
   }();
-  int64_t a = p1.getX;
-  int64_t b = p2.getX;
-  int64_t v1 = p1.getX;
+  int64_t a = p1.getX(std::monostate{});
+  int64_t b = p2.getX(std::monostate{});
+  int64_t v1 = p1.getX(std::monostate{});
   p2.moveD(v1);
-  int64_t c = p1.getX;
-  int64_t d = p2.getX;
+  int64_t c = p1.getX(std::monostate{});
+  int64_t d = p2.getX(std::monostate{});
   return std::make_pair(std::make_pair(std::make_pair(a, b), c), d);
+}
+
+std::pair<std::pair<std::pair<int64_t, int64_t>, bool>, int64_t>
+acc_test1_ext() {
+  Account<std::monostate> acc = []() {
+    std::shared_ptr<int64_t> bal_ref;
+    bal_ref = std::make_shared<decltype(INT64_C(100))>(INT64_C(100));
+    return Account<std::monostate>{
+        [=](std::monostate) mutable { return *bal_ref; },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                          static_cast<uint64_t>(amt));
+          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                      static_cast<uint64_t>(amt));
+        },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          if (static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                   static_cast<uint64_t>(amt)) < INT64_C(0)) {
+            return std::optional<int64_t>();
+          } else {
+            *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                            static_cast<uint64_t>(amt));
+            return std::make_optional<int64_t>(static_cast<int64_t>(
+                static_cast<uint64_t>(bal) - static_cast<uint64_t>(amt)));
+          }
+        }};
+  }();
+  int64_t a = acc.getBalance(std::monostate{});
+  int64_t b = acc.deposit(INT64_C(50));
+  std::optional<int64_t> c = acc.withdraw(INT64_C(160));
+  int64_t d = acc.getBalance(std::monostate{});
+  return std::make_pair(std::make_pair(std::make_pair(a, b),
+                                       [=]() mutable -> bool {
+                                         if (c.has_value()) {
+                                           const int64_t &_x = *c;
+                                           return true;
+                                         } else {
+                                           return false;
+                                         }
+                                       }()),
+                        d);
+}
+
+std::pair<std::pair<std::pair<int64_t, bool>, int64_t>, int64_t>
+acc_test2_ext() {
+  Account<std::monostate> acc1 = []() {
+    std::shared_ptr<int64_t> bal_ref;
+    bal_ref = std::make_shared<decltype(INT64_C(100))>(INT64_C(100));
+    return Account<std::monostate>{
+        [=](std::monostate) mutable { return *bal_ref; },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                          static_cast<uint64_t>(amt));
+          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                      static_cast<uint64_t>(amt));
+        },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          if (static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                   static_cast<uint64_t>(amt)) < INT64_C(0)) {
+            return std::optional<int64_t>();
+          } else {
+            *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                            static_cast<uint64_t>(amt));
+            return std::make_optional<int64_t>(static_cast<int64_t>(
+                static_cast<uint64_t>(bal) - static_cast<uint64_t>(amt)));
+          }
+        }};
+  }();
+  Account<std::monostate> acc2 = []() {
+    std::shared_ptr<int64_t> bal_ref;
+    bal_ref = std::make_shared<decltype(INT64_C(150))>(INT64_C(150));
+    return Account<std::monostate>{
+        [=](std::monostate) mutable { return *bal_ref; },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                          static_cast<uint64_t>(amt));
+          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
+                                      static_cast<uint64_t>(amt));
+        },
+        [=](int64_t amt) mutable {
+          int64_t bal = *bal_ref;
+          if (static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                   static_cast<uint64_t>(amt)) < INT64_C(0)) {
+            return std::optional<int64_t>();
+          } else {
+            *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                            static_cast<uint64_t>(amt));
+            return std::make_optional<int64_t>(static_cast<int64_t>(
+                static_cast<uint64_t>(bal) - static_cast<uint64_t>(amt)));
+          }
+        }};
+  }();
+  int64_t a = acc1.getBalance(std::monostate{});
+  std::optional<int64_t> result = acc1.withdraw(a);
+  if (result.has_value()) {
+    const int64_t &z = *result;
+    if (z == 0) {
+      int64_t b = std::move(acc2).deposit(a);
+      int64_t c = std::move(acc1).getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, true), b), c);
+    } else if (z > 0) {
+      unsigned int _x = static_cast<unsigned int>(z);
+      int64_t b = std::move(acc2).getBalance(std::monostate{});
+      int64_t c = std::move(acc1).getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+    } else {
+      unsigned int _x = static_cast<unsigned int>(-z);
+      int64_t b = std::move(acc2).getBalance(std::monostate{});
+      int64_t c = std::move(acc1).getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+    }
+  } else {
+    int64_t b = std::move(acc2).getBalance(std::monostate{});
+    int64_t c = std::move(acc1).getBalance(std::monostate{});
+    return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+  }
 }

--- a/tests/monadic/object_model/object_model.h
+++ b/tests/monadic/object_model/object_model.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -108,13 +109,23 @@ struct STRefNat {
 };
 
 template <typename S> struct Point {
-  int64_t getX;
+  std::function<int64_t(std::monostate)> getX;
   std::function<void(int64_t)> moveD;
-  int64_t offsetX;
+  std::function<int64_t(std::monostate)> offsetX;
+};
+
+template <typename S> struct Account {
+  std::function<int64_t(std::monostate)> getBalance;
+  std::function<int64_t(int64_t)> deposit;
+  std::function<std::optional<int64_t>(int64_t)> withdraw;
 };
 
 std::pair<std::pair<int64_t, int64_t>, int64_t> testtoST1_ext();
 std::pair<std::pair<std::pair<int64_t, int64_t>, int64_t>, int64_t>
 testtoST2_ext();
+std::pair<std::pair<std::pair<int64_t, int64_t>, bool>, int64_t>
+acc_test1_ext();
+std::pair<std::pair<std::pair<int64_t, bool>, int64_t>, int64_t>
+acc_test2_ext();
 
 #endif // INCLUDED_OBJECT_MODEL

--- a/tests/monadic/object_model/object_model.h
+++ b/tests/monadic/object_model/object_model.h
@@ -1,0 +1,120 @@
+#ifndef INCLUDED_OBJECT_MODEL
+#define INCLUDED_OBJECT_MODEL
+
+#include <any>
+#include <concepts>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+struct Nat {
+  // TYPES
+  struct O {};
+
+  struct S {
+    std::shared_ptr<Nat> a0;
+  };
+
+  using variant_t = std::variant<O, S>;
+
+private:
+  // DATA
+  variant_t v_;
+
+public:
+  // CREATORS
+  Nat() {}
+
+  explicit Nat(O _v) : v_(_v) {}
+
+  explicit Nat(S _v) : v_(std::move(_v)) {}
+
+  static Nat o() { return Nat(O{}); }
+
+  static Nat s(Nat a0) { return Nat(S{std::make_shared<Nat>(std::move(a0))}); }
+
+  // MANIPULATORS
+  ~Nat() {
+    std::vector<std::shared_ptr<Nat>> _stack = {};
+    auto _drain = [&](variant_t &_v) {
+      if (auto *_alt = std::get_if<S>(&_v)) {
+        if (_alt->a0) {
+          _stack.push_back(std::move(_alt->a0));
+        }
+      }
+    };
+    _drain(v_mut());
+    while (!_stack.empty()) {
+      auto _cur = std::move(_stack.back());
+      _stack.pop_back();
+      if (_cur.use_count() == 1) {
+        _drain(_cur->v_mut());
+      }
+    }
+  }
+
+  inline variant_t &v_mut() { return v_; }
+
+  // ACCESSORS
+  const variant_t &v() const { return v_; }
+};
+
+template <typename Err> struct ExceptE {
+  // DATA
+  Err a0;
+
+  // ACCESSORS
+  ExceptE<Err> clone() const { return {a0}; }
+
+  // CREATORS
+  static ExceptE<Err> Throw_(Err a0) { return {std::move(a0)}; }
+};
+
+struct Err {
+  // DATA
+  std::string x;
+
+  // ACCESSORS
+  Err clone() const { return {x}; }
+
+  // CREATORS
+  static Err error(std::string x) { return {std::move(x)}; }
+};
+
+template <typename I, typename T>
+concept STRefClass = requires {
+  { I::mkSTRef(std::declval<T>()) } -> std::convertible_to<std::any>;
+  { I::STRefToIx(std::declval<std::any>()) } -> std::convertible_to<T>;
+};
+
+struct STRefNat {
+  // DATA
+  Nat s;
+
+  // ACCESSORS
+  STRefNat clone() const { return {s}; }
+
+  // CREATORS
+  static STRefNat mkstref(Nat s) { return {std::move(s)}; }
+
+  Nat STRefToIxNat() const {
+    const auto &[s] = *this;
+    return s;
+  }
+};
+
+template <typename S> struct Point {
+  int64_t getX;
+  std::function<void(int64_t)> moveD;
+  int64_t offsetX;
+};
+
+std::pair<std::pair<int64_t, int64_t>, int64_t> testtoST1_ext();
+std::pair<std::pair<std::pair<int64_t, int64_t>, int64_t>, int64_t>
+testtoST2_ext();
+
+#endif // INCLUDED_OBJECT_MODEL

--- a/tests/monadic/object_model/object_model.t.cpp
+++ b/tests/monadic/object_model/object_model.t.cpp
@@ -1,0 +1,64 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// Distributed under the terms of the GNU LGPL v2.1 license.
+#include "object_model.h"
+
+#include <iostream>
+#include <variant>
+
+// ============================================================================
+//                     STANDARD BDE ASSERT TEST FUNCTION
+// ----------------------------------------------------------------------------
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line) {
+  if (condition) {
+    std::cout << "Error " __FILE__ "(" << line << "): " << message
+              << "    (failed)" << std::endl;
+
+    if (0 <= testStatus && testStatus <= 100) {
+      ++testStatus;
+    }
+  }
+}
+
+} // namespace
+
+#define ASSERT(X) aSsErT(!(X), #X, __LINE__);
+
+int main() {
+  // Test 1: point_test1 returns (1,3,2)
+  {
+    auto result = testtoST1_ext();
+    ASSERT(result.first.first == 1);
+    ASSERT(result.first.second == 3);
+    ASSERT(result.second == 2);
+    std::cout << "Test 1 (point_test1 works): (" << result.first.first << ", "
+              << result.first.second << ", " << result.second << ")"
+              << std::endl;
+  }
+
+  // Test 2: point_test2 returns (1, 10, 1,11)
+  {
+    auto result = testtoST2_ext();
+    ASSERT(result.first.first.first == 1);
+    ASSERT(result.first.first.second == 10);
+    ASSERT(result.first.second == 1);
+    ASSERT(result.second == 11);
+    std::cout << "Test 2 (point_test2 works): (" << result.first.first.first
+              << ", " << result.first.first.second << ", " << result.first.second
+              << ", " << result.second << ")" << std::endl;
+  }
+
+  if (testStatus == 0) {
+    std::cout << "\nAll point tests passed!" << std::endl;
+  } else {
+    std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
+  }
+  return testStatus;
+}
+
+
+

--- a/tests/monadic/object_model/object_model.t.cpp
+++ b/tests/monadic/object_model/object_model.t.cpp
@@ -52,8 +52,34 @@ int main() {
               << ", " << result.second << ")" << std::endl;
   }
 
+  // Test 3: acc_test1 returns (100,150,false,150)
+  {
+    auto result = acc_test1_ext();
+    ASSERT(result.first.first.first == 100);
+    ASSERT(result.first.first.second == 150);
+    ASSERT(result.first.second == false);
+    ASSERT(result.second == 150);
+    std::cout << "Test 3 (account1 works): (" << result.first.first.first
+              << ", " << result.first.first.second << ", " << result.first.second
+              << ", " << result.second << ")" << std::endl;
+    
+  }
+
+  // Test 3: acc_test2 returns (100,true,250,0)
+  {
+    auto result = acc_test2_ext();
+    ASSERT(result.first.first.first == 100);
+    ASSERT(result.first.first.second == true);
+    ASSERT(result.first.second == 250);
+    ASSERT(result.second == 0);
+    std::cout << "Test 4 (account2 works): (" << result.first.first.first
+              << ", " << result.first.first.second << ", " << result.first.second
+              << ", " << result.second << ")" << std::endl;
+    
+  }
+
   if (testStatus == 0) {
-    std::cout << "\nAll point tests passed!" << std::endl;
+    std::cout << "\nAll object model tests passed!" << std::endl;
   } else {
     std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
   }

--- a/tests/monadic/object_model/point.t.cpp
+++ b/tests/monadic/object_model/point.t.cpp
@@ -1,0 +1,3 @@
+#include "point.t.h"
+
+

--- a/tests/monadic/object_model/point.t.cpp
+++ b/tests/monadic/object_model/point.t.cpp
@@ -1,3 +1,0 @@
-#include "point.t.h"
-
-

--- a/tests/monadic/stmonad/STMonadExtractionTests.v
+++ b/tests/monadic/stmonad/STMonadExtractionTests.v
@@ -105,6 +105,7 @@ End STMonadTests.
 
 Set Crane Loopify.
 Crane Extract Inlined Constant STMonadTests.runST' => "%a0".
+Crane Extract Skip callE.
 
 
 Crane Extraction "stmonad" STMonadTests.
@@ -113,3 +114,6 @@ Crane Benchmark
   STMonadTests.test_quicksort_fun,
   STMonadTests.test_quicksort_ST
 On C++ With "".
+
+
+

--- a/tests/monadic/stmonad/STMonadExtractionTests.v
+++ b/tests/monadic/stmonad/STMonadExtractionTests.v
@@ -108,6 +108,7 @@ Crane Extract Inlined Constant STMonadTests.runST' => "%a0".
 Crane Extract Skip callE.
 
 
+
 Crane Extraction "stmonad" STMonadTests.
 
 Crane Benchmark

--- a/tests/monadic/stmonad/STMonadFunctionalModelTests.v
+++ b/tests/monadic/stmonad/STMonadFunctionalModelTests.v
@@ -1348,6 +1348,7 @@ Section NatProgramProofs.
 End NatProgramProofs.
 
 
+
 Lemma fib_ST_eq_fib_fun : forall {S : Type} (n : nat),
     ret (fib_fun n) ≈ runST (S := S) (fun S0 => fib_ST n).
 Proof.

--- a/tests/monadic/stmonad/stmonad.h
+++ b/tests/monadic/stmonad/stmonad.h
@@ -276,27 +276,29 @@ struct STMonadTests {
     if (n < UINT64_C(2)) {
       return n;
     } else {
-      uint64_t x;
-      x = UINT64_C(0);
-      uint64_t y;
-      y = UINT64_C(1);
-      auto fib_loop_impl = [&](auto &, uint64_t k, uint64_t x0, uint64_t y0,
-                               uint64_t, uint64_t) -> uint64_t {
+      std::shared_ptr<uint64_t> x;
+      x = std::make_shared<decltype(UINT64_C(0))>(UINT64_C(0));
+      std::shared_ptr<uint64_t> y;
+      y = std::make_shared<decltype(UINT64_C(1))>(UINT64_C(1));
+      auto fib_loop_impl = [&](auto &, uint64_t k, std::shared_ptr<uint64_t> x0,
+                               std::shared_ptr<uint64_t> y0, uint64_t,
+                               uint64_t) -> uint64_t {
         uint64_t _loop_k = std::move(k);
         while (true) {
           if (_loop_k <= 0) {
-            return x0;
+            return *x0;
           } else {
             uint64_t k_ = _loop_k - 1;
-            uint64_t x_ = x0;
-            uint64_t y_ = y0;
-            x0 = y_;
-            y0 = (x_ + y_);
+            uint64_t x_ = *x0;
+            uint64_t y_ = *y0;
+            *x0 = y_;
+            *y0 = (x_ + y_);
             _loop_k = k_;
           }
         }
       };
-      auto fib_loop = [&](uint64_t k, uint64_t x0, uint64_t y0, uint64_t idx_x,
+      auto fib_loop = [&](uint64_t k, std::shared_ptr<uint64_t> x0,
+                          std::shared_ptr<uint64_t> y0, uint64_t idx_x,
                           uint64_t idx_y) -> uint64_t {
         return fib_loop_impl(fib_loop_impl, k, x0, y0, idx_x, idx_y);
       };
@@ -310,50 +312,51 @@ struct STMonadTests {
   template <typename _tcI0, typename _tcI1>
     requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static std::pair<bool, bool> new_and_read_both_bool() {
-    bool r1;
-    r1 = false;
-    bool r2;
-    r2 = true;
-    bool x1 = r1;
-    bool x2 = r2;
+    std::shared_ptr<bool> r1;
+    r1 = std::make_shared<decltype(false)>(false);
+    std::shared_ptr<bool> r2;
+    r2 = std::make_shared<decltype(true)>(true);
+    bool x1 = *r1;
+    bool x2 = *r2;
     return std::make_pair(x1, x2);
   }
 
   template <typename _tcI0, typename _tcI1>
     requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static std::pair<uint64_t, uint64_t> new_and_read_both_nat() {
-    uint64_t r1;
-    r1 = UINT64_C(5);
-    uint64_t r2;
-    r2 = UINT64_C(6);
-    uint64_t x1 = r1;
-    uint64_t x2 = r2;
+    std::shared_ptr<uint64_t> r1;
+    r1 = std::make_shared<decltype(UINT64_C(5))>(UINT64_C(5));
+    std::shared_ptr<uint64_t> r2;
+    r2 = std::make_shared<decltype(UINT64_C(6))>(UINT64_C(6));
+    uint64_t x1 = *r1;
+    uint64_t x2 = *r2;
     return std::make_pair(x1, x2);
   }
 
   template <typename _tcI0, typename _tcI1>
     requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static uint64_t tree_simp_another_nat() {
-    uint64_t v;
-    v = UINT64_C(5);
-    v = UINT64_C(6);
-    return v;
+    std::shared_ptr<uint64_t> v;
+    v = std::make_shared<decltype(UINT64_C(5))>(UINT64_C(5));
+    *v = UINT64_C(6);
+    uint64_t val = *v;
+    return val;
   }
 
   template <typename _tcI0, typename _tcI1>
     requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static bool tree_simp_bool() {
-    bool v;
-    v = true;
-    return std::move(v);
+    std::shared_ptr<bool> v;
+    v = std::make_shared<decltype(true)>(true);
+    return *std::move(v);
   }
 
   template <typename _tcI0, typename _tcI1>
     requires STRefClass<_tcI0, uint64_t> && Ix<_tcI1, uint64_t>
   static uint64_t tree_simp_nat() {
-    uint64_t v;
-    v = UINT64_C(5);
-    return std::move(v);
+    std::shared_ptr<uint64_t> v;
+    v = std::make_shared<decltype(UINT64_C(5))>(UINT64_C(5));
+    return *std::move(v);
   }
 
   static List<uint64_t> quicksort_fun(const List<uint64_t> &x);

--- a/tests/monadic/stmonad/stmonad.h
+++ b/tests/monadic/stmonad/stmonad.h
@@ -339,8 +339,7 @@ struct STMonadTests {
     std::shared_ptr<uint64_t> v;
     v = std::make_shared<decltype(UINT64_C(5))>(UINT64_C(5));
     *v = UINT64_C(6);
-    uint64_t val = *v;
-    return val;
+    return *v;
   }
 
   template <typename _tcI0, typename _tcI1>

--- a/tests/monadic/stmonad/stmonad.t.cpp
+++ b/tests/monadic/stmonad/stmonad.t.cpp
@@ -151,7 +151,7 @@ int main() {
   }
 
   if (testStatus == 0) {
-    std::cout << "\nAll quicksort tests passed!" << std::endl;
+    std::cout << "\nAll stmonad tests passed!" << std::endl;
   } else {
     std::cout << "\n" << testStatus << " test(s) failed!" << std::endl;
   }

--- a/theories/Monads/MonadFacts.v
+++ b/theories/Monads/MonadFacts.v
@@ -19,6 +19,7 @@ From ITree Require Import
   Events.Exception
   Events.MapDefault
   Events.State
+  Events.StateFacts
   ITree
   ITreeFacts
 .

--- a/theories/Monads/STMonad.v
+++ b/theories/Monads/STMonad.v
@@ -311,10 +311,10 @@ Crane Extract Skip STRefToIx.
 (* NOTE: skipping STRefClass seems to drop too much typing information,
  and the value types within references are not inferred. *)
 (* Crane Extract Skip STRefClass. *)
-Crane Extract Inlined Constant STRef => "%t2".
-Crane Extract Inlined Constant newSTRef => "%result = %a1".
-Crane Extract Inlined Constant readSTRef => "%a1".
-Crane Extract Inlined Constant writeSTRef => "%a1 = %a2".
+Crane Extract Inlined Constant STRef => "std::shared_ptr<%t2>".
+Crane Extract Inlined Constant newSTRef => "%result = std::make_shared<decltype(%a1)>(%a1)".
+Crane Extract Inlined Constant readSTRef => "*%a1".
+Crane Extract Inlined Constant writeSTRef => "*%a1 = %a2".
 (* array extraction *)
 
 Crane Extract Inductive STArray => "std::vector<%t2> *" [ "" ].


### PR DESCRIPTION


**Describe your changes**
This adds two class examples, a `Point` class, and an `Account` class, which track a single point and a single bank account with `STRefs`, respectively.

This includes a fix for the extraction of `STRef`s, which previously were being extracted as locals. This reproduced when calling a function that allocated an STRef and returned it (such as say, an object constructor for a `Point` class that allocates a reference for the private data of that class), as the created reference needs to escape the scope of the function that defines it.



**Testing performed**

The functions are tested within a functional model of `STMonad`, as well as being extracted to C++ and tested as C++ functions.


