### PR TITLE
Minor additions to class model tests

### DIFF
--- a/tests/monadic/dune
+++ b/tests/monadic/dune
@@ -242,7 +242,7 @@
 (subdir object_model
  (rule
   (targets object_model.t.exe)
-  (deps ObjectModelExtractionTests.vo object_model.t.cpp (source_tree .))
+  (deps ObjectModelTests.vo object_model.t.cpp (source_tree .))
   (action
    (run %{project_root}/scripts/compile-std.sh %{project_root} object_model.t.exe object_model.cpp object_model.t.cpp)))
  (rule

--- a/tests/monadic/object_model/ObjectModelExtractionTests.v
+++ b/tests/monadic/object_model/ObjectModelExtractionTests.v
@@ -120,17 +120,17 @@ Section PointDef.
   
   Record Account := mkAccount {
       getBalance : unit -> itree E0 Z;
-      deposit : Z -> itree E0 Z;
+      deposit : nat -> itree E0 Z;
       withdraw : Z -> itree E0 (option Z);
     }.
 
   Definition getBalance_imp (idx : T) (ref : STRef S Z) : unit -> itree E0 Z :=
     fun _ => readSTRef (idx := idx) ref.
 
-  Definition deposit_imp (idx : T) (ref : STRef S Z) : Z -> itree E0 Z :=
-    fun amt : Z =>
+  Definition deposit_imp (idx : T) (ref : STRef S Z) : nat -> itree E0 Z :=
+    fun amt : nat =>
       bal <- readSTRef (idx := idx) ref;;
-      let new_bal := (bal + amt)%Z in
+      let new_bal := (bal + (Z.of_nat amt))%Z in
       writeSTRef (idx := idx) ref new_bal;;
       Ret new_bal.
 
@@ -151,7 +151,7 @@ Section PointDef.
       {| getBalance _ := !bal_ref;
          deposit amt := 
             bal <- !bal_ref;;
-            let new_bal := (bal + amt)%Z in
+            let new_bal := (bal + (Z.of_nat amt))%Z in
              bal_ref :== new_bal;;
              Ret new_bal;
         withdraw amt := 
@@ -186,7 +186,7 @@ Section PointDef.
     result <- withdraw acc1 a;;
     match result with
     | Some 0%Z => (* withdrawal succeeds, transfer money*)
-        b <- deposit acc2 a;;
+        b <- deposit acc2 (Z.to_nat a);;
         c <- getBalance acc1 tt;;
         Ret (a,true,b,c)
     | _ => (* withdrawal failed, do nothing, return balance of a,b *)
@@ -198,9 +198,7 @@ Section PointDef.
   #[export] Instance hmap_nat_v : HMap (@idx_key T T) (idx_key_type V) mem :=
     HMap_halist (idx_key T) (idx_key_type V).
 
-
   (* TODO: make this a structure instead of `and` *)
-
 
   Definition backed_by (acc : Account) (idx : T) (ref : STRef S Z) : Prop :=
     getBalance acc = getBalance_imp idx ref /\
@@ -330,13 +328,12 @@ Section PointDef.
 
 
   Lemma deposit_preserves_wf :
-    forall (acc : Account) (idx : T) (ref : STRef S Z) (amt new_bal : Z) (m0 m1 : @mem T V) (out_val : Z),
-      (amt >= 0)%Z ->
+    forall (acc : Account) (idx : T) (ref : STRef S Z) (amt : nat) (new_bal : Z) (m0 m1 : @mem T V) (out_val : Z),
       account_wf acc idx ref m0 ->
       interp_st ltu _ (deposit acc amt) m0 ≈ Ret (m1 , out_val) ->
       account_wf acc idx ref m1.
     Proof using Type.
-      intros acc idx ref amt b m0 m1 o Hamt Hwdrw Hintrp.
+      intros acc idx ref amt b m0 m1 o Hwdrw Hintrp.
       unfold account_wf in *. destruct Hwdrw as [Hback Hlookup].
       split; try assumption.
       unfold backed_by in Hback. destruct Hback as [Hgetb [Hwdrw Hdepos]].
@@ -351,7 +348,7 @@ Section PointDef.
       repeat (repeat setoid_rewrite Monad.bind_bind in Hintrp;
           repeat setoid_rewrite bind_Ret_l in Hintrp;
           repeat setoid_rewrite bind_Ret_r in Hintrp).
-      exists (v + amt)%Z. unfold_instances.
+      exists (v + Z.of_nat amt)%Z. unfold_instances.
       change (@Monad.bind (itree ?E) _) with (@ITree.bind E) in Hintrp.
       rewrite interp_st_bind_eutt in Hintrp.
       unfold writeSTRef in Hintrp.
@@ -431,7 +428,7 @@ Proof. lazy. reflexivity. Qed.
 
 
 
-From Crane Require Import Mapping.ZInt.
+From Crane Require Import Mapping.ZInt Mapping.NatIntStd.
 
 Definition testtoST1_ext :=
   Eval unfold testtoST1, class_pointST in (testtoST1 unit).

--- a/tests/monadic/object_model/ObjectModelExtractionTests.v
+++ b/tests/monadic/object_model/ObjectModelExtractionTests.v
@@ -198,17 +198,16 @@ Section PointDef.
   #[export] Instance hmap_nat_v : HMap (@idx_key T T) (idx_key_type V) mem :=
     HMap_halist (idx_key T) (idx_key_type V).
 
-  (* TODO: make this a structure instead of `and` *)
-
-  Definition backed_by (acc : Account) (idx : T) (ref : STRef S Z) : Prop :=
-    getBalance acc = getBalance_imp idx ref /\
-    withdraw acc = withdraw_imp idx ref /\
-    deposit acc = deposit_imp idx ref.
-
+  Record account_impl  (idx : T) (ref : STRef S Z) (acc : Account) := 
+    mkAccountImpl {
+        getBalance_impld_by : getBalance acc = getBalance_imp idx ref;
+        withdraw_impld_by : withdraw acc = withdraw_imp idx ref;
+        deposit_impld_by : deposit acc = deposit_imp idx ref;
+      }.
 
   Definition account_wf (acc : Account) (idx : T) (ref : STRef S Z)
     (m : @mem T V)  : Prop :=
-    backed_by acc idx ref /\
+    account_impl idx ref acc  /\
     exists v, HMap.lookup (STRefToIx S Z ref, idx) m = Some v /\ (v >= 0)%Z.
 
   Definition max_idx (m : @mem T V) :=
@@ -269,6 +268,7 @@ Section PointDef.
       - econstructor.
         + econstructor.
         + split; reflexivity.
+        + econstructor.
       - exists init. 
         split.
         + eapply st_lookup_add_eq. 
@@ -289,7 +289,7 @@ Section PointDef.
       intros acc idx ref amt b m0 m1 o Hwdrw Hintrp.
       unfold account_wf in *. destruct Hwdrw as [Hback Hlookup].
       split. try assumption.
-      unfold backed_by in Hback. destruct Hback as [Hgetb [Hwdrw Hdepos]].
+      destruct Hback as [Hgetb Hwdrw Hdepos].
       rewrite Hwdrw in Hintrp.
       unfold withdraw_imp in Hintrp. unfold_instances.
       rewrite interp_st_bind in Hintrp.
@@ -336,7 +336,7 @@ Section PointDef.
       intros acc idx ref amt b m0 m1 o Hwdrw Hintrp.
       unfold account_wf in *. destruct Hwdrw as [Hback Hlookup].
       split; try assumption.
-      unfold backed_by in Hback. destruct Hback as [Hgetb [Hwdrw Hdepos]].
+      destruct Hback as [Hgetb Hwdrw Hdepos].
       rewrite Hdepos in Hintrp. unfold deposit_imp in Hintrp. unfold_instances.
       rewrite interp_st_bind in Hintrp. unfold readSTRef in *. rewrite interp_st_trigger in Hintrp. cbn in Hintrp.  
       destruct Hlookup as [v [Hlookup Hvnz]].
@@ -371,9 +371,9 @@ Section PointDef.
       account_wf acc idx ref m0 ->
       interp_st ltu _ (getBalance acc tt) m0 ≈ Ret (m1 , out_val) ->
       account_wf acc idx ref m1.
-    Proof.
+    Proof using Type.
       intros acc idx ref out_val m0 m1 Hwf Hintrp.
-      destruct Hwf as [[Hgetbal [Hwth Hdep]] Hlookup]; rewrite Hgetbal in Hintrp.
+      destruct Hwf as [[Hgetbal Hwth Hdep] Hlookup]; rewrite Hgetbal in Hintrp.
       unfold getBalance_imp in Hintrp.
       unfold readSTRef in Hintrp.
       unfold_instances.

--- a/tests/monadic/object_model/ObjectModelTests.v
+++ b/tests/monadic/object_model/ObjectModelTests.v
@@ -179,7 +179,7 @@ Section Classes.
   (* Fully transfer amounts between two accounts *)
   Definition testAccount2 : itree E0 (Z * bool * Z * Z) :=
     acc1 <- @class_Account 0%nat 100;;
-    acc2 <- @class_Account 0%nat 150;;
+    acc2 <- @class_Account 1%nat 150;;
     a <- getBalance acc1 tt;;
     result <- withdraw acc1 a;;
     match result with
@@ -384,6 +384,38 @@ Section Classes.
       exists out_val. split; try (repeat split; assumption).
     Qed.
 
+    
+    Record BankAccountCollection :=
+      mkBankAccount {
+        checking : Account;
+        saving   : Account;
+      }.
+
+    Definition class_BankAccount (idx : T) (init_checking init_saving : Z) : itree E0 BankAccountCollection :=
+      checking' <- @class_Account idx init_checking;;
+      saving' <- @class_Account (suc idx) init_saving;;
+      Ret
+        {| checking := checking';
+           saving := saving';
+        |}.
+
+  (* Fully transfer amounts between two accounts *)
+  Definition testBankAccount1 : itree E0 (Z * bool * Z * Z) :=
+    acc <- class_BankAccount 0%nat 100 150;; 
+    a <- getBalance (checking acc) tt;;
+    result <- withdraw (checking acc) a;;
+    match result with
+    | Some 0%Z => (* withdrawal succeeds, transfer money*)
+        b <- deposit (saving acc) (Z.to_nat a);;
+        c <- getBalance (checking acc) tt;;
+        Ret (a,true,b,c)
+    | _ => (* withdrawal failed, do nothing, return balance of a,b *)
+        b <- getBalance (checking acc) tt;;
+        c <- getBalance (saving acc) tt;;
+        Ret (a,false,b,c)
+    end.
+
+
 End Classes.
 
 
@@ -414,6 +446,12 @@ Definition run_acc2 : itree (exceptE Err) (Z * bool * Z * Z) :=
 Lemma acc_run_burn2 : burn 100 run_acc2 = Ret (100, true, 250, 0)%Z.
 Proof. lazy. reflexivity. Qed.
 
+Definition run_bank_acc1 : itree (exceptE Err) (Z * bool * Z * Z) :=
+  runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testBankAccount1.
+
+Lemma bank_acc_run_burn1 : burn 100 run_bank_acc1 = Ret (100, true, 250, 0)%Z.
+Proof. lazy. reflexivity. Qed.
+
 
 
 
@@ -432,7 +470,16 @@ Definition acc_test1_ext :=
 Definition acc_test2_ext :=
   Eval unfold testAccount2, class_Account in (testAccount2 unit).
 
-Crane Extraction "object_model" testtoST1_ext testtoST2_ext acc_test1_ext acc_test2_ext.
+Definition bankacc_test1_ext :=
+  Eval unfold testBankAccount1, class_BankAccount, class_Account in (testBankAccount1 unit).
+
+Crane Extraction "object_model"
+  testtoST1_ext
+  testtoST2_ext
+  acc_test1_ext
+  acc_test2_ext
+  bankacc_test1_ext
+.
 
 
 

--- a/tests/monadic/object_model/ObjectModelTests.v
+++ b/tests/monadic/object_model/ObjectModelTests.v
@@ -3,8 +3,6 @@
 
 (* An object model using STRefs for mutable state *)
 
-
-
 From Stdlib Require Import
   Arith.PeanoNat
   Arith.Peano_dec
@@ -59,7 +57,7 @@ From Crane Require Import
   Utils.HAList
   Extraction.
 
-Section PointDef.
+Section Classes.
 
 
   Context (S : Type).
@@ -386,18 +384,11 @@ Section PointDef.
       exists out_val. split; try (repeat split; assumption).
     Qed.
 
-
-
-
-                                            
-
-End PointDef.
+End Classes.
 
 
 Transparent HAList.halist_lookup HAList.halist_add
             HAList.HMap_halist HAList.HMapOk_halist.
-Existing Instance nat_ix_correct.
-Existing Instance nat_ix_stref.
 
 Definition run_test1 : itree (exceptE Err) (Z * Z * Z) :=
   runST (T := nat) (ltu := Nat.le) (V := fun _ : nat => Z) (S := unit) testtoST1.

--- a/tests/monadic/object_model/object_model.cpp
+++ b/tests/monadic/object_model/object_model.cpp
@@ -77,12 +77,14 @@ acc_test1_ext() {
     bal_ref = std::make_shared<decltype(INT64_C(100))>(INT64_C(100));
     return Account<std::monostate>{
         [=](std::monostate) mutable { return *bal_ref; },
-        [=](int64_t amt) mutable {
+        [=](uint64_t amt) mutable {
           int64_t bal = *bal_ref;
-          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                          static_cast<uint64_t>(amt));
-          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                      static_cast<uint64_t>(amt));
+          *bal_ref = static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
+          return static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
         },
         [=](int64_t amt) mutable {
           int64_t bal = *bal_ref;
@@ -98,7 +100,7 @@ acc_test1_ext() {
         }};
   }();
   int64_t a = acc.getBalance(std::monostate{});
-  int64_t b = acc.deposit(INT64_C(50));
+  int64_t b = acc.deposit(UINT64_C(50));
   std::optional<int64_t> c = acc.withdraw(INT64_C(160));
   int64_t d = acc.getBalance(std::monostate{});
   return std::make_pair(std::make_pair(std::make_pair(a, b),
@@ -120,12 +122,14 @@ acc_test2_ext() {
     bal_ref = std::make_shared<decltype(INT64_C(100))>(INT64_C(100));
     return Account<std::monostate>{
         [=](std::monostate) mutable { return *bal_ref; },
-        [=](int64_t amt) mutable {
+        [=](uint64_t amt) mutable {
           int64_t bal = *bal_ref;
-          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                          static_cast<uint64_t>(amt));
-          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                      static_cast<uint64_t>(amt));
+          *bal_ref = static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
+          return static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
         },
         [=](int64_t amt) mutable {
           int64_t bal = *bal_ref;
@@ -145,12 +149,14 @@ acc_test2_ext() {
     bal_ref = std::make_shared<decltype(INT64_C(150))>(INT64_C(150));
     return Account<std::monostate>{
         [=](std::monostate) mutable { return *bal_ref; },
-        [=](int64_t amt) mutable {
+        [=](uint64_t amt) mutable {
           int64_t bal = *bal_ref;
-          *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                          static_cast<uint64_t>(amt));
-          return static_cast<int64_t>(static_cast<uint64_t>(bal) +
-                                      static_cast<uint64_t>(amt));
+          *bal_ref = static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
+          return static_cast<int64_t>(
+              static_cast<uint64_t>(bal) +
+              static_cast<uint64_t>(static_cast<int64_t>(amt)));
         },
         [=](int64_t amt) mutable {
           int64_t bal = *bal_ref;
@@ -170,7 +176,7 @@ acc_test2_ext() {
   if (result.has_value()) {
     const int64_t &z = *result;
     if (z == 0) {
-      int64_t b = std::move(acc2).deposit(a);
+      int64_t b = std::move(acc2).deposit(static_cast<uint64_t>(a < 0 ? 0 : a));
       int64_t c = std::move(acc1).getBalance(std::monostate{});
       return std::make_pair(std::make_pair(std::make_pair(a, true), b), c);
     } else if (z > 0) {

--- a/tests/monadic/object_model/object_model.cpp
+++ b/tests/monadic/object_model/object_model.cpp
@@ -196,3 +196,97 @@ acc_test2_ext() {
     return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
   }
 }
+
+std::pair<std::pair<std::pair<int64_t, bool>, int64_t>, int64_t>
+bankacc_test1_ext() {
+  BankAccountCollection<std::monostate> acc = []() {
+    Account<std::monostate> checking_ = []() {
+      std::shared_ptr<int64_t> bal_ref;
+      bal_ref = std::make_shared<decltype(INT64_C(100))>(INT64_C(100));
+      return Account<std::monostate>{
+          [=](std::monostate) mutable { return *bal_ref; },
+          [=](uint64_t amt) mutable {
+            int64_t bal = *bal_ref;
+            *bal_ref = static_cast<int64_t>(
+                static_cast<uint64_t>(bal) +
+                static_cast<uint64_t>(static_cast<int64_t>(amt)));
+            return static_cast<int64_t>(
+                static_cast<uint64_t>(bal) +
+                static_cast<uint64_t>(static_cast<int64_t>(amt)));
+          },
+          [=](int64_t amt) mutable {
+            int64_t bal = *bal_ref;
+            if (static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                     static_cast<uint64_t>(amt)) < INT64_C(0)) {
+              return std::optional<int64_t>();
+            } else {
+              *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                              static_cast<uint64_t>(amt));
+              return std::make_optional<int64_t>(static_cast<int64_t>(
+                  static_cast<uint64_t>(bal) - static_cast<uint64_t>(amt)));
+            }
+          }};
+    }();
+    Account<std::monostate> saving_ = []() {
+      std::shared_ptr<int64_t> bal_ref;
+      bal_ref = std::make_shared<decltype(INT64_C(150))>(INT64_C(150));
+      return Account<std::monostate>{
+          [=](std::monostate) mutable { return *bal_ref; },
+          [=](uint64_t amt) mutable {
+            int64_t bal = *bal_ref;
+            *bal_ref = static_cast<int64_t>(
+                static_cast<uint64_t>(bal) +
+                static_cast<uint64_t>(static_cast<int64_t>(amt)));
+            return static_cast<int64_t>(
+                static_cast<uint64_t>(bal) +
+                static_cast<uint64_t>(static_cast<int64_t>(amt)));
+          },
+          [=](int64_t amt) mutable {
+            int64_t bal = *bal_ref;
+            if (static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                     static_cast<uint64_t>(amt)) < INT64_C(0)) {
+              return std::optional<int64_t>();
+            } else {
+              *bal_ref = static_cast<int64_t>(static_cast<uint64_t>(bal) -
+                                              static_cast<uint64_t>(amt));
+              return std::make_optional<int64_t>(static_cast<int64_t>(
+                  static_cast<uint64_t>(bal) - static_cast<uint64_t>(amt)));
+            }
+          }};
+    }();
+    return BankAccountCollection<std::monostate>{checking_, saving_};
+  }();
+  int64_t a = acc.checking.getBalance(std::monostate{});
+  std::optional<int64_t> result = acc.checking.withdraw(a);
+  if (result.has_value()) {
+    const int64_t &z = *result;
+    if (z == 0) {
+      int64_t b = acc.saving.deposit(static_cast<uint64_t>(a < 0 ? 0 : a));
+      int64_t c = acc.checking.getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, true), b), c);
+    } else if (z > 0) {
+      unsigned int _x = static_cast<unsigned int>(z);
+      int64_t b = acc.checking.getBalance(std::monostate{});
+      int64_t c = acc.saving.getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+    } else {
+      unsigned int _x = static_cast<unsigned int>(-z);
+      int64_t b = acc.checking.getBalance(std::monostate{});
+      int64_t c = acc.saving.getBalance(std::monostate{});
+      return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+    }
+  } else {
+    int64_t b = acc.checking.getBalance(std::monostate{});
+    int64_t c = acc.saving.getBalance(std::monostate{});
+    return std::make_pair(std::make_pair(std::make_pair(a, false), b), c);
+  }
+}
+
+List<uint64_t> ListDef::seq(uint64_t start, uint64_t len) {
+  if (len <= 0) {
+    return List<uint64_t>::nil();
+  } else {
+    uint64_t len0 = len - 1;
+    return List<uint64_t>::cons(start, ListDef::seq((start + 1), len0));
+  }
+}

--- a/tests/monadic/object_model/object_model.h
+++ b/tests/monadic/object_model/object_model.h
@@ -10,59 +10,6 @@
 #include <string>
 #include <utility>
 #include <variant>
-#include <vector>
-
-struct Nat {
-  // TYPES
-  struct O {};
-
-  struct S {
-    std::shared_ptr<Nat> a0;
-  };
-
-  using variant_t = std::variant<O, S>;
-
-private:
-  // DATA
-  variant_t v_;
-
-public:
-  // CREATORS
-  Nat() {}
-
-  explicit Nat(O _v) : v_(_v) {}
-
-  explicit Nat(S _v) : v_(std::move(_v)) {}
-
-  static Nat o() { return Nat(O{}); }
-
-  static Nat s(Nat a0) { return Nat(S{std::make_shared<Nat>(std::move(a0))}); }
-
-  // MANIPULATORS
-  ~Nat() {
-    std::vector<std::shared_ptr<Nat>> _stack = {};
-    auto _drain = [&](variant_t &_v) {
-      if (auto *_alt = std::get_if<S>(&_v)) {
-        if (_alt->a0) {
-          _stack.push_back(std::move(_alt->a0));
-        }
-      }
-    };
-    _drain(v_mut());
-    while (!_stack.empty()) {
-      auto _cur = std::move(_stack.back());
-      _stack.pop_back();
-      if (_cur.use_count() == 1) {
-        _drain(_cur->v_mut());
-      }
-    }
-  }
-
-  inline variant_t &v_mut() { return v_; }
-
-  // ACCESSORS
-  const variant_t &v() const { return v_; }
-};
 
 template <typename Err> struct ExceptE {
   // DATA
@@ -94,15 +41,15 @@ concept STRefClass = requires {
 
 struct STRefNat {
   // DATA
-  Nat s;
+  uint64_t s;
 
   // ACCESSORS
   STRefNat clone() const { return {s}; }
 
   // CREATORS
-  static STRefNat mkstref(Nat s) { return {std::move(s)}; }
+  static STRefNat mkstref(uint64_t s) { return {s}; }
 
-  Nat STRefToIxNat() const {
+  uint64_t STRefToIxNat() const {
     const auto &[s] = *this;
     return s;
   }
@@ -116,7 +63,7 @@ template <typename S> struct Point {
 
 template <typename S> struct Account {
   std::function<int64_t(std::monostate)> getBalance;
-  std::function<int64_t(int64_t)> deposit;
+  std::function<int64_t(uint64_t)> deposit;
   std::function<std::optional<int64_t>(int64_t)> withdraw;
 };
 

--- a/tests/monadic/object_model/object_model.h
+++ b/tests/monadic/object_model/object_model.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDED_OBJECT_MODEL
 #define INCLUDED_OBJECT_MODEL
 
+#include <algorithm>
 #include <any>
 #include <concepts>
 #include <cstdint>
@@ -10,6 +11,101 @@
 #include <string>
 #include <utility>
 #include <variant>
+#include <vector>
+
+template <typename A> struct List {
+  // TYPES
+  struct Nil {};
+
+  struct Cons {
+    A a;
+    std::shared_ptr<List<A>> l;
+  };
+
+  using variant_t = std::variant<Nil, Cons>;
+
+private:
+  // DATA
+  variant_t v_;
+
+public:
+  // CREATORS
+  List() {}
+
+  explicit List(Nil _v) : v_(_v) {}
+
+  explicit List(Cons _v) : v_(std::move(_v)) {}
+
+  template <typename _U> List(const List<_U> &_other) {
+    if (std::holds_alternative<typename List<_U>::Nil>(_other.v())) {
+      this->v_ = Nil{};
+    } else {
+      const auto &[a, l] = std::get<typename List<_U>::Cons>(_other.v());
+      this->v_ = Cons{
+          [&]() -> A {
+            if constexpr (std::is_same_v<_U, std::any>) {
+              if (a.type() == typeid(A))
+                return std::any_cast<A>(a);
+              if constexpr (requires {
+                              typename A::first_type;
+                              typename A::second_type;
+                            }) {
+                const auto &[_k, _v] =
+                    std::any_cast<std::pair<std::any, std::any>>(a);
+                return A{[&]() -> typename A::first_type {
+                           if constexpr (std::is_same_v<typename A::first_type,
+                                                        std::any>)
+                             return _k;
+                           else
+                             return std::any_cast<typename A::first_type>(_k);
+                         }(),
+                         [&]() -> typename A::second_type {
+                           if constexpr (std::is_same_v<typename A::second_type,
+                                                        std::any>)
+                             return _v;
+                           else
+                             return std::any_cast<typename A::second_type>(_v);
+                         }()};
+              }
+              return std::any_cast<A>(a);
+            } else
+              return A(a);
+          }(),
+          l ? std::make_shared<List<A>>(*l) : nullptr};
+    }
+  }
+
+  static List<A> nil() { return List(Nil{}); }
+
+  static List<A> cons(A a, List<A> l) {
+    return List(Cons{std::move(a), std::make_shared<List<A>>(std::move(l))});
+  }
+
+  // MANIPULATORS
+  ~List() {
+    std::vector<std::shared_ptr<List<A>>> _stack = {};
+    auto _drain = [&](variant_t &_v) {
+      if (auto *_alt = std::get_if<Cons>(&_v)) {
+        if (_alt->l) {
+          _stack.push_back(std::move(_alt->l));
+        }
+      }
+    };
+    _drain(v_mut());
+    while (!_stack.empty()) {
+      auto _cur = std::move(_stack.back());
+      _stack.pop_back();
+      if (_cur.use_count() == 1) {
+        _drain(_cur->v_mut());
+      }
+    }
+  }
+
+  inline variant_t &v_mut() { return v_; }
+
+  // ACCESSORS
+  const variant_t &v() const { return v_; }
+};
 
 template <typename Err> struct ExceptE {
   // DATA
@@ -20,6 +116,10 @@ template <typename Err> struct ExceptE {
 
   // CREATORS
   static ExceptE<Err> Throw_(Err a0) { return {std::move(a0)}; }
+};
+
+struct ListDef {
+  static List<uint64_t> seq(uint64_t start, uint64_t len);
 };
 
 struct Err {
@@ -33,6 +133,24 @@ struct Err {
   static Err error(std::string x) { return {std::move(x)}; }
 };
 
+template <typename I, typename T>
+concept Ix = requires {
+  {
+    I::range(std::declval<T>(), std::declval<T>())
+  } -> std::convertible_to<List<T>>;
+  {
+    I::index(std::declval<T>(), std::declval<T>(), std::declval<T>())
+  } -> std::convertible_to<std::optional<uint64_t>>;
+  {
+    I::rangeSize(std::declval<T>(), std::declval<T>())
+  } -> std::convertible_to<uint64_t>;
+  { I::toNat(std::declval<T>()) } -> std::convertible_to<uint64_t>;
+  { I::fromNat(std::declval<uint64_t>()) } -> std::convertible_to<T>;
+  { I::suc(std::declval<T>()) } -> std::convertible_to<T>;
+  { I::sub(std::declval<T>(), std::declval<T>()) } -> std::convertible_to<T>;
+  { I::max(std::declval<T>(), std::declval<T>()) } -> std::convertible_to<T>;
+  { I::zero() } -> std::convertible_to<T>;
+};
 template <typename I, typename T>
 concept STRefClass = requires {
   { I::mkSTRef(std::declval<T>()) } -> std::convertible_to<std::any>;
@@ -67,6 +185,11 @@ template <typename S> struct Account {
   std::function<std::optional<int64_t>(int64_t)> withdraw;
 };
 
+template <typename S> struct BankAccountCollection {
+  Account<S> checking;
+  Account<S> saving;
+};
+
 std::pair<std::pair<int64_t, int64_t>, int64_t> testtoST1_ext();
 std::pair<std::pair<std::pair<int64_t, int64_t>, int64_t>, int64_t>
 testtoST2_ext();
@@ -74,5 +197,7 @@ std::pair<std::pair<std::pair<int64_t, int64_t>, bool>, int64_t>
 acc_test1_ext();
 std::pair<std::pair<std::pair<int64_t, bool>, int64_t>, int64_t>
 acc_test2_ext();
+std::pair<std::pair<std::pair<int64_t, bool>, int64_t>, int64_t>
+bankacc_test1_ext();
 
 #endif // INCLUDED_OBJECT_MODEL

--- a/tests/monadic/object_model/object_model.t.cpp
+++ b/tests/monadic/object_model/object_model.t.cpp
@@ -78,6 +78,19 @@ int main() {
     
   }
 
+  // Test 4: bank_acc_test1 returns (100,true,250,0)
+  {
+    auto result = bankacc_test1_ext();
+    ASSERT(result.first.first.first == 100);
+    ASSERT(result.first.first.second == true);
+    ASSERT(result.first.second == 250);
+    ASSERT(result.second == 0);
+    std::cout << "Test 5 (bank_account1 works): (" << result.first.first.first
+              << ", " << result.first.first.second << ", " << result.first.second
+              << ", " << result.second << ")" << std::endl;
+    
+  }
+
   if (testStatus == 0) {
     std::cout << "\nAll object model tests passed!" << std::endl;
   } else {


### PR DESCRIPTION


**Describe your changes**
This makes minor changes to the class model tests, including:
- shifts deposit to use natural numbers
- backed_by uses a record instead of and (might be plausible to use notation to define both the record and this)
- Addition of a classes within classes example.
- minor renaming and refactoring.

**Testing performed**
The tests on accounts perform as before.

